### PR TITLE
fix: minor changes and fixes to Payments

### DIFF
--- a/models/doctype/JournalEntry/JournalEntry.js
+++ b/models/doctype/JournalEntry/JournalEntry.js
@@ -24,48 +24,48 @@ export default {
         'Excise Entry',
         'Write Off Entry',
         'Opening Entry',
-        'Depreciation Entry'
+        'Depreciation Entry',
       ],
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'date',
       label: 'Date',
       fieldtype: 'Date',
-      default: DateTime.local().toISODate()
+      default: () => DateTime.local().toISODate(),
     },
     {
       fieldname: 'accounts',
       label: 'Account Entries',
       fieldtype: 'Table',
       childtype: 'JournalEntryAccount',
-      required: true
+      required: true,
     },
     {
       fieldname: 'referenceNumber',
       label: 'Reference Number',
-      fieldtype: 'Data'
+      fieldtype: 'Data',
     },
     {
       fieldname: 'referenceDate',
       label: 'Reference Date',
-      fieldtype: 'Date'
+      fieldtype: 'Date',
     },
     {
       fieldname: 'userRemark',
       label: 'User Remark',
       fieldtype: 'Text',
-      placeholder: 'User Remark'
-    }
+      placeholder: 'User Remark',
+    },
   ],
   actions: [
     {
       label: 'Revert',
-      condition: doc => doc.submitted,
+      condition: (doc) => doc.submitted,
       action(doc) {
         doc.revert();
-      }
+      },
     },
-    ledgerLink
-  ]
+    ledgerLink,
+  ],
 };

--- a/models/doctype/Payment/Payment.js
+++ b/models/doctype/Payment/Payment.js
@@ -81,7 +81,7 @@ export default {
       label: 'Ref. / Cheque No.',
       placeholder: 'Ref. / Cheque No.',
       fieldtype: 'Data',
-      required: 1 // TODO: UNIQUE
+      required: (doc) => doc.paymentMethod !== 'Cash' // TODO: UNIQUE
     },
     {
       fieldname: 'referenceDate',
@@ -94,9 +94,7 @@ export default {
       label: 'Clearance Date',
       placeholder: 'Clearance Date',
       fieldtype: 'Date',
-      hidden: doc => {
-        return doc.paymentMethod === 'Cash' ? 1 : 0;
-      }
+      hidden: (doc) => doc.paymentMethod === 'Cash'
     },
     {
       fieldname: 'amount',
@@ -105,6 +103,7 @@ export default {
       required: 1,
       formula: doc => doc.getSum('for', 'amount'),
       validate(value, doc) {
+        if(doc.for.length  === 0) return;
         const amount = doc.getSum('for', 'amount');
 
         if (value > amount) {
@@ -135,7 +134,7 @@ export default {
       label: 'Payment For',
       fieldtype: 'Table',
       childtype: 'PaymentFor',
-      required: 1
+      required: 0,
     }
   ],
 

--- a/models/doctype/Payment/Payment.js
+++ b/models/doctype/Payment/Payment.js
@@ -15,13 +15,13 @@ export default {
       label: 'Party',
       fieldtype: 'Link',
       target: 'Party',
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'date',
       label: 'Posting Date',
       fieldtype: 'Date',
-      default: new Date().toISOString()
+      default: () => new Date().toISOString(),
     },
     {
       fieldname: 'account',
@@ -37,14 +37,14 @@ export default {
             return { accountType: ['in', ['Bank', 'Cash']], isGroup: 0 };
           }
         }
-      }
+      },
     },
     {
       fieldname: 'paymentType',
       label: 'Payment Type',
       fieldtype: 'Select',
       options: ['', 'Receive', 'Pay'],
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'paymentAccount',
@@ -62,11 +62,11 @@ export default {
           }
         }
       },
