### PR TITLE
Fix database name in sidebar [WINDOWS]

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -17,6 +17,7 @@
   </div>
 </template>
 <script>
+const path = require('path');
 export default {
   data() {
     return {
@@ -54,7 +55,7 @@ export default {
     const accountingSettings = await frappe.getDoc('AccountingSettings');
     this.companyName = accountingSettings.companyName;
     if (localStorage.dbPath) {
-      const parts = localStorage.dbPath.split('/');
+      const parts = localStorage.dbPath.split(path.sep);
       this.dbFileName = parts[parts.length - 1];
     }
   },


### PR DESCRIPTION
Database name section in sidebar shows **absolute path** instead of **dbname** in windows i.e. platform=win32.


 ## Before

![before-path-fix](https://imgur.com/RiXCA7b.png)


 ## After

![after-path-fix](https://i.imgur.com/oD9zbEv.png)