### PR TITLE
CSV JSON module added

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "nodemailer": "^4.7.0",
     "popper.js": "^1.14.4",
     "vue-color": "^2.7.0",
-    "vue-toasted": "^1.1.25"
+    "vue-toasted": "^1.1.25",
+    "csvjson-csv2json": "latest"
   }
 }


### PR DESCRIPTION
The "csvjson-csv2json" module was added as a dependency to prevent the "dependency not found" error that can pop up if the csvjson-csv2json module is not found on the target machine when running `yarn electron` to start this application.