-      formula: doc => {
+      formula: (doc) => {
         if (doc.paymentMethod === 'Cash') {
           return 'Cash';
         }
-      }
+      },
     },
     {
       fieldname: 'paymentMethod',
@@ -74,36 +74,36 @@ export default {
       placeholder: 'Payment Method',
       fieldtype: 'Select',
       options: ['', 'Cash', 'Cheque', 'Transfer'],
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'referenceId',
       label: 'Ref. / Cheque No.',
       placeholder: 'Ref. / Cheque No.',
       fieldtype: 'Data',
-      required: (doc) => doc.paymentMethod !== 'Cash' // TODO: UNIQUE
+      required: (doc) => doc.paymentMethod !== 'Cash', // TODO: UNIQUE
     },
     {
       fieldname: 'referenceDate',
       label: 'Ref. Date',
       placeholder: 'Ref. Date',
-      fieldtype: 'Date'
+      fieldtype: 'Date',
     },
     {
       fieldname: 'clearanceDate',
       label: 'Clearance Date',
       placeholder: 'Clearance Date',
       fieldtype: 'Date',
-      hidden: (doc) => doc.paymentMethod === 'Cash'
+      hidden: (doc) => doc.paymentMethod === 'Cash',
     },
     {
       fieldname: 'amount',
       label: 'Amount',
       fieldtype: 'Currency',
       required: 1,
-      formula: doc => doc.getSum('for', 'amount'),
+      formula: (doc) => doc.getSum('for', 'amount'),
       validate(value, doc) {
-        if(doc.for.length  === 0) return;
+        if (doc.for.length === 0) return;
         const amount = doc.getSum('for', 'amount');
 
         if (value > amount) {
@@ -118,24 +118,27 @@ export default {
         } else if (value === 0) {
           throw new frappe.errors.ValidationError(
             frappe._(
-              `Payment amount cannot be ${frappe.format(value, 'Currency')}. Amount has been reset to max viable amount.`
+              `Payment amount cannot be ${frappe.format(
+                value,
+                'Currency'
+              )}. Amount has been reset to max viable amount.`
             )
           );
         }
-      }
+      },
     },
     {
       fieldname: 'writeoff',
       label: 'Write Off / Refund',
-      fieldtype: 'Currency'
+      fieldtype: 'Currency',
     },
     {
       fieldname: 'for',
-      label: 'Payment For',
+      label: 'Payment Reference',
       fieldtype: 'Table',
       childtype: 'PaymentFor',
       required: 0,
-    }
+    },
   ],
 
   quickEditFields: [
@@ -150,58 +153,58 @@ export default {
     'clearanceDate',
     'amount',
     'writeoff',
-    'for'
+    'for',
   ],
 
   layout: [
     {
       columns: [
         {
-          fields: ['party', 'account']
+          fields: ['party', 'account'],
         },
         {
-          fields: ['date', 'paymentAccount']
-        }
-      ]
+          fields: ['date', 'paymentAccount'],
+        },
+      ],
     },
     {
       columns: [
         {
-          fields: ['paymentMethod']
+          fields: ['paymentMethod'],
         },
         {
-          fields: ['paymentType']
+          fields: ['paymentType'],
         },
         {
-          fields: ['referenceId']
-        }
-      ]
+          fields: ['referenceId'],
+        },
+      ],
     },
     {
       columns: [
         {
-          fields: ['referenceDate']
+          fields: ['referenceDate'],
         },
         {
-          fields: ['clearanceDate']
-        }
-      ]
+          fields: ['clearanceDate'],
+        },
+      ],
     },
     {
       columns: [
         {
-          fields: ['for']
-        }
-      ]
+          fields: ['for'],
+        },
+      ],
     },
     {
       columns: [
         {
-          fields: ['amount', 'writeoff']
-        }
-      ]
-    }
+          fields: ['amount', 'writeoff'],
+        },
+      ],
+    },
   ],
 
-  links: [utils.ledgerLink]
+  links: [utils.ledgerLink],
 };

--- a/models/doctype/Payment/Payment.js
+++ b/models/doctype/Payment/Payment.js
@@ -205,6 +205,16 @@ export default {
       ],
     },
   ],
+  actions: [
+    {
+      label: 'Revert',
+      condition: (doc) => doc.submitted,
+      action(doc) {
+        doc.revert();
+      },
+    },
+    utils.ledgerLink,
+  ],
 
   links: [utils.ledgerLink],
 };

