### PR TITLE
fix: db creation flow, don't show annoying messages when not required

### DIFF
--- a/models/doctype/Contact/Contact.js
+++ b/models/doctype/Contact/Contact.js
@@ -64,7 +64,6 @@ export default {
             return ['fullName'];
         },
         getRowHTML(list, data) {
-            console.log(list, data);
             return `<div class="col-11">${list.getNameHTML(data)}</div>`;
         }
     },

--- a/models/doctype/Tax/RegionalChanges.js
+++ b/models/doctype/Tax/RegionalChanges.js
@@ -1,41 +1,49 @@
+import frappe from 'frappejs';
+
 export default async function generateTaxes(country) {
   if (country === 'India') {
     const GSTs = {
       GST: [28, 18, 12, 6, 5, 3, 0.25, 0],
       IGST: [28, 18, 12, 6, 5, 3, 0.25, 0],
       'Exempt-GST': [0],
-      'Exempt-IGST': [0]
+      'Exempt-IGST': [0],
     };
     let newTax = await frappe.getNewDoc('Tax');
+
     for (const type of Object.keys(GSTs)) {
       for (const percent of GSTs[type]) {
-        if (type === 'GST') {
-          await newTax.set({
-            name: `${type}-${percent}`,
-            details: [
-              {
-                account: 'CGST',
-                rate: percent / 2
-              },
-              {
-                account: 'SGST',
-                rate: percent / 2
-              }
-            ]
-          });
-        } else {
-          await newTax.set({
-            name: `${type}-${percent}`,
-            details: [
-              {
-                account: type.toString().split('-')[0],
-                rate: percent
-              }
-            ]
-          });
-        }
+        const name = `${type}-${percent}`;
+
+        // Not cross checking cause hardcoded values.
+        await frappe.db.knex('Tax').where({ name }).del();
+        await frappe.db.knex('TaxDetail').where({ parent: name }).del();
+
+        const details = getTaxDetails(type, percent);
+        await newTax.set({ name, details });
         await newTax.insert();
       }
     }
   }
-};
+}
+
+function getTaxDetails(type, percent) {
+  if (type === 'GST') {
+    return [
+      {
+        account: 'CGST',
+        rate: percent / 2,
+      },
+      {
+        account: 'SGST',
+        rate: percent / 2,
+      },
+    ];
+  } else {
+    return [
+      {
+        account: type.toString().split('-')[0],
+        rate: percent,
+      },
+    ];
+  }
+}

