### PR TITLE
Change the currency of Lithuania to EUR

### DIFF
--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -1467,11 +1467,10 @@
     },
     "Lithuania": {
         "code": "lt",
-        "currency": "LTL",
-        "currency_fraction": "Centas",
+        "currency": "EUR",
+        "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_name": "Lithuanian Litas",
-        "currency_symbol": "Lt",
+        "currency_symbol": "\u20ac",
         "date_format": "yyyy-MM-dd",
         "number_format": "# ###,##",
         "timezones": [


### PR DESCRIPTION
Lithuania has switched to [EUR in 2015](https://ec.europa.eu/info/business-economy-euro/euro-area/euro/eu-countries-and-euro/lithuania-and-euro_en)

Fixes #134