### PR TITLE
Change VATComply API for exchange rates

### DIFF
--- a/accounting/exchangeRate.js
+++ b/accounting/exchangeRate.js
@@ -14,7 +14,7 @@ export async function getExchangeRate({ fromCurrency, toCurrency, date }) {
   if (!exchangeRate) {
     try {
       let res = await fetch(
-        `https://api.exchangeratesapi.io/${date}?base=${fromCurrency}&symbols=${toCurrency}`
+        `https://api.vatcomply.com/${date}?base=${fromCurrency}&symbols=${toCurrency}`
       );
       let data = await res.json();
       exchangeRate = data.rates[toCurrency];


### PR DESCRIPTION
Change the exchangeratesapi.io to https://api.vatcomply.com rates API.

I'm the original author of Exchangerates API which now has a paywall and was acquired some years ago.

VATComply API will not be sold and provides the same API for exchange rates for free without requiring a API key.
For example: https://api.vatcomply.com/rates/2021-11-09?base=EUR&symbols=USD,GBP

The service is running on Heroku, behind CloudFlare for caching and the source code is public on Github for anyone to use and deploy: https://github.com/madisvain/vatcomply