--- a/reports/AccountsReceivablePayable/AccountsReceivablePayable.js
+++ b/reports/AccountsReceivablePayable/AccountsReceivablePayable.js
@@ -31,8 +31,6 @@ async function getReceivablePayable({ reportType = 'Receivable', date }) {
   for (let entry of validEntries) {
     const { outStandingAmount, creditNoteAmount } = getOutstandingAmount(entry);
 
-    console.log(outStandingAmount);
-
     if (outStandingAmount > 0.1 / 10) {
       const row = {
         date: entry.date,

--- a/src/pages/DatabaseSelector.vue
+++ b/src/pages/DatabaseSelector.vue
@@ -139,7 +139,7 @@ export default {
     };
   },
   mounted() {
-    this.files = config.get('files', []).filter(({filepath}) => fs.existsSync(filepath));
+    this.files = config.get('files', []).filter(({filePath}) => fs.existsSync(filePath));
     this.showFiles = this.files.length > 0;
   },
   methods: {
@@ -158,6 +158,10 @@ export default {
       await this.connectToDatabase(file.filePath);
     },
     async connectToDatabase(filePath) {
+      if (!filePath) {
+        return;
+      }
+
       this.loadingDatabase = true;
       const connectionSuccess = await connectToLocalDatabase(filePath);
       this.loadingDatabase = false;

--- a/src/pages/SetupWizard/setupCompany.js
+++ b/src/pages/SetupWizard/setupCompany.js
@@ -12,7 +12,7 @@ export default async function setupCompany(setupWizardValues) {
     email,
     bankName,
     fiscalYearStart,
-    fiscalYearEnd
+    fiscalYearEnd,
   } = setupWizardValues;
 
   const accountingSettings = frappe.AccountingSettings;
@@ -24,7 +24,7 @@ export default async function setupCompany(setupWizardValues) {
     bankName,
     fiscalYearStart,
     fiscalYearEnd,
-    currency: countryList[country]['currency']
+    currency: countryList[country]['currency'],
   });
 
   const printSettings = await frappe.getSingle('PrintSettings');
@@ -32,7 +32,7 @@ export default async function setupCompany(setupWizardValues) {
     logo: companyLogo,
     companyName,
     email,
-    displayLogo: companyLogo ? 1 : 0
+    displayLogo: companyLogo ? 1 : 0,
   });
 
   await setupGlobalCurrencies(countryList);
@@ -55,24 +55,28 @@ async function setupGlobalCurrencies(countries) {
       currency_fraction_units: fractionUnits,
       smallest_currency_fraction_value: smallestValue,
       currency_symbol: symbol,
-      number_format: numberFormat
+      number_format: numberFormat,
     } = country;
 
-    if (currency) {
-      const exists = queue.includes(currency);
-      if (!exists) {
-        const doc = await frappe.newDoc({
-          doctype: 'Currency',
-          name: currency,
-          fraction,
-          fractionUnits,
-          smallestValue,
-          symbol,
-          numberFormat: numberFormat || '#,###.##'
-        });
-        promises.push(doc.insert());
-        queue.push(currency);
-      }
+    if (!currency || queue.includes(currency)) {
+      continue;
+    }
+
+    const docObject = {
+      doctype: 'Currency',
+      name: currency,
+      fraction,
+      fractionUnits,
+      smallestValue,
+      symbol,
+      numberFormat: numberFormat || '#,###.##',
+    };
+
+    const canCreate = await checkIfExactRecordAbsent(docObject);
+    if (canCreate) {
+      const doc = await frappe.newDoc(docObject);
+      promises.push(doc.insert());
+      queue.push(currency);
     }
   }
   return Promise.all(promises);
@@ -80,26 +84,30 @@ async function setupGlobalCurrencies(countries) {
 
 async function setupChartOfAccounts(bankName) {
   await frappe.call({
-    method: 'import-coa'
+    method: 'import-coa',
   });
 
-  const accountDoc = await frappe.newDoc({
-    doctype: 'Account'
-  });
-  Object.assign(accountDoc, {
+  const docObject = {
+    doctype: 'Account',
     name: bankName,
     rootType: 'Asset',
     parentAccount: 'Bank Accounts',
     accountType: 'Bank',
-    isGroup: 0
-  });
-  accountDoc.insert();
+    isGroup: 0,
+  };
+
+  if (await checkIfExactRecordAbsent(docObject)) {
+    const accountDoc = await frappe.newDoc(docObject);
+    accountDoc.insert();
+  }
 }
 
 async function setupRegionalChanges(country) {
   await generateTaxes(country);
   if (country === 'India') {
-    frappe.models.Party = await import('../../../models/doctype/Party/RegionalChanges');
+    frappe.models.Party = await import(
+      '../../../models/doctype/Party/RegionalChanges'
+    );
     await frappe.db.migrate();
   }
 }
@@ -107,10 +115,35 @@ async function setupRegionalChanges(country) {
 function updateCompanyNameInConfig() {
   let filePath = frappe.db.dbPath;
   let files = config.get('files', []);
-  files.forEach(file => {
+  files.forEach((file) => {
     if (file.filePath === filePath) {
       file.companyName = frappe.AccountingSettings.companyName;
     }
   });
   config.set('files', files);
+}
+
+export async function checkIfExactRecordAbsent(docObject) {
+  const { doctype, name } = docObject;
+  const newDocObject = Object.assign({}, docObject);
+  delete newDocObject.doctype;
+  const rows = await frappe.db.knex(doctype).where({ name });
+
+  if (rows.length === 0) {
+    return true;
+  }
+
+  const storedDocObject = rows[0];
+  const matchList = Object.keys(newDocObject).map((key) => {
+    const newValue = newDocObject[key];
+    const storedValue = storedDocObject[key];
+    return newValue == storedValue; // Should not be type sensitive.
+  });
+
+  if (!matchList.every(Boolean)) {
+    await frappe.db.knex(doctype).where({ name }).del();
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
Changes
  - [x] refactor `filepath` to `filePath`
  - [x] clean up `createNewDatabase` prevent double confirm on overwrite.
  - [x] defer the running of patches when 'RunPatch' doesn't exists cause db
      creation hasn't run yet.
  - [x] clean up `migrate.js`
  - [x] Don't show annoying message "_Please select an ..."_ if nothing was selected.
  - [x] Don't show _"Records already exists..."_, silently rename db file and
      continue.