--- a/models/doctype/Payment/PaymentServer.js
+++ b/models/doctype/Payment/PaymentServer.js
@@ -20,8 +20,8 @@ export default class PaymentServer extends BaseDocument {
   }
 
   async beforeSubmit() {
-    if (!this.for.length) {
-      throw new Error(`No reference for the payment.`);
+    if (!this.for || !this.for.length) {
+      return;
     }
     for (let row of this.for) {
       if (!['SalesInvoice', 'PurchaseInvoice'].includes(row.referenceType)) {

--- a/models/doctype/Payment/PaymentServer.js
+++ b/models/doctype/Payment/PaymentServer.js
@@ -36,9 +36,14 @@ export default class PaymentServer extends BaseDocument {
         outstandingAmount = baseGrandTotal;
       }
       if (this.amount <= 0 || this.amount > outstandingAmount) {
-        throw new Error(
-          `Payment amount (${this.amount}) should be greater than 0 and less than Outstanding amount (${outstandingAmount})`
+        let message = frappe._(
+          `Payment amount (${this.amount}) should be less than Outstanding amount (${outstandingAmount}).`
         );
+        if (this.amount <= 0) {
+          const amt = this.amount < 0 ? ` (${this.amount})` : '';
+          message = frappe._(`Payment amount${amt} should be greater than 0.`);
+        }
+        throw new frappe.errors.ValidationError(message);
       } else {
         // update outstanding amounts in invoice and party
         let newOutstanding = outstandingAmount - this.amount;
@@ -61,4 +66,4 @@ export default class PaymentServer extends BaseDocument {
 
     // Maybe revert outstanding amount of invoice too?
   }
-};
+}

--- a/models/doctype/PurchaseInvoice/PurchaseInvoice.js
+++ b/models/doctype/PurchaseInvoice/PurchaseInvoice.js
@@ -26,7 +26,7 @@ export default {
       fieldname: 'date',
       label: 'Date',
       fieldtype: 'Date',
-      default: new Date().toISOString().slice(0, 10)
+      default: () => new Date().toISOString().slice(0, 10)
     },
     {
       fieldname: 'supplier',

--- a/models/doctype/SalesInvoice/SalesInvoice.js
+++ b/models/doctype/SalesInvoice/SalesInvoice.js
@@ -19,20 +19,20 @@ export default {
       fieldname: 'name',
       fieldtype: 'Data',
       required: 1,
-      readOnly: 1
+      readOnly: 1,
     },
     {
       fieldname: 'date',
       label: 'Date',
       fieldtype: 'Date',
-      default: new Date().toISOString().slice(0, 10)
+      default: () => new Date().toISOString().slice(0, 10),
     },
     {
       fieldname: 'customer',
       label: 'Customer',
       fieldtype: 'Link',
       target: 'Customer',
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'account',
@@ -40,90 +40,90 @@ export default {
       fieldtype: 'Link',
       target: 'Account',
       disableCreation: true,
-      formula: doc => doc.getFrom('Party', doc.customer, 'defaultAccount'),
+      formula: (doc) => doc.getFrom('Party', doc.customer, 'defaultAccount'),
       getFilters: () => {
         return {
           isGroup: 0,
-          accountType: 'Receivable'
+          accountType: 'Receivable',
         };
-      }
+      },
     },
     {
       fieldname: 'currency',
       label: 'Customer Currency',
       fieldtype: 'Link',
       target: 'Currency',
-      formula: doc => doc.getFrom('Party', doc.customer, 'currency'),
-      formulaDependsOn: ['customer']
+      formula: (doc) => doc.getFrom('Party', doc.customer, 'currency'),
+      formulaDependsOn: ['customer'],
     },
     {
       fieldname: 'exchangeRate',
       label: 'Exchange Rate',
       fieldtype: 'Float',
-      formula: doc => doc.getExchangeRate(),
-      readOnly: true
+      formula: (doc) => doc.getExchangeRate(),
+      readOnly: true,
     },
     {
       fieldname: 'items',
       label: 'Items',
       fieldtype: 'Table',
       childtype: 'SalesInvoiceItem',
-      required: true
+      required: true,
     },
     {
       fieldname: 'netTotal',
       label: 'Net Total',
       fieldtype: 'Currency',
-      formula: doc => doc.getSum('items', 'amount'),
+      formula: (doc) => doc.getSum('items', 'amount'),
       readOnly: 1,
-      getCurrency: doc => doc.currency
+      getCurrency: (doc) => doc.currency,
     },
     {
       fieldname: 'baseNetTotal',
       label: 'Net Total (Company Currency)',
       fieldtype: 'Currency',
-      formula: doc => doc.netTotal * doc.exchangeRate,
-      readOnly: 1
+      formula: (doc) => doc.netTotal * doc.exchangeRate,
+      readOnly: 1,
     },
     {
       fieldname: 'taxes',
       label: 'Taxes',
       fieldtype: 'Table',
       childtype: 'TaxSummary',
-      formula: doc => doc.getTaxSummary(),
-      readOnly: 1
+      formula: (doc) => doc.getTaxSummary(),
+      readOnly: 1,
     },
     {
       fieldname: 'grandTotal',
       label: 'Grand Total',
       fieldtype: 'Currency',
-      formula: doc => doc.getGrandTotal(),
+      formula: (doc) => doc.getGrandTotal(),
       readOnly: 1,
-      getCurrency: doc => doc.currency
+      getCurrency: (doc) => doc.currency,
     },
     {
       fieldname: 'baseGrandTotal',
       label: 'Grand Total (Company Currency)',
       fieldtype: 'Currency',
-      formula: doc => doc.grandTotal * doc.exchangeRate,
-      readOnly: 1
+      formula: (doc) => doc.grandTotal * doc.exchangeRate,
+      readOnly: 1,
     },
     {
       fieldname: 'outstandingAmount',
       label: 'Outstanding Amount',
       fieldtype: 'Currency',
-      formula: doc => {
+      formula: (doc) => {
         if (doc.submitted) return;
         return doc.baseGrandTotal;
       },
-      readOnly: 1
+      readOnly: 1,
     },
     {
       fieldname: 'terms',
       label: 'Notes',
-      fieldtype: 'Text'
-    }
+      fieldtype: 'Text',
+    },
   ],
 
-  actions: getActions('SalesInvoice')
+  actions: getActions('SalesInvoice'),
 };

--- a/patches/patches.txt
+++ b/patches/patches.txt
@@ -1,0 +1,1 @@
+v0_0_3/makePaymentRefIdNullable

--- a/patches/v0_0_3/makePaymentRefIdNullable.js
+++ b/patches/v0_0_3/makePaymentRefIdNullable.js
@@ -1,0 +1,28 @@
+import frappe from 'frappejs';
+
+export default async function execute() {
+  // Since sqlite has no ALTER TABLE to change column meta
+  // the table has to be _Prestiged_.
+  const tableInfo = await frappe.db.sql('pragma table_info("Payment")');
+  const referenceId = tableInfo.find(({ name }) => name === 'referenceId');
+  if (!referenceId || !referenceId.notnull) {
+    return;
+  }
+
+  await frappe.db.createTable('Payment', '__Payment');
+  await frappe.db.sql('insert into __Payment select * from Payment');
+
+  const mainCount = await frappe.db.knex
+    .table('Payment')
+    .count('name as count');
+  const replCount = await frappe.db.knex
+    .table('__Payment')
+    .count('name as count');
+
+  if (mainCount[0].count === replCount[0].count) {
+    await frappe.db.knex.schema.dropTable('Payment');
+    await frappe.db.knex.schema.renameTable('__Payment', 'Payment');
+  } else {
+    await frappe.db.knex.schema.dropTable('__Payment');
+  }
+}

--- a/src/components/TwoColumnForm.vue
+++ b/src/components/TwoColumnForm.vue
@@ -8,7 +8,8 @@
         size="small"
         :df="df"
         :value="doc[df.fieldname]"
-        @change="value => onChange(df, value)"
+        :read-only="submitted"
+        @change="(value) => onChange(df, value)"
       />
       <template v-else>
         <template v-if="inlineEditField === df && inlineEditDoc">
@@ -20,7 +21,7 @@
               :column-ratio="columnRatio"
               :no-border="true"
               :focus-first-input="true"
-              @error="msg => $emit('error', msg)"
+              @error="(msg) => $emit('error', msg)"
             />
             <div class="flex px-4 pb-2">
               <Button
@@ -55,7 +56,7 @@
             class="py-2 pr-4"
             @click="activateInlineEditing(df)"
             :class="{
-              'pl-2': df.fieldtype === 'AttachImage'
+              'pl-2': df.fieldtype === 'AttachImage',
             }"
           >
             <FormControl
@@ -71,9 +72,10 @@
                   : doc[df.fieldname]
               "
               :class="{ 'p-2': df.fieldtype === 'Check' }"
-              @change="value => onChange(df, value)"
+              :read-only="submitted"
+              @change="(value) => onChange(df, value)"
               @focus="activateInlineEditing(df)"
-              @new-doc="newdoc => onChange(df, newdoc.name)"
+              @new-doc="(newdoc) => onChange(df, newdoc.name)"
             />
             <div
               class="text-sm text-red-600 mt-2 pl-2"
@@ -101,10 +103,10 @@ let TwoColumnForm = {
     autosave: Boolean,
     columnRatio: {
       type: Array,
-      default: () => [1, 1]
+      default: () => [1, 1],
     },
     noBorder: Boolean,
-    focusFirstInput: Boolean
+    focusFirstInput: Boolean,
   },
   data() {
     return {
@@ -112,20 +114,20 @@ let TwoColumnForm = {
       inlineEditDoc: null,
       inlineEditFields: null,
       inlineEditDisplayField: null,
-      errors: {}
+      errors: {},
     };
   },
   provide() {
     return {
       doctype: this.doc.doctype,
       name: this.doc.name,
-      doc: this.doc
+      doc: this.doc,
     };
   },
   components: {
     FormControl,
     Button,
-    TwoColumnForm: () => TwoColumnForm
+    TwoColumnForm: () => TwoColumnForm,
   },
   mounted() {
     if (this.focusFirstInput) {
@@ -135,8 +137,9 @@ let TwoColumnForm = {
   methods: {
     onChange(df, value) {
       if (value == null) {
-        return;
+        return
       }
+
       let oldValue = this.doc.get(df.fieldname);
 
       if (oldValue === value) {
@@ -151,7 +154,7 @@ let TwoColumnForm = {
       // reset error messages
       this.$set(this.errors, df.fieldname, null);
 
-      this.doc.set(df.fieldname, value).catch(e => {
+      this.doc.set(df.fieldname, value).catch((e) => {
         // set error message for this field
         this.$set(this.errors, df.fieldname, getErrorMessage(e, this.doc));
       });
@@ -197,7 +200,7 @@ let TwoColumnForm = {
         await this.doc.loadLinks();
         this.inlineEditField = null;
       }
-    }
+    },
   },
   computed: {
     formFields() {
@@ -205,13 +208,16 @@ let TwoColumnForm = {
     },
     style() {
       let templateColumns = (this.columnRatio || [1, 1])
-        .map(r => `${r}fr`)
+        .map((r) => `${r}fr`)
         .join(' ');
       return {
-        'grid-template-columns': templateColumns
+        'grid-template-columns': templateColumns,
       };
-    }
-  }
+    },
+    submitted() {
+      return Boolean(this.doc.meta.isSubmittable && this.doc.submitted);
+    },
+  },
 };
 
 export default TwoColumnForm;

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -6,11 +6,11 @@ const requirePatch = require.context('../patches', true, /\w+\.(js)$/);
 export default async function runMigrate() {
   let patchOrder = patchesTxt.split('\n');
   let allPatches = {};
-  requirePatch.keys().forEach(fileName => {
+  requirePatch.keys().forEach((fileName) => {
     if (fileName === './index.js') return;
     let method;
     try {
-      method = requirePatch(fileName);
+      method = requirePatch(fileName).default;
     } catch (error) {
       console.error(error);
       method = null;

--- a/src/pages/QuickEditForm.vue
+++ b/src/pages/QuickEditForm.vue
@@ -26,10 +26,10 @@
           type="primary"
           v-if="
             meta &&
-              meta.isSubmittable &&
-              doc &&
-              !doc.submitted &&
-              !doc._notInserted
+            meta.isSubmittable &&
+            doc &&
+            !doc.submitted &&
+            !doc._notInserted
           "
           class="ml-2 text-white text-xs"
         >
@@ -43,7 +43,7 @@
           v-if="imageField"
           :df="imageField"
           :value="doc[imageField.fieldname]"
-          @change="value => valueChange(imageField, value)"
+          @change="(value) => valueChange(imageField, value)"
           size="small"
           class="mb-1"
           :letter-placeholder="
@@ -57,7 +57,7 @@
           v-if="titleField"
           :df="titleField"
           :value="doc[titleField.fieldname]"
-          @change="value => valueChange(titleField, value)"
+          @change="(value) => valueChange(titleField, value)"
           @input="setTitleSize"
         />
       </div>
@@ -81,7 +81,11 @@ import Button from '@/components/Button';
 import FormControl from '@/components/Controls/FormControl';
 import TwoColumnForm from '@/components/TwoColumnForm';
 import DropdownWithActions from '@/components/DropdownWithActions';
-import { openQuickEdit, getActionsForDocument } from '@/utils';
+import {
+  openQuickEdit,
+  getActionsForDocument,
+  handleErrorWithDialog,
+} from '@/utils';
 
 export default {
   name: 'QuickEditForm',
@@ -90,7 +94,7 @@ export default {
     Button,
     FormControl,
     TwoColumnForm,
-    DropdownWithActions
+    DropdownWithActions,
   },
   provide() {
     let vm = this;
@@ -99,7 +103,7 @@ export default {
       name: this.name,
       get doc() {
         return vm.doc;
-      }
+      },
     };
   },
   data() {
@@ -107,7 +111,7 @@ export default {
       doc: null,
       titleField: null,
       imageField: null,
-      statusText: null
+      statusText: null,
     };
   },
   async created() {
@@ -120,7 +124,7 @@ export default {
     fields() {
       return this.meta
         .getQuickEditFields()
-        .filter(df => !(this.hideFields || []).includes(df.fieldname));
+        .filter((df) => !(this.hideFields || []).includes(df.fieldname));
     },
     actions() {
       return getActionsForDocument(this.doc);
@@ -130,7 +134,7 @@ export default {
         return null;
       }
       return this.meta.quickEditWidget(this.doc);
-    }
+    },
   },
   methods: {
     async fetchMetaAndDoc() {
@@ -165,7 +169,7 @@ export default {
         this.doc.once('afterRename', () => {
           openQuickEdit({
             doctype: this.doctype,
-            name: this.doc.name
+            name: this.doc.name,
           });
         });
         this.doc.on('beforeUpdate', () => {
@@ -186,8 +190,14 @@ export default {
     insertDoc() {
       this.$refs.form.insert();
     },
-    submitDoc() {
-      this.$refs.form.submit();
+    async submitDoc() {
+      console.log(this.meta)
+      console.log(this.doc)
+      try {
+        await this.$refs.form.submit();
+      } catch (e) {
+        this.statusText = null;
+      }
     },
     routeToPrevious() {
       this.$router.back();
@@ -202,7 +212,7 @@ export default {
         }
         input.size = valueLength;
       }
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/saveHtmlAsPdf.js
+++ b/src/saveHtmlAsPdf.js
@@ -33,7 +33,7 @@ function getInitializedPrintWindow() {
   const printWindow = new BrowserWindow({
     width: 595,
     height: 842,
-    show: true,
+    show: false,
     webPreferences: {
       contextIsolation: false,
       nodeIntegration: process.env.ELECTRON_NODE_INTEGRATION,


### PR DESCRIPTION
- [x] Handle _"Saving..."_ hang up.
- [x] Prevent altering _Submitted_ submittable doctypes (such as Payments) from the quick view.
- [x] Add reversion and ledger link to Payment quick form view.
- [x] Rename **Payment For** to **Payment References**. (∵ the field name shows on error and "Payment For" doesn't show any where, table column names have "Reference" in them so this is less confusing)
- [x] Make `for` not mandatory. (∵ deferred to ERPNext functionality)
- [x] Allow any amount to be set if no reference. (∵ used to set to 0 otherwise)
- [x] **Ref. / Cheque No.** is mandatory only if method is not _Cash_. (∵ Cash Payments may not have a reference)
- [x] Add migration for the **Payment** table. (∵ changes in `for` and `referenceId` changes) Added this as an exercise.
- [x] Convert `default` calling Date to functional defaults. (∵ Default gets set whenever the script is done so table updates sets defaults )
- [x] Formatting fixes.

**Note**: SQLite doesn't allow column changes, so table will have to be [_prestiged_](https://en.wikipedia.org/wiki/The_Prestige_(film)) even for minor changes like flipping a NOT NULL.

_(fixes boolean from previous PR, didn't realize this got added in)_

Fixes: https://github.com/frappe/books/issues/137 https://github.com/frappe/books/issues/178

Needs [frappejs/pull/152](https://github.com/frappe/frappejs/pull/152) to work.