### PR TITLE
Update locale and currency information for Curacao

### DIFF
--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -677,10 +677,15 @@
     },
     "Cura\u00e7ao": {
         "code": "cw",
+        "currency": "ANG",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
+        "currency_name": "Netherlands Antillean Guilder",
         "currency_symbol": "\u0192",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "timezones": [
+            "America/Curacao"
+        ]
     },
     "Cyprus": {
         "code": "cy",


### PR DESCRIPTION
This change adds Curaçao's currency and time zone (as listed in IANA time zone db).