### PR TITLE
fix: formula for amount field in Payment

### DIFF
--- a/models/doctype/Payment/Payment.js
+++ b/models/doctype/Payment/Payment.js
@@ -102,7 +102,7 @@ module.exports = {
       label: 'Amount',
       fieldtype: 'Currency',
       required: 1,
-      default: doc => doc.getSum('for', 'amount')
+      formula: doc => doc.getSum('for', 'amount')
     },
     {
       fieldname: 'writeoff',


### PR DESCRIPTION
Payment table creation failing during setup:

![db](https://user-images.githubusercontent.com/24353136/84271446-bd976780-ab49-11ea-9d42-b684cda52d85.png)

After setting formula for amount field in Payment, the setup works:

![solved](https://user-images.githubusercontent.com/24353136/84271584-e881bb80-ab49-11ea-9c53-bb37bd0ee413.png)



