### PR TITLE
fix: bank account parent not being set on setup

### DIFF
--- a/accounting/importCOA.js
+++ b/accounting/importCOA.js
@@ -1,49 +1,53 @@
 import frappe from 'frappejs';
 import countries from '../fixtures/countryInfo.json';
 import standardCOA from '../fixtures/verified/standardCOA.json';
-const accountFields = [
-  'accountType',
-  'rootType',
-  'isGroup',
-  'account_type',
-  'root_type',
-  'is_group'
-];
+const accountFields = ['accountType', 'accountNumber', 'rootType', 'isGroup'];
 
-async function importAccounts(children, parent, rootType, rootAccount) {
-  for (let accountName in children) {
-    const child = children[accountName];
+function getAccountName(accountName, accountNumber) {
+  if (accountNumber) {
+    return `${accountName} - ${accountNumber}`;
+  }
+  return accountName;
+}
+
+async function importAccounts(children, parentAccount, rootType, rootAccount) {
+  for (let rootName in children) {
+    if (accountFields.includes(rootName)) {
+      continue;
+    }
+
+    const child = children[rootName];
 
     if (rootAccount) {
-      rootType = child.rootType || child.root_type;
+      rootType = child.rootType;
     }
 
-    if (!accountFields.includes(accountName)) {
-      let isGroup = identifyIsGroup(child);
-      const doc = frappe.newDoc({
-        doctype: 'Account',
-        name: accountName,
-        parentAccount: parent,
-        isGroup,
-        rootType,
-        balance: 0,
-        accountType: child.accountType || child.account_type
-      });
+    const { accountType, accountNumber } = child;
+    const accountName = getAccountName(rootName, accountNumber);
+    const isGroup = identifyIsGroup(child);
+    console.log('inserting account: ', accountName);
+    const doc = frappe.newDoc({
+      doctype: 'Account',
+      name: accountName,
+      parentAccount,
+      isGroup,
+      rootType,
+      balance: 0,
+      accountType,
+    });
 
-      await doc.insert();
-
-      await importAccounts(child, accountName, rootType);
-    }
+    await doc.insert();
+    await importAccounts(child, accountName, rootType);
   }
 }
 
 function identifyIsGroup(child) {
-  if (child.isGroup || child.is_group) {
-    return child.isGroup || child.is_group;
+  if (child.isGroup) {
+    return child.isGroup;
   }
 
   const keys = Object.keys(child);
-  const children = keys.filter(key => !accountFields.includes(key));
+  const children = keys.filter((key) => !accountFields.includes(key));
 
   if (children.length) {
     return 1;
@@ -52,12 +56,14 @@ function identifyIsGroup(child) {
   return 0;
 }
 
-async function getCountryCOA() {
+export async function getCountryCOA() {
   const doc = await frappe.getDoc('AccountingSettings');
   const conCode = countries[doc.country].code;
 
   try {
-    const countryCoa = await import('../fixtures/verified/' + conCode + '.json');
+    const countryCoa = await import(
+      '../fixtures/verified/' + conCode + '.json'
+    );
     return countryCoa.tree;
   } catch (e) {
     return standardCOA;
@@ -67,4 +73,4 @@ async function getCountryCOA() {
 export default async function importCharts() {
   const chart = await getCountryCOA();
   await importAccounts(chart, '', '', true);
-};
+}

--- a/fixtures/verified/ae.json
+++ b/fixtures/verified/ae.json
@@ -1,467 +1,467 @@
 
 {
-  "country_code": "ae", 
-  "name": "U.A.E - Chart of Accounts", 
+  "countryCode": "ae",
+  "name": "U.A.E - Chart of Accounts",
   "tree": {
-      "Assets": {
-          "Current Assets": {
-              "Accounts Receivable": {
-                  "Corporate Credit Cards": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Other Receivable": {
-                      "Accrued Rebates Due from Suppliers": {
-                          "account_type": "Receivable"
-                      }, 
-                      "Accured Income from Suppliers": {
-                          "account_type": "Receivable"
-                      }, 
-                      "Other Debtors": {
-                          "account_type": "Receivable"
-                      }, 
-                      "account_type": "Receivable"
-                  }, 
-                  "Post Dated Cheques Received": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Staff Receivable": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Trade Receivable": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Trade in Opening Fees": {
-                      "account_type": "Receivable"
-                  }, 
-                  "account_type": "Receivable"
-              }, 
-              "Cash in Hand & Banks": {
-                  "Banks": {
-                      "Bank Margin On LC & LG": {}, 
-                      "Banks Blocked Deposits": {}, 
-                      "Banks Call Deposit Accounts": {}, 
-                      "Banks Current Accounts": {
-                          "account_type": "Bank"
-                      }, 
-                      "account_type": "Bank"
-                  }, 
-                  "Cash in Hand": {
-                      "Cash in Safe": {
-                          "Main Safe": {
-                              "account_type": "Cash"
-                          }, 
-                          "Main Safe - Foreign Currency": {
-                              "account_type": "Cash"
-                          }
-                      }, 
-                      "Petty Cash": {
-                          "Petty Cash - Admininistration": {
-                              "account_type": "Cash"
-                          }, 
-                          "Petty Cash - Others": {
-                              "account_type": "Cash"
-                          }
-                      }, 
-                      "account_type": "Cash"
-                  }, 
-                  "Cash in Transit": {
-                      "Credit Cards": {
-                          "Gateway Credit Cards": {
-                              "account_type": "Bank"
-                          }, 
-                          "Manual Visa & Master Cards": {
-                              "account_type": "Bank"
-                          }, 
-                          "PayPal Account": {
-                              "account_type": "Bank"
-                          }, 
-                          "Visa & Master Credit Cards": {
-                              "account_type": "Bank"
-                          }
-                      }
-                  }
-              }, 
-              "Inventory": {
-                  "Consigned Stock": {
-                      "Handling Difference in Inventory": {
-                          "account_type": "Stock Adjustment"
-                      }, 
-                      "Items Delivered to Customs on temprary Base": {}
-                  }, 
-                  "Stock in Hand": {
-                      "account_type": "Stock"
-                  }
-              }, 
-              "Perliminary and Preoperating Expenses": {
-                  "Preoperating Expenses": {}
-              }, 
-              "Prepayments & Deposits": {
-                  "Deposits": {
-                      "Deposit - Office Rent": {}, 
-                      "Deposit Others": {}, 
-                      "Deposit to Immigration (Visa)": {}, 
-                      "Deposits - Customs": {}
-                  }, 
-                  "Prepaid Taxes": {
-                      "Sales Taxes Receivables": {}, 
-                      "Withholding Tax Receivables": {}
-                  }, 
-                  "Prepayments": {
-                      "Other Prepayments": {}, 
-                      "PrePaid Advertisement Expenses": {}, 
-                      "Prepaid Bank Guarantee": {}, 
-                      "Prepaid Consultancy Fees": {}, 
-                      "Prepaid Employees Housing": {}, 
-                      "Prepaid Finance charge for Loans": {}, 
-                      "Prepaid Legal Fees": {}, 
-                      "Prepaid License Fees": {}, 
-                      "Prepaid Life Insurance": {}, 
-                      "Prepaid Maintenance": {}, 
-                      "Prepaid Medical Insurance": {}, 
-                      "Prepaid Office Rent": {}, 
-                      "Prepaid Other Insurance": {}, 
-                      "Prepaid Schooling Fees": {}, 
-                      "Prepaid Site Hosting Fees": {}, 
-                      "Prepaid Sponsorship Fees": {}
-                  }
+    "Assets": {
+      "Current Assets": {
+        "Accounts Receivable": {
+          "Corporate Credit Cards": {
+            "accountType": "Receivable"
+          },
+          "Other Receivable": {
+            "Accrued Rebates Due from Suppliers": {
+              "accountType": "Receivable"
+            },
+            "Accured Income from Suppliers": {
+              "accountType": "Receivable"
+            },
+            "Other Debtors": {
+              "accountType": "Receivable"
+            },
+            "accountType": "Receivable"
+          },
+          "Post Dated Cheques Received": {
+            "accountType": "Receivable"
+          },
+          "Staff Receivable": {
+            "accountType": "Receivable"
+          },
+          "Trade Receivable": {
+            "accountType": "Receivable"
+          },
+          "Trade in Opening Fees": {
+            "accountType": "Receivable"
+          },
+          "accountType": "Receivable"
+        },
+        "Cash in Hand & Banks": {
+          "Banks": {
+            "Bank Margin On LC & LG": {},
+            "Banks Blocked Deposits": {},
+            "Banks Call Deposit Accounts": {},
+            "Banks Current Accounts": {
+              "accountType": "Bank"
+            },
+            "accountType": "Bank"
+          },
+          "Cash in Hand": {
+            "Cash in Safe": {
+              "Main Safe": {
+                "accountType": "Cash"
+              },
+              "Main Safe - Foreign Currency": {
+                "accountType": "Cash"
               }
-          }, 
-          "Long Term Assets": {
-              "Fixed Assets": {
-                  "Accumulated Depreciation": {
-                      "Acc. Depreciation of Motor Vehicles": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "Acc. Deprn.Computer Hardware & Software": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "Acc.Deprn.of Furniture & Office Equipment": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "Amortisation on Leasehold Improvement": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "account_type": "Accumulated Depreciation"
-                  }, 
-                  "Fixed Assets (Cost Price)": {
-                      "Computer Hardware & Software": {
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "Furniture and Equipment": {
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "Leasehold Improvement": {}, 
-                      "Motor Vehicules": {
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "Work In Progrees": {}, 
-                      "account_type": "Fixed Asset"
-                  }
-              }, 
-              "Intangible Assets": {
-                  "Computer Card Renewal": {}, 
-                  "Dispoal of Outlets": {}, 
-                  "Registration of Trademarks": {}
-              }, 
-              "Intercompany Accounts": {}, 
-              "Investments": {
-                  "Investments in Subsidiaries": {}
+            },
+            "Petty Cash": {
+              "Petty Cash - Admininistration": {
+                "accountType": "Cash"
+              },
+              "Petty Cash - Others": {
+                "accountType": "Cash"
               }
-          }, 
-          "root_type": "Asset"
-      }, 
-      "Closing And Temporary Accounts": {
-          "Closing Accounts": {
-              "Closing Account": {}
-          }, 
-          "root_type": "Liability"
-      }, 
-      "Expenses": {
-          "Commercial Expenses": {
-              "Consultancy Fees": {}, 
-              "Provision for Doubtful Debts": {}
-          }, 
-          "Cost of Sale": {
-              "Cost Of Goods Sold": {
-                  "Cost Of Goods Sold I/C Sales": {}, 
-                  "Cost of Goods Sold in Trading": {
-                      "account_type": "Cost of Goods Sold"
-                  }, 
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "Expenses Included In Valuation": {
-                  "account_type": "Expenses Included In Valuation"
+            },
+            "accountType": "Cash"
+          },
+          "Cash in Transit": {
+            "Credit Cards": {
+              "Gateway Credit Cards": {
+                "accountType": "Bank"
+              },
+              "Manual Visa & Master Cards": {
+                "accountType": "Bank"
+              },
+              "PayPal Account": {
+                "accountType": "Bank"
+              },
+              "Visa & Master Credit Cards": {
+                "accountType": "Bank"
               }
-          }, 
-          "Depreciation": {
-              "Depreciation & Amortization": {
-                  "Amortization on Leasehold Improvement": {}, 
-                  "Depreciation Of Computer Hard & Soft": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Depreciation Of Furniture & Office Equipment\n\t\t\t": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Depreciation Of Motor Vehicles": {
-                      "account_type": "Depreciation"
-                  }
-              }
-          }, 
-          "Direct Expenses": {
-              "Financial Charges": {
-                  "Air Miles Card Charges": {}, 
-                  "Amex Credit Cards Charges": {}, 
-                  "Bank Finance & Loan Charges": {}, 
-                  "Credit Card Charges": {}, 
-                  "Credit Card Swipe Charges": {}, 
-                  "PayPal Charges": {}
-              }
-          }, 
-          "MISC Charges": {
-              "Other Charges": {
-                  "Captial Loss": {
-                      "Disposal of Business Branch": {}, 
-                      "Loss On Fixed Assets Disposal": {}, 
-                      "Loss on Difference on Exchange": {}
-                  }, 
-                  "Other Non Operating Exp": {
-                      "Other Non Operating Expenses": {}
-                  }, 
-                  "Previous Year Adjustments": {
-                      "Previous Year Adjustments Account": {}
-                  }, 
-                  "Royalty Fees": {
-                      "Royalty to Parent Co.": {}
-                  }, 
-                  "Tax / Zakat Expenses": {
-                      "Income Tax": {
-                          "account_type": "Tax"
-                      }, 
-                      "Zakat": {}, 
-                      "account_type": "Tax"
-                  }
-              }
-          }, 
-          "Share Resources": {
-              "Share Resource Expenses Account": {}
-          }, 
-          "Store Operating Expenses": {
-              "Selling, General & Admin Expenses": {
-                  "Advertising Expenses": {
-                      "Other - Advertising Expenses": {}
-                  }, 
-                  "Bank & Finance Charges": {
-                      "Other Bank Charges": {}
-                  }, 
-                  "Communications": {
-                      "Courrier": {}, 
-                      "Others - Communication": {}, 
-                      "Telephone": {}, 
-                      "Web Site Hosting Fees": {}
-                  }, 
-                  "Office & Various Expenses": {
-                      "Cleaning": {}, 
-                      "Convoyance Expenses": {}, 
-                      "Gifts & Donations": {}, 
-                      "Insurance": {}, 
-                      "Kitchen and Buffet Expenses": {}, 
-                      "Maintenance": {}, 
-                      "Others - Office Various Expenses": {}, 
-                      "Security & Guard": {}, 
-                      "Stationary From Suppliers": {}, 
-                      "Stationary Out Of Stock": {}, 
-                      "Subscriptions": {}, 
-                      "Training": {}, 
-                      "Vehicle Expenses": {}
-                  }, 
-                  "Personnel Cost": {
-                      "Basic Salary": {}, 
-                      "End Of Service Indemnity": {}, 
-                      "Housing Allowance": {}, 
-                      "Leave Salary": {}, 
-                      "Leave Ticket": {}, 
-                      "Life Insurance": {}, 
-                      "Medical Insurance": {}, 
-                      "Personnel Cost Others": {}, 
-                      "Sales Commission": {}, 
-                      "Staff School Allowances": {}, 
-                      "Transportation Allowance": {}, 
-                      "Uniform": {}, 
-                      "Visa Expenses": {}
-                  }, 
-                  "Professional & Legal Fees": {
-                      "Audit Fees": {}, 
-                      "Legal fees": {}, 
-                      "Others - Professional Fees": {}, 
-                      "Sponsorship Fees": {}, 
-                      "Trade License Fees": {}
-                  }, 
-                  "Provision & Write Off": {
-                      "Amortisation of Preoperating Expenses": {}, 
-                      "Cash Shortage": {}, 
-                      "Others - Provision & Write off": {}, 
-                      "Write Off Inventory": {}, 
-                      "Write Off Receivables & Payables": {}
-                  }, 
-                  "Rent Expenses": {
-                      "Office Rent": {}, 
-                      "Warehouse Rent": {}
-                  }, 
-                  "Travel Expenses": {
-                      "Air tickets": {}, 
-                      "Hotel": {}, 
-                      "Meals": {}, 
-                      "Others": {}, 
-                      "Per Diem": {}
-                  }, 
-                  "Utilities": {
-                      "Other Utility Cahrges": {}, 
-                      "Water & Electricity": {}
-                  }
-              }
-          }, 
-          "root_type": "Expense"
-      }, 
-      "Liabilities": {
-          "Current Liabilities": {
-              "Accounts Payable": {
-                  "Payables": {
-                      "Advance Paybale to Suppliers": {
-                          "account_type": "Payable"
-                      }, 
-                      "Consigned Payable": {
-                          "account_type": "Payable"
-                      }, 
-                      "Other Payable": {
-                          "account_type": "Payable"
-                      }, 
-                      "Post Dated Cheques Paid": {
-                          "account_type": "Payable"
-                      }, 
-                      "Staff Payable": {}, 
-                      "Suppliers Price Protection": {
-                          "account_type": "Payable"
-                      }, 
-                      "Trade Payable": {
-                          "account_type": "Payable"
-                      }, 
-                      "account_type": "Payable"
-                  }
-              }, 
-              "Accruals & Provisions": {
-                  "Accruals": {
-                      "Accrued Personnel Cost": {
-                          "Accrued - Commissions": {}, 
-                          "Accrued - Leave Salary": {}, 
-                          "Accrued - Leave Tickets": {}, 
-                          "Accrued - Salaries": {}, 
-                          "Accrued Other Personnel Cost": {}, 
-                          "Accrued Salaries Increment": {}, 
-                          "Accrued-Staff Bonus": {}
-                      }
-                  }, 
-                  "Accrued Expenses": {
-                      "Accrued Other Expenses": {
-                          "Accrued - Audit Fees": {}, 
-                          "Accrued - Office Rent": {}, 
-                          "Accrued - Sponsorship": {}, 
-                          "Accrued - Telephone": {}, 
-                          "Accrued - Utilities": {}, 
-                          "Accrued Others": {}
-                      }
-                  }, 
-                  "Other Current Liabilities": {
-                      "Accrued Dubai Customs": {}, 
-                      "Deferred income": {}, 
-                      "Shipping & Handling": {}
-                  }, 
-                  "Provisions": {
-                      "Tax Payables": {
-                          "Income Tax Payable": {}, 
-                          "Sales Tax Payable": {}, 
-                          "Withholding Tax Payable": {}
-                      }
-                  }, 
-                  "Short Term Loan": {}
-              }, 
-              "Duties and Taxes": {
-                  "account_type": "Tax", 
-                  "is_group": 1
-              }, 
-              "Reservations & Credit Notes": {
-                  "Credit Notes": {
-                      "Credit Notes to Customers": {}, 
-                      "Reservations": {}
-                  }
-              }, 
-              "Stock Liabilities": {
-                  "Stock Received But Not Billed": {
-                      "account_type": "Stock Received But Not Billed"
-                  }
-              }, 
-              "Unearned Income": {}
-          }, 
-          "Long Term Liabilities": {
-              "Long Term Loans & Provisions": {}
-          }, 
-          "root_type": "Liability"
-      }, 
-      "Revenue": {
-          "Direct Revenue": {
-              "Other Direct Revenue": {
-                  "Other Revenue - Operating": {
-                      "Advertising Income": {}, 
-                      "Branding Income": {}, 
-                      "Early Setmt Margin from Suppliers": {}, 
-                      "Marketing Rebate from Suppliers": {}, 
-                      "Rebate from Suppliers": {}, 
-                      "Service Income": {}, 
-                      "Space Rental Income": {}
-                  }
-              }
-          }, 
-          "Indirect Revenue": {
-              "Other Indirect Revenue": {
-                  "Capital Gain": {}, 
-                  "Excess In Till": {}, 
-                  "Gain On Difference Of Exchange": {}, 
-                  "Management Consultancy Fees": {}, 
-                  "Other Income": {}
-              }, 
-              "Other Revenue - Non Operating": {
-                  "Interest Revenue": {}, 
-                  "Interest from FD": {}, 
-                  "Products Listing Fees from Suppliers": {}, 
-                  "Trade Opening Fees from suppliers": {}
-              }
-          }, 
-          "Sales": {
-              "Sales from Other Regions": {
-                  "Sales from Other Region": {}
-              }, 
-              "Sales of same region": {
-                  "Management Consultancy Fees 1": {}, 
-                  "Sales Account": {}, 
-                  "Sales of I/C": {}
-              }
-          }, 
-          "root_type": "Income"
-      }, 
-      "Share Holder Equity": {
-          "Capital": {
-              "Contributed Capital": {}, 
-              "Share Capital": {}, 
-              "Shareholders Current A/c": {}, 
-              "Sub Ordinated Loan": {}, 
-              "Treasury Stocks": {}
-          }, 
-          "Retained Earnings": {
-              "Current Year Results": {}, 
-              "Dividends Paid": {}, 
-              "Previous Years Results": {}
-          }, 
-          "account_type": "Equity", 
-          "root_type": "Equity"
-      }
+            }
+          }
+        },
+        "Inventory": {
+          "Consigned Stock": {
+            "Handling Difference in Inventory": {
+              "accountType": "Stock Adjustment"
+            },
+            "Items Delivered to Customs on temprary Base": {}
+          },
+          "Stock in Hand": {
+            "accountType": "Stock"
+          }
+        },
+        "Perliminary and Preoperating Expenses": {
+          "Preoperating Expenses": {}
+        },
+        "Prepayments & Deposits": {
+          "Deposits": {
+            "Deposit - Office Rent": {},
+            "Deposit Others": {},
+            "Deposit to Immigration (Visa)": {},
+            "Deposits - Customs": {}
+          },
+          "Prepaid Taxes": {
+            "Sales Taxes Receivables": {},
+            "Withholding Tax Receivables": {}
+          },
+          "Prepayments": {
+            "Other Prepayments": {},
+            "PrePaid Advertisement Expenses": {},
+            "Prepaid Bank Guarantee": {},
+            "Prepaid Consultancy Fees": {},
+            "Prepaid Employees Housing": {},
+            "Prepaid Finance charge for Loans": {},
+            "Prepaid Legal Fees": {},
+            "Prepaid License Fees": {},
+            "Prepaid Life Insurance": {},
+            "Prepaid Maintenance": {},
+            "Prepaid Medical Insurance": {},
+            "Prepaid Office Rent": {},
+            "Prepaid Other Insurance": {},
+            "Prepaid Schooling Fees": {},
+            "Prepaid Site Hosting Fees": {},
+            "Prepaid Sponsorship Fees": {}
+          }
+        }
+      },
+      "Long Term Assets": {
+        "Fixed Assets": {
+          "Accumulated Depreciation": {
+            "Acc. Depreciation of Motor Vehicles": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "Acc. Deprn.Computer Hardware & Software": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "Acc.Deprn.of Furniture & Office Equipment": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "Amortisation on Leasehold Improvement": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "accountType": "Accumulated Depreciation"
+          },
+          "Fixed Assets (Cost Price)": {
+            "Computer Hardware & Software": {
+              "accountType": "Fixed Asset"
+            },
+            "Furniture and Equipment": {
+              "accountType": "Fixed Asset"
+            },
+            "Leasehold Improvement": {},
+            "Motor Vehicules": {
+              "accountType": "Fixed Asset"
+            },
+            "Work In Progrees": {},
+            "accountType": "Fixed Asset"
+          }
+        },
+        "Intangible Assets": {
+          "Computer Card Renewal": {},
+          "Dispoal of Outlets": {},
+          "Registration of Trademarks": {}
+        },
+        "Intercompany Accounts": {},
+        "Investments": {
+          "Investments in Subsidiaries": {}
+        }
+      },
+      "rootType": "Asset"
+    },
+    "Closing And Temporary Accounts": {
+      "Closing Accounts": {
+        "Closing Account": {}
+      },
+      "rootType": "Liability"
+    },
+    "Expenses": {
+      "Commercial Expenses": {
+        "Consultancy Fees": {},
+        "Provision for Doubtful Debts": {}
+      },
+      "Cost of Sale": {
+        "Cost Of Goods Sold": {
+          "Cost Of Goods Sold I/C Sales": {},
+          "Cost of Goods Sold in Trading": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "accountType": "Cost of Goods Sold"
+        },
+        "Expenses Included In Valuation": {
+          "accountType": "Expenses Included In Valuation"
+        }
+      },
+      "Depreciation": {
+        "Depreciation & Amortization": {
+          "Amortization on Leasehold Improvement": {},
+          "Depreciation Of Computer Hard & Soft": {
+            "accountType": "Depreciation"
+          },
+          "Depreciation Of Furniture & Office Equipment\n\t\t\t": {
+            "accountType": "Depreciation"
+          },
+          "Depreciation Of Motor Vehicles": {
+            "accountType": "Depreciation"
+          }
+        }
+      },
+      "Direct Expenses": {
+        "Financial Charges": {
+          "Air Miles Card Charges": {},
+          "Amex Credit Cards Charges": {},
+          "Bank Finance & Loan Charges": {},
+          "Credit Card Charges": {},
+          "Credit Card Swipe Charges": {},
+          "PayPal Charges": {}
+        }
+      },
+      "MISC Charges": {
+        "Other Charges": {
+          "Captial Loss": {
+            "Disposal of Business Branch": {},
+            "Loss On Fixed Assets Disposal": {},
+            "Loss on Difference on Exchange": {}
+          },
+          "Other Non Operating Exp": {
+            "Other Non Operating Expenses": {}
+          },
+          "Previous Year Adjustments": {
+            "Previous Year Adjustments Account": {}
+          },
+          "Royalty Fees": {
+            "Royalty to Parent Co.": {}
+          },
+          "Tax / Zakat Expenses": {
+            "Income Tax": {
+              "accountType": "Tax"
+            },
+            "Zakat": {},
+            "accountType": "Tax"
+          }
+        }
+      },
+      "Share Resources": {
+        "Share Resource Expenses Account": {}
+      },
+      "Store Operating Expenses": {
+        "Selling, General & Admin Expenses": {
+          "Advertising Expenses": {
+            "Other - Advertising Expenses": {}
+          },
+          "Bank & Finance Charges": {
+            "Other Bank Charges": {}
+          },
+          "Communications": {
+            "Courrier": {},
+            "Others - Communication": {},
+            "Telephone": {},
+            "Web Site Hosting Fees": {}
+          },
+          "Office & Various Expenses": {
+            "Cleaning": {},
+            "Convoyance Expenses": {},
+            "Gifts & Donations": {},
+            "Insurance": {},
+            "Kitchen and Buffet Expenses": {},
+            "Maintenance": {},
+            "Others - Office Various Expenses": {},
+            "Security & Guard": {},
+            "Stationary From Suppliers": {},
+            "Stationary Out Of Stock": {},
+            "Subscriptions": {},
+            "Training": {},
+            "Vehicle Expenses": {}
+          },
+          "Personnel Cost": {
+            "Basic Salary": {},
+            "End Of Service Indemnity": {},
+            "Housing Allowance": {},
+            "Leave Salary": {},
+            "Leave Ticket": {},
+            "Life Insurance": {},
+            "Medical Insurance": {},
+            "Personnel Cost Others": {},
+            "Sales Commission": {},
+            "Staff School Allowances": {},
+            "Transportation Allowance": {},
+            "Uniform": {},
+            "Visa Expenses": {}
+          },
+          "Professional & Legal Fees": {
+            "Audit Fees": {},
+            "Legal fees": {},
+            "Others - Professional Fees": {},
+            "Sponsorship Fees": {},
+            "Trade License Fees": {}
+          },
+          "Provision & Write Off": {
+            "Amortisation of Preoperating Expenses": {},
+            "Cash Shortage": {},
+            "Others - Provision & Write off": {},
+            "Write Off Inventory": {},
+            "Write Off Receivables & Payables": {}
+          },
+          "Rent Expenses": {
+            "Office Rent": {},
+            "Warehouse Rent": {}
+          },
+          "Travel Expenses": {
+            "Air tickets": {},
+            "Hotel": {},
+            "Meals": {},
+            "Others": {},
+            "Per Diem": {}
+          },
+          "Utilities": {
+            "Other Utility Cahrges": {},
+            "Water & Electricity": {}
+          }
+        }
+      },
+      "rootType": "Expense"
+    },
+    "Liabilities": {
+      "Current Liabilities": {
+        "Accounts Payable": {
+          "Payables": {
+            "Advance Paybale to Suppliers": {
+              "accountType": "Payable"
+            },
+            "Consigned Payable": {
+              "accountType": "Payable"
+            },
+            "Other Payable": {
+              "accountType": "Payable"
+            },
+            "Post Dated Cheques Paid": {
+              "accountType": "Payable"
+            },
+            "Staff Payable": {},
+            "Suppliers Price Protection": {
+              "accountType": "Payable"
+            },
+            "Trade Payable": {
+              "accountType": "Payable"
+            },
+            "accountType": "Payable"
+          }
+        },
+        "Accruals & Provisions": {
+          "Accruals": {
+            "Accrued Personnel Cost": {
+              "Accrued - Commissions": {},
+              "Accrued - Leave Salary": {},
+              "Accrued - Leave Tickets": {},
+              "Accrued - Salaries": {},
+              "Accrued Other Personnel Cost": {},
+              "Accrued Salaries Increment": {},
+              "Accrued-Staff Bonus": {}
+            }
+          },
+          "Accrued Expenses": {
+            "Accrued Other Expenses": {
+              "Accrued - Audit Fees": {},
+              "Accrued - Office Rent": {},
+              "Accrued - Sponsorship": {},
+              "Accrued - Telephone": {},
+              "Accrued - Utilities": {},
+              "Accrued Others": {}
+            }
+          },
+          "Other Current Liabilities": {
+            "Accrued Dubai Customs": {},
+            "Deferred income": {},
+            "Shipping & Handling": {}
+          },
+          "Provisions": {
+            "Tax Payables": {
+              "Income Tax Payable": {},
+              "Sales Tax Payable": {},
+              "Withholding Tax Payable": {}
+            }
+          },
+          "Short Term Loan": {}
+        },
+        "Duties and Taxes": {
+          "accountType": "Tax",
+          "isGroup": 1
+        },
+        "Reservations & Credit Notes": {
+          "Credit Notes": {
+            "Credit Notes to Customers": {},
+            "Reservations": {}
+          }
+        },
+        "Stock Liabilities": {
+          "Stock Received But Not Billed": {
+            "accountType": "Stock Received But Not Billed"
+          }
+        },
+        "Unearned Income": {}
+      },
+      "Long Term Liabilities": {
+        "Long Term Loans & Provisions": {}
+      },
+      "rootType": "Liability"
+    },
+    "Revenue": {
+      "Direct Revenue": {
+        "Other Direct Revenue": {
+          "Other Revenue - Operating": {
+            "Advertising Income": {},
+            "Branding Income": {},
+            "Early Setmt Margin from Suppliers": {},
+            "Marketing Rebate from Suppliers": {},
+            "Rebate from Suppliers": {},
+            "Service Income": {},
+            "Space Rental Income": {}
+          }
+        }
+      },
+      "Indirect Revenue": {
+        "Other Indirect Revenue": {
+          "Capital Gain": {},
+          "Excess In Till": {},
+          "Gain On Difference Of Exchange": {},
+          "Management Consultancy Fees": {},
+          "Other Income": {}
+        },
+        "Other Revenue - Non Operating": {
+          "Interest Revenue": {},
+          "Interest from FD": {},
+          "Products Listing Fees from Suppliers": {},
+          "Trade Opening Fees from suppliers": {}
+        }
+      },
+      "Sales": {
+        "Sales from Other Regions": {
+          "Sales from Other Region": {}
+        },
+        "Sales of same region": {
+          "Management Consultancy Fees 1": {},
+          "Sales Account": {},
+          "Sales of I/C": {}
+        }
+      },
+      "rootType": "Income"
+    },
+    "Share Holder Equity": {
+      "Capital": {
+        "Contributed Capital": {},
+        "Share Capital": {},
+        "Shareholders Current A/c": {},
+        "Sub Ordinated Loan": {},
+        "Treasury Stocks": {}
+      },
+      "Retained Earnings": {
+        "Current Year Results": {},
+        "Dividends Paid": {},
+        "Previous Years Results": {}
+      },
+      "accountType": "Equity",
+      "rootType": "Equity"
+    }
   }
 }

--- a/fixtures/verified/ca.json
+++ b/fixtures/verified/ca.json
@@ -1,412 +1,412 @@
 {
-  "country_code": "ca", 
-  "name": "Canada - Plan comptable pour les provinces francophones", 
+  "countryCode": "ca",
+  "name": "Canada - Plan comptable pour les provinces francophones",
   "tree": {
-      "Actif": {
-          "Actif \u00e0 court terme": {
-              "Avances": {
-                  "Avances aux actionnaires": {}, 
-                  "Avances aux employ\u00e9s": {}, 
-                  "Avances sur commissions": {}
-              }, 
-              "Banque": {
-                  "account_type": "Bank", 
-                  "is_group": 1
-              }, 
-              "Comptes \u00e0 recevoir": {
-                  "Comptes clients": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Provision pour cr\u00e9ances douteuses": {}
-              }, 
-              "Encaisse": {
-                  "is_group": 1
-              }, 
-              "Frais pay\u00e9s d\u2019avance": {
-                  "Assurances pay\u00e9s d'avance": {}, 
-                  "Publicit\u00e9 pay\u00e9 d'avance": {}, 
-                  "Taxes pay\u00e9s d'avance": {}
-              }, 
-              "Petite caisse": {
-                  "account_type": "Cash", 
-                  "is_group": 1
-              }, 
-              "Stocks": {
-                  "Mati\u00e8res premi\u00e8res": {}, 
-                  "Stock de produits fini": {}, 
-                  "Stock exp\u00e9di\u00e9 non-factur\u00e9": {}, 
-                  "Travaux en cours": {}, 
-                  "account_type": "Stock"
-              }, 
-              "Subventions \u00e0 recevoir": {}, 
-              "TR\u00c9SORERIE OU \u00c9QUIVALENTS DE TR\u00c9SORERIE": {}, 
-              "Taxes \u00e0 recevoir": {
-                  "TPS \u00e0 recevoir": {}, 
-                  "TVH \u00e0 recevoir": {
-                      "TVH \u00e0 recevoir - 13%": {}, 
-                      "TVH \u00e0 recevoir - 14%": {}, 
-                      "TVH \u00e0 recevoir - 15%": {}
-                  }, 
-                  "TVP/TVQ \u00e0 recevoir": {}
-              }
-          }, 
-          "Autres actifs": {
-              " Frais de premier \u00e9tablissement": {}, 
-              "Achalandage": {}, 
-              "Brevets, droits": {}, 
-              "Frais de recherche et de d\u00e9veloppement - actif": {}
-          }, 
-          "Immobilisations": {
-              " Amortissement accumul\u00e9 - b\u00e2timent": {}, 
-              " Amortissement accumul\u00e9 - entrep\u00f4t": {}, 
-              " Amortissement accumul\u00e9 - logiciels": {}, 
-              " Amortissement accumul\u00e9 - machinerie et \u00e9quipement": {}, 
-              " Amortissement accumul\u00e9 - \u00e9quipement informatique": {}, 
-              "Amortissement accumul\u00e9 - am\u00e9liorations locatives": {}, 
-              "Amortissement accumul\u00e9 - biens lou\u00e9s en vertu d\u2019un contrat de location - acquisition": {}, 
-              "Amortissement accumul\u00e9 - mat\u00e9riel roulant": {}, 
-              "Amortissement accumul\u00e9 - mobilier et \u00e9quipement de bureau": {}, 
-              "Am\u00e9liorations locatives": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Biens lou\u00e9s en vertu d\u2019un contrat de location - acquisition": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "B\u00e2timent": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Entrep\u00f4t": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Logiciels": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Machinerie et \u00e9quipement": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Mat\u00e9riel roulant": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Mobilier et \u00e9quipement de bureau": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Terrain": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "account_type": "Fixed Asset", 
-              "\u00c9quipement informatique": {
-                  "account_type": "Fixed Asset"
-              }
-          }, 
-          "Placements": {
-              "D\u00e9p\u00f4ts": {}, 
-              "Placement": {}
-          }, 
-          "root_type": "Asset"
-      }, 
-      "Avoir des actionnaires": {
-          " B\u00e9n\u00e9fice de la p\u00e9riode": {}, 
-          "Bonis": {}, 
-          "B\u00e9n\u00e9fices non r\u00e9partis": {}, 
-          "Capital - actions ordinaire": {}, 
-          "Capital - actions privil\u00e9gi\u00e9": {}, 
-          "Dividendes": {}, 
-          "Surplus d\u2019apport": {}, 
-          "root_type": "Equity"
-      }, 
-      "Charges": {
-          "Charges d'exploitation": {
-              "Salaires et charges sociales": {
-                  "Assurance - emploi": {
-                      "account_type": "Chargeable"
-                  }, 
-                  "Assurance parentale": {}, 
-                  "Fonds des services de sant\u00e9": {}, 
-                  "Imp\u00f4t f\u00e9d\u00e9ral": {}, 
-                  "Imp\u00f4t provincial": {}, 
-                  "Normes du travail": {}, 
-                  "Rentes": {}, 
-                  "Salaires": {
-                      "account_type": "Chargeable"
-                  }, 
-                  "sant\u00e9 et s\u00e9curit\u00e9 du travail CSST": {
-                      "account_type": "Chargeable"
-                  }
-              }
-          }, 
-          "Frais fixes": {
-              "Frais de fabrication": {
-                  " R\u00e9parations et entretien - moules et matrices": {}, 
-                  "Ammortissements": {
-                      "Amortissements - am\u00e9liorations locatives": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "Amortissements - biens lou\u00e9s contrat de location - acquisition": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "Amortissements - b\u00e2timent": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "Amortissements - entrep\u00f4t": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "Amortissements - machinerie et \u00e9quipement": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "Amortissements - mat\u00e9riel roulant": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "Amortissements - moules et matrices": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "account_type": "Depreciation"
-                  }, 
-                  "Assurances": {
-                      " Assurances - feu": {}, 
-                      " Assurances - responsabilit\u00e9": {}, 
-                      " Assurances - vol": {}
-                  }, 
-                  "Avantages sociaux - frais de fabrication": {}, 
-                  "D\u00e9penses - mat\u00e9riel roulant": {}, 
-                  "Entretien du terrain \u00e0 contrat": {}, 
-                  "Fournitures d\u2019emballage": {}, 
-                  "Fournitures d\u2019usine": {}, 
-                  "Location de machinerie": {}, 
-                  "Loyer - b\u00e2timent": {}, 
-                  "Loyer - entrep\u00f4t": {}, 
-                  "Op\u00e9rations indirectes de la main-d\u2019\u0153uvre directe": {
-                      "is_group": 1
-                  }, 
-                  "R\u00e9parations et entretien - b\u00e2timent": {}, 
-                  "R\u00e9parations et entretien - machinerie et \u00e9quipement": {}, 
-                  "Salaires de soutien": {}, 
-                  "Salaires de supervision": {}, 
-                  "Taxes fonci\u00e8res": {}, 
-                  "\u00c9nergie": {}
-              }, 
-              "Frais de formation": {
-                  " Salaires - administration - frais fixe formation": {}, 
-                  "Avantages sociaux - frais fixe formation": {}, 
-                  "Cr\u00e9dits d\u2019imp\u00f4ts \u00e0 la formation": {}, 
-                  "Honoraires": {}, 
-                  "Main-d\u2019\u0153uvre directe - frais fixe formation": {}, 
-                  "Main-d\u2019\u0153uvre indirecte - frais fixe formation": {}, 
-                  "Salaires - bureau - frais fixe formation": {}, 
-                  "Salaires - vente": {}
-              }, 
-              "Frais de non-qualit\u00e9": {
-                  " Avantages sociaux - non-qualit\u00e9": {}, 
-                  " Main-d\u2019\u0153uvre directe - non-qualit\u00e9": {
-                      "Main-d\u2019\u0153uvre directe - gaspillage": {}, 
-                      "Main-d\u2019\u0153uvre directe - r\u00e9parations de garantie": {}, 
-                      "Main-d\u2019\u0153uvre directe - travail a reprendre": {}
-                  }, 
-                  "Mat\u00e9riel - non-qualit\u00e9": {
-                      "Mat\u00e9riel - gaspillage": {}, 
-                      "Mat\u00e9riel - r\u00e9parations de garantie": {}, 
-                      "Mat\u00e9riel - travail a reprendre": {}
-                  }, 
-                  "Salaire - inspecteur (contr\u00f4le de la qualit\u00e9)": {}
-              }, 
-              "Frais de recherche et de d\u00e9veloppement - charge": {
-                  " Mati\u00e8res premi\u00e8res - R&D": {}, 
-                  "Avantages sociaux - R&D": {}, 
-                  "Cr\u00e9dits d\u2019imp\u00f4ts - R&D": {}, 
-                  "Honoraires professionnels - R&D": {}, 
-                  "Main-d\u2019\u0153uvre directe - R&D": {}, 
-                  "Sous-traitance - R&D": {}
-              }, 
-              "Frais financiers": {
-                  " Escomptes de caisse sur achats": {}, 
-                  " Int\u00e9r\u00eats et frais de banque": {}, 
-                  " Int\u00e9r\u00eats sur emprunts - actionnaires": {}, 
-                  " Int\u00e9r\u00eats sur emprunts - machinerie": {}, 
-                  " Int\u00e9r\u00eats sur emprunts - mat\u00e9riel roulant": {}, 
-                  "Escomptes de caisse sur ventes": {}, 
-                  "Int\u00e9r\u00eats sur hypoth\u00e8que": {}
-              }, 
-              "Frais fixe de vente": {
-                  " Frais de voyages - camionneurs": {}, 
-                  " Frais de voyages - service apr\u00e8s-vente": {}, 
-                  "Amortissement - camions": {}, 
-                  "Amortissements - frais fixe de vente": {
-                      " Amortissements - autos": {}, 
-                      " Amortissements - bureau de vente": {}
-                  }, 
-                  "Assurances - camions": {}, 
-                  "Assurances d\u2019autos - vendeurs": {}, 
-                  "Avantages sociaux - frais fixe de vente": {}, 
-                  "Catalogues": {}, 
-                  "D\u00e9penses - bureau de vente": {}, 
-                  "Emballage \u00e0 la livraison": {}, 
-                  "Entretien et r\u00e9parations - camions": {}, 
-                  "Frais de repr\u00e9sentation": {}, 
-                  "Frais de voyages - vendeurs": {}, 
-                  "Frais d\u2019autos - service apr\u00e8s-vente": {}, 
-                  "Frais d\u2019autos - vendeurs": {}, 
-                  "Loyer - bureau de vente": {}, 
-                  "Prototypes et \u00e9chantillons": {}, 
-                  "Publicit\u00e9": {}, 
-                  "Salaires - camionneurs": {}, 
-                  "Salaires - frais fixe de vente": {
-                      "Salaires - exp\u00e9diteurs": {}, 
-                      "Salaires - g\u00e9rants": {}, 
-                      "Salaires - service apr\u00e8s-vente": {}, 
-                      "Salaires - vendeurs": {}
-                  }
-              }, 
-              "Frais fixe d\u2019administration": {
-                  " Assurances d\u2019autos - administration": {}, 
-                  "Amortissements - frais fixe d'administration": {
-                      "Amortissements - autos - frais fixe d'administration": {}, 
-                      "Amortissements - logiciels": {}, 
-                      "Amortissements - mobilier de bureau": {}, 
-                      "Amortissements - \u00e9quipement informatique": {}
-                  }, 
-                  "Avantages sociaux - frais fixe d'administration": {}, 
-                  "Dons et associations": {}, 
-                  "Entretien et r\u00e9parations - bureau": {}, 
-                  "Frais de perception": {}, 
-                  "Frais de voyages - administration": {}, 
-                  "Frais de v\u00e9rification": {}, 
-                  "Frais d\u2019autos - administration": {}, 
-                  "Frais juridiques": {}, 
-                  "Location - \u00e9quipement de bureau": {}, 
-                  "Mauvaises cr\u00e9ances": {}, 
-                  "Papeterie et d\u00e9penses de bureau": {}, 
-                  "Salaires - frais fixe d'administration": {
-                      "Salaires - administration": {}, 
-                      "Salaires - bureau": {}
-                  }, 
-                  "Taxe sur le capital": {}, 
-                  "Taxes, licences, permis": {}, 
-                  "Timbres": {}, 
-                  "T\u00e9l\u00e9communications": {}
-              }
-          }, 
-          "Frais variables": {
-              "Frais variables de fabrication": {
-                  " Emballage \u00e0 la production": {
-                      "account_type": "Cost of Goods Sold"
-                  }, 
-                  " Sous-traitance": {
-                      "account_type": "Cost of Goods Sold"
-                  }, 
-                  "Achats de mati\u00e8res premi\u00e8res": {
-                      "account_type": "Cost of Goods Sold"
-                  }, 
-                  "Achats de mat\u00e9riel direct": {
-                      "account_type": "Cost of Goods Sold"
-                  }, 
-                  "Achats de produits non fabriqu\u00e9s": {
-                      "account_type": "Expenses Included In Valuation"
-                  }, 
-                  "Avantages sociaux": {
-                      "account_type": "Cost of Goods Sold"
-                  }, 
-                  "Main-d\u2019\u0153uvre directe": {
-                      "account_type": "Cost of Goods Sold"
-                  }, 
-                  "Variation des stocks": {
-                      "account_type": "Stock Adjustment"
-                  }, 
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "Frais variables de vente": {
-                  "Commissions": {}, 
-                  "Redevances": {}, 
-                  "Transport (\u00e0 contrat)": {}
-              }
-          }, 
-          "root_type": "Expense"
-      }, 
-      "Passif": {
-          "PASSIFS NON-COURANTS": {
-              "AUTRES PASSIFS NON-COURANTS": {}, 
-              "DETTES FINANCI\u00c8RES NON-COURANTES": {}, 
-              "IMP\u00d4TS DIFF\u00c9R\u00c9S": {}, 
-              "PROVISIONS POUR RETRAITES ET AUTRES AVANTAGES POST\u00c9RIEURS \u00c0 L'EMPLOI": {}
-          }, 
-          "Passif \u00e0 court terme": {
-              " Commissions \u00e0 payer": {}, 
-              "Assurance collective \u00e0 payer": {}, 
-              "Autres comptes cr\u00e9diteurs": {}, 
-              "Comptes \u00e0 payer": {
-                  "Comptes fournisseurs": {
-                      "account_type": "Payable"
-                  }
-              }, 
-              "D\u00e9p\u00f4ts de clients": {}, 
-              "Emprunt de banque": {}, 
-              "Imp\u00f4ts li\u00e9s aux salaires \u00e0 payer": {
-                  "Agence du revenu du Canada": {
-                      "Assurance - emploi \u00e0 payer": {
-                          "AE - Contribution de l'employeur": {}, 
-                          "AE - Contribution des employ\u00e9s": {}
-                      }, 
-                      "Imp\u00f4t f\u00e9d\u00e9ral sur salaires \u00e0 payer": {}
-                  }, 
-                  "Agence du revenu du Qu\u00e9bec": {
-                      "Fond des Services de Sant\u00e9 \u00e0 payer": {}, 
-                      "Imp\u00f4t provincial sur salaires \u00e0 payer": {}, 
-                      "Normes du Travail \u00e0 payer": {}, 
-                      "Provision pour sant\u00e9 et s\u00e9curit\u00e9 du travail CSST": {}, 
-                      "R\u00e9gime des rentes du Qu\u00e9bec \u00e0 payer": {
-                          "Rentes - Contribution de l'employeur": {}, 
-                          "Rentes - Contribution des employ\u00e9s": {}
-                      }, 
-                      "R\u00e9gime qu\u00e9becois d'assurance parentale": {
-                          "AP - Contribution de l'employeur": {}, 
-                          "AP - Contribution des employ\u00e9s": {}
-                      }
-                  }, 
-                  "Caisse de retraite \u00e0 payer": {}
-              }, 
-              "Imp\u00f4ts \u00e0 payer": {
-                  "Imp\u00f4t f\u00e9d\u00e9ral sur le revenu \u00e0 payer": {}, 
-                  "Imp\u00f4t provincial sur le revenu \u00e0 payer": {}, 
-                  "TPS \u00e0 payer": {}, 
-                  "TVH \u00e0 payer": {
-                      "TVH \u00e0 payer - 13%": {}, 
-                      "TVH \u00e0 payer - 14%": {}, 
-                      "TVH \u00e0 payer - 15%": {}
-                  }, 
-                  "TVP/TVQ \u00e0 payer": {}
-              }, 
-              "Passifs de stock": {
-                  "Stock re\u00e7u non factur\u00e9": {
-                      "account_type": "Stock Received But Not Billed"
-                  }
-              }, 
-              "Provision pour vacances et cong\u00e9s": {}, 
-              "Revenus per\u00e7us d\u2019avance": {}, 
-              "Salaires \u00e0 payer": {}
-          }, 
-          "Passif \u00e0 long terme": {
-              "Avances des actionnaires": {}, 
-              "Cr\u00e9dits d\u2019imp\u00f4ts report\u00e9s": {}, 
-              "Hypoth\u00e8que \u00e0 payer": {}, 
-              "Liens sur machinerie": {}, 
-              "Liens sur mat\u00e9riel roulant": {}, 
-              "Obligation d\u00e9coulant d\u2019un contrat de location - acquisition": {}, 
-              "Passif d\u2019imp\u00f4ts futurs": {}
-          }, 
-          "root_type": "Liability"
-      }, 
-      "Produits": {
-          "Revenus de ventes": {
-              " Escomptes de volume sur ventes": {}, 
-              "Autres produits d'exploitation": {}, 
-              "Ventes": {}, 
-              "Ventes avec des provinces harmonis\u00e9es": {}, 
-              "Ventes avec des provinces non-harmonis\u00e9es": {}, 
-              "Ventes \u00e0 l'\u00e9tranger": {}
-          }, 
-          "Revenus non li\u00e9 \u00e0 la vente": {
-              "Autres revenus non li\u00e9s \u00e0 la vente": {}, 
-              "Revenues d'int\u00e9r\u00eats": {}
-          }, 
-          "root_type": "Income"
-      }
+    "Actif": {
+      "Actif \u00e0 court terme": {
+        "Avances": {
+          "Avances aux actionnaires": {},
+          "Avances aux employ\u00e9s": {},
+          "Avances sur commissions": {}
+        },
+        "Banque": {
+          "accountType": "Bank",
+          "isGroup": 1
+        },
+        "Comptes \u00e0 recevoir": {
+          "Comptes clients": {
+            "accountType": "Receivable"
+          },
+          "Provision pour cr\u00e9ances douteuses": {}
+        },
+        "Encaisse": {
+          "isGroup": 1
+        },
+        "Frais pay\u00e9s d\u2019avance": {
+          "Assurances pay\u00e9s d'avance": {},
+          "Publicit\u00e9 pay\u00e9 d'avance": {},
+          "Taxes pay\u00e9s d'avance": {}
+        },
+        "Petite caisse": {
+          "accountType": "Cash",
+          "isGroup": 1
+        },
+        "Stocks": {
+          "Mati\u00e8res premi\u00e8res": {},
+          "Stock de produits fini": {},
+          "Stock exp\u00e9di\u00e9 non-factur\u00e9": {},
+          "Travaux en cours": {},
+          "accountType": "Stock"
+        },
+        "Subventions \u00e0 recevoir": {},
+        "TR\u00c9SORERIE OU \u00c9QUIVALENTS DE TR\u00c9SORERIE": {},
+        "Taxes \u00e0 recevoir": {
+          "TPS \u00e0 recevoir": {},
+          "TVH \u00e0 recevoir": {
+            "TVH \u00e0 recevoir - 13%": {},
+            "TVH \u00e0 recevoir - 14%": {},
+            "TVH \u00e0 recevoir - 15%": {}
+          },
+          "TVP/TVQ \u00e0 recevoir": {}
+        }
+      },
+      "Autres actifs": {
+        " Frais de premier \u00e9tablissement": {},
+        "Achalandage": {},
+        "Brevets, droits": {},
+        "Frais de recherche et de d\u00e9veloppement - actif": {}
+      },
+      "Immobilisations": {
+        " Amortissement accumul\u00e9 - b\u00e2timent": {},
+        " Amortissement accumul\u00e9 - entrep\u00f4t": {},
+        " Amortissement accumul\u00e9 - logiciels": {},
+        " Amortissement accumul\u00e9 - machinerie et \u00e9quipement": {},
+        " Amortissement accumul\u00e9 - \u00e9quipement informatique": {},
+        "Amortissement accumul\u00e9 - am\u00e9liorations locatives": {},
+        "Amortissement accumul\u00e9 - biens lou\u00e9s en vertu d\u2019un contrat de location - acquisition": {},
+        "Amortissement accumul\u00e9 - mat\u00e9riel roulant": {},
+        "Amortissement accumul\u00e9 - mobilier et \u00e9quipement de bureau": {},
+        "Am\u00e9liorations locatives": {
+          "accountType": "Fixed Asset"
+        },
+        "Biens lou\u00e9s en vertu d\u2019un contrat de location - acquisition": {
+          "accountType": "Fixed Asset"
+        },
+        "B\u00e2timent": {
+          "accountType": "Fixed Asset"
+        },
+        "Entrep\u00f4t": {
+          "accountType": "Fixed Asset"
+        },
+        "Logiciels": {
+          "accountType": "Fixed Asset"
+        },
+        "Machinerie et \u00e9quipement": {
+          "accountType": "Fixed Asset"
+        },
+        "Mat\u00e9riel roulant": {
+          "accountType": "Fixed Asset"
+        },
+        "Mobilier et \u00e9quipement de bureau": {
+          "accountType": "Fixed Asset"
+        },
+        "Terrain": {
+          "accountType": "Fixed Asset"
+        },
+        "accountType": "Fixed Asset",
+        "\u00c9quipement informatique": {
+          "accountType": "Fixed Asset"
+        }
+      },
+      "Placements": {
+        "D\u00e9p\u00f4ts": {},
+        "Placement": {}
+      },
+      "rootType": "Asset"
+    },
+    "Avoir des actionnaires": {
+      " B\u00e9n\u00e9fice de la p\u00e9riode": {},
+      "Bonis": {},
+      "B\u00e9n\u00e9fices non r\u00e9partis": {},
+      "Capital - actions ordinaire": {},
+      "Capital - actions privil\u00e9gi\u00e9": {},
+      "Dividendes": {},
+      "Surplus d\u2019apport": {},
+      "rootType": "Equity"
+    },
+    "Charges": {
+      "Charges d'exploitation": {
+        "Salaires et charges sociales": {
+          "Assurance - emploi": {
+            "accountType": "Chargeable"
+          },
+          "Assurance parentale": {},
+          "Fonds des services de sant\u00e9": {},
+          "Imp\u00f4t f\u00e9d\u00e9ral": {},
+          "Imp\u00f4t provincial": {},
+          "Normes du travail": {},
+          "Rentes": {},
+          "Salaires": {
+            "accountType": "Chargeable"
+          },
+          "sant\u00e9 et s\u00e9curit\u00e9 du travail CSST": {
+            "accountType": "Chargeable"
+          }
+        }
+      },
+      "Frais fixes": {
+        "Frais de fabrication": {
+          " R\u00e9parations et entretien - moules et matrices": {},
+          "Ammortissements": {
+            "Amortissements - am\u00e9liorations locatives": {
+              "accountType": "Depreciation"
+            },
+            "Amortissements - biens lou\u00e9s contrat de location - acquisition": {
+              "accountType": "Depreciation"
+            },
+            "Amortissements - b\u00e2timent": {
+              "accountType": "Depreciation"
+            },
+            "Amortissements - entrep\u00f4t": {
+              "accountType": "Depreciation"
+            },
+            "Amortissements - machinerie et \u00e9quipement": {
+              "accountType": "Depreciation"
+            },
+            "Amortissements - mat\u00e9riel roulant": {
+              "accountType": "Depreciation"
+            },
+            "Amortissements - moules et matrices": {
+              "accountType": "Depreciation"
+            },
+            "accountType": "Depreciation"
+          },
+          "Assurances": {
+            " Assurances - feu": {},
+            " Assurances - responsabilit\u00e9": {},
+            " Assurances - vol": {}
+          },
+          "Avantages sociaux - frais de fabrication": {},
+          "D\u00e9penses - mat\u00e9riel roulant": {},
+          "Entretien du terrain \u00e0 contrat": {},
+          "Fournitures d\u2019emballage": {},
+          "Fournitures d\u2019usine": {},
+          "Location de machinerie": {},
+          "Loyer - b\u00e2timent": {},
+          "Loyer - entrep\u00f4t": {},
+          "Op\u00e9rations indirectes de la main-d\u2019\u0153uvre directe": {
+            "isGroup": 1
+          },
+          "R\u00e9parations et entretien - b\u00e2timent": {},
+          "R\u00e9parations et entretien - machinerie et \u00e9quipement": {},
+          "Salaires de soutien": {},
+          "Salaires de supervision": {},
+          "Taxes fonci\u00e8res": {},
+          "\u00c9nergie": {}
+        },
+        "Frais de formation": {
+          " Salaires - administration - frais fixe formation": {},
+          "Avantages sociaux - frais fixe formation": {},
+          "Cr\u00e9dits d\u2019imp\u00f4ts \u00e0 la formation": {},
+          "Honoraires": {},
+          "Main-d\u2019\u0153uvre directe - frais fixe formation": {},
+          "Main-d\u2019\u0153uvre indirecte - frais fixe formation": {},
+          "Salaires - bureau - frais fixe formation": {},
+          "Salaires - vente": {}
+        },
+        "Frais de non-qualit\u00e9": {
+          " Avantages sociaux - non-qualit\u00e9": {},
+          " Main-d\u2019\u0153uvre directe - non-qualit\u00e9": {
+            "Main-d\u2019\u0153uvre directe - gaspillage": {},
+            "Main-d\u2019\u0153uvre directe - r\u00e9parations de garantie": {},
+            "Main-d\u2019\u0153uvre directe - travail a reprendre": {}
+          },
+          "Mat\u00e9riel - non-qualit\u00e9": {
+            "Mat\u00e9riel - gaspillage": {},
+            "Mat\u00e9riel - r\u00e9parations de garantie": {},
+            "Mat\u00e9riel - travail a reprendre": {}
+          },
+          "Salaire - inspecteur (contr\u00f4le de la qualit\u00e9)": {}
+        },
+        "Frais de recherche et de d\u00e9veloppement - charge": {
+          " Mati\u00e8res premi\u00e8res - R&D": {},
+          "Avantages sociaux - R&D": {},
+          "Cr\u00e9dits d\u2019imp\u00f4ts - R&D": {},
+          "Honoraires professionnels - R&D": {},
+          "Main-d\u2019\u0153uvre directe - R&D": {},
+          "Sous-traitance - R&D": {}
+        },
+        "Frais financiers": {
+          " Escomptes de caisse sur achats": {},
+          " Int\u00e9r\u00eats et frais de banque": {},
+          " Int\u00e9r\u00eats sur emprunts - actionnaires": {},
+          " Int\u00e9r\u00eats sur emprunts - machinerie": {},
+          " Int\u00e9r\u00eats sur emprunts - mat\u00e9riel roulant": {},
+          "Escomptes de caisse sur ventes": {},
+          "Int\u00e9r\u00eats sur hypoth\u00e8que": {}
+        },
+        "Frais fixe de vente": {
+          " Frais de voyages - camionneurs": {},
+          " Frais de voyages - service apr\u00e8s-vente": {},
+          "Amortissement - camions": {},
+          "Amortissements - frais fixe de vente": {
+            " Amortissements - autos": {},
+            " Amortissements - bureau de vente": {}
+          },
+          "Assurances - camions": {},
+          "Assurances d\u2019autos - vendeurs": {},
+          "Avantages sociaux - frais fixe de vente": {},
+          "Catalogues": {},
+          "D\u00e9penses - bureau de vente": {},
+          "Emballage \u00e0 la livraison": {},
+          "Entretien et r\u00e9parations - camions": {},
+          "Frais de repr\u00e9sentation": {},
+          "Frais de voyages - vendeurs": {},
+          "Frais d\u2019autos - service apr\u00e8s-vente": {},
+          "Frais d\u2019autos - vendeurs": {},
+          "Loyer - bureau de vente": {},
+          "Prototypes et \u00e9chantillons": {},
+          "Publicit\u00e9": {},
+          "Salaires - camionneurs": {},
+          "Salaires - frais fixe de vente": {
+            "Salaires - exp\u00e9diteurs": {},
+            "Salaires - g\u00e9rants": {},
+            "Salaires - service apr\u00e8s-vente": {},
+            "Salaires - vendeurs": {}
+          }
+        },
+        "Frais fixe d\u2019administration": {
+          " Assurances d\u2019autos - administration": {},
+          "Amortissements - frais fixe d'administration": {
+            "Amortissements - autos - frais fixe d'administration": {},
+            "Amortissements - logiciels": {},
+            "Amortissements - mobilier de bureau": {},
+            "Amortissements - \u00e9quipement informatique": {}
+          },
+          "Avantages sociaux - frais fixe d'administration": {},
+          "Dons et associations": {},
+          "Entretien et r\u00e9parations - bureau": {},
+          "Frais de perception": {},
+          "Frais de voyages - administration": {},
+          "Frais de v\u00e9rification": {},
+          "Frais d\u2019autos - administration": {},
+          "Frais juridiques": {},
+          "Location - \u00e9quipement de bureau": {},
+          "Mauvaises cr\u00e9ances": {},
+          "Papeterie et d\u00e9penses de bureau": {},
+          "Salaires - frais fixe d'administration": {
+            "Salaires - administration": {},
+            "Salaires - bureau": {}
+          },
+          "Taxe sur le capital": {},
+          "Taxes, licences, permis": {},
+          "Timbres": {},
+          "T\u00e9l\u00e9communications": {}
+        }
+      },
+      "Frais variables": {
+        "Frais variables de fabrication": {
+          " Emballage \u00e0 la production": {
+            "accountType": "Cost of Goods Sold"
+          },
+          " Sous-traitance": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "Achats de mati\u00e8res premi\u00e8res": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "Achats de mat\u00e9riel direct": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "Achats de produits non fabriqu\u00e9s": {
+            "accountType": "Expenses Included In Valuation"
+          },
+          "Avantages sociaux": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "Main-d\u2019\u0153uvre directe": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "Variation des stocks": {
+            "accountType": "Stock Adjustment"
+          },
+          "accountType": "Cost of Goods Sold"
+        },
+        "Frais variables de vente": {
+          "Commissions": {},
+          "Redevances": {},
+          "Transport (\u00e0 contrat)": {}
+        }
+      },
+      "rootType": "Expense"
+    },
+    "Passif": {
+      "PASSIFS NON-COURANTS": {
+        "AUTRES PASSIFS NON-COURANTS": {},
+        "DETTES FINANCI\u00c8RES NON-COURANTES": {},
+        "IMP\u00d4TS DIFF\u00c9R\u00c9S": {},
+        "PROVISIONS POUR RETRAITES ET AUTRES AVANTAGES POST\u00c9RIEURS \u00c0 L'EMPLOI": {}
+      },
+      "Passif \u00e0 court terme": {
+        " Commissions \u00e0 payer": {},
+        "Assurance collective \u00e0 payer": {},
+        "Autres comptes cr\u00e9diteurs": {},
+        "Comptes \u00e0 payer": {
+          "Comptes fournisseurs": {
+            "accountType": "Payable"
+          }
+        },
+        "D\u00e9p\u00f4ts de clients": {},
+        "Emprunt de banque": {},
+        "Imp\u00f4ts li\u00e9s aux salaires \u00e0 payer": {
+          "Agence du revenu du Canada": {
+            "Assurance - emploi \u00e0 payer": {
+              "AE - Contribution de l'employeur": {},
+              "AE - Contribution des employ\u00e9s": {}
+            },
+            "Imp\u00f4t f\u00e9d\u00e9ral sur salaires \u00e0 payer": {}
+          },
+          "Agence du revenu du Qu\u00e9bec": {
+            "Fond des Services de Sant\u00e9 \u00e0 payer": {},
+            "Imp\u00f4t provincial sur salaires \u00e0 payer": {},
+            "Normes du Travail \u00e0 payer": {},
+            "Provision pour sant\u00e9 et s\u00e9curit\u00e9 du travail CSST": {},
+            "R\u00e9gime des rentes du Qu\u00e9bec \u00e0 payer": {
+              "Rentes - Contribution de l'employeur": {},
+              "Rentes - Contribution des employ\u00e9s": {}
+            },
+            "R\u00e9gime qu\u00e9becois d'assurance parentale": {
+              "AP - Contribution de l'employeur": {},
+              "AP - Contribution des employ\u00e9s": {}
+            }
+          },
+          "Caisse de retraite \u00e0 payer": {}
+        },
+        "Imp\u00f4ts \u00e0 payer": {
+          "Imp\u00f4t f\u00e9d\u00e9ral sur le revenu \u00e0 payer": {},
+          "Imp\u00f4t provincial sur le revenu \u00e0 payer": {},
+          "TPS \u00e0 payer": {},
+          "TVH \u00e0 payer": {
+            "TVH \u00e0 payer - 13%": {},
+            "TVH \u00e0 payer - 14%": {},
+            "TVH \u00e0 payer - 15%": {}
+          },
+          "TVP/TVQ \u00e0 payer": {}
+        },
+        "Passifs de stock": {
+          "Stock re\u00e7u non factur\u00e9": {
+            "accountType": "Stock Received But Not Billed"
+          }
+        },
+        "Provision pour vacances et cong\u00e9s": {},
+        "Revenus per\u00e7us d\u2019avance": {},
+        "Salaires \u00e0 payer": {}
+      },
+      "Passif \u00e0 long terme": {
+        "Avances des actionnaires": {},
+        "Cr\u00e9dits d\u2019imp\u00f4ts report\u00e9s": {},
+        "Hypoth\u00e8que \u00e0 payer": {},
+        "Liens sur machinerie": {},
+        "Liens sur mat\u00e9riel roulant": {},
+        "Obligation d\u00e9coulant d\u2019un contrat de location - acquisition": {},
+        "Passif d\u2019imp\u00f4ts futurs": {}
+      },
+      "rootType": "Liability"
+    },
+    "Produits": {
+      "Revenus de ventes": {
+        " Escomptes de volume sur ventes": {},
+        "Autres produits d'exploitation": {},
+        "Ventes": {},
+        "Ventes avec des provinces harmonis\u00e9es": {},
+        "Ventes avec des provinces non-harmonis\u00e9es": {},
+        "Ventes \u00e0 l'\u00e9tranger": {}
+      },
+      "Revenus non li\u00e9 \u00e0 la vente": {
+        "Autres revenus non li\u00e9s \u00e0 la vente": {},
+        "Revenues d'int\u00e9r\u00eats": {}
+      },
+      "rootType": "Income"
+    }
   }
 }

--- a/fixtures/verified/gt.json
+++ b/fixtures/verified/gt.json
@@ -1,423 +1,423 @@
 {
-  "country_code": "gt", 
-  "name": "Guatemala - Cuentas", 
+  "countryCode": "gt",
+  "name": "Guatemala - Cuentas",
   "tree": {
-      "Activos": {
-          "Activo Corriente": {
-              "Activos Biol\u00f3gicos": {
-                  "Activos Biol\u00f3gicos a Valor Razonable": {
-                      "Animales": {
-                          "account_number": "1.5.2.1", 
-                          "account_type": "Stock", 
-                          "is_group": 1
-                      }, 
-                      "Plantas": {
-                          "account_number": "1.5.2.2", 
-                          "account_type": "Stock", 
-                          "is_group": 1
-                      }, 
-                      "account_number": "1.5.2", 
-                      "account_type": "Stock"
-                  }, 
-                  "Activos Biol\u00f3gicos al Costo": {
-                      "account_number": "1.5.1", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1.5", 
-                  "account_type": "Stock"
-              }, 
-              "Activos Corrientes Adicionales": {
-                  "Activos Diferidos o Restringidos": {
-                      "Cr\u00e9dito Fiscal (IVA Por Cobrar)": {
-                          "account_number": "1.1.2.1", 
-                          "account_type": "Chargeable", 
-                          "is_group": 1
-                      }, 
-                      "account_number": "1.1.2", 
-                      "account_type": "Chargeable"
-                  }, 
-                  "Inversiones Corrientes no Clasificados como Equivalentes de Caja y Bancos": {
-                      "account_number": "1.1.1"
-                  }, 
-                  "account_number": "1.1", 
-                  "account_type": "Chargeable"
-              }, 
-              "Activos Devengables y Otros Activos": {
-                  "Activos Adicionales y Otros": {
-                      "account_number": "1.6.6", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Cobrables Relacionados con Impuestos": {
-                      "account_number": "1.6.2", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Contratos de Construccion": {
-                      "account_number": "1.6.4", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Costos de Montaje": {
-                      "account_number": "1.6.5", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Pagos Anticipados y Otros Activos Circulantes": {
-                      "Seguro Pagado Anticipadamente": {
-                          "account_number": "1.6.1.0", 
-                          "account_type": "Chargeable"
-                      }, 
-                      "account_number": "1.6.1", 
-                      "account_type": "Chargeable"
-                  }, 
-                  "Proveedores de Servicio": {
-                      "account_number": "1.6.3", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1.6", 
-                  "account_type": "Chargeable"
-              }, 
-              "Activos Financieros": {
-                  "Activos Financieros Clasificados por Designaci\u00f3n": {
-                      "account_number": "1.4.6", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Activos Financieros Derivados": {
-                      "account_number": "1.4.3", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Inversion o Participaci\u00f3n Accionaria en Empresas Afiliadas": {
-                      "account_number": "1.4.1", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Inversiones Burs\u00e1tiles e Instrumentos Financieros": {
-                      "account_number": "1.4.2", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Otros Activos Financieros": {
-                      "account_number": "1.4.4", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Provisi\u00f3n por Riesgo de Cr\u00e9dito (agregado) (Contra-activo)": {
-                      "account_number": "1.4.5", 
-                      "account_type": "Round Off", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1.4", 
-                  "account_type": "Chargeable"
-              }, 
-              "Activos Intangibles": {
-                  "account_number": "1.3", 
-                  "account_type": "Chargeable", 
-                  "is_group": 1
-              }, 
-              "Caja y Equivalentes": {
-                  "Caja": {
-                      "account_number": "1.9.1", 
-                      "account_type": "Cash", 
-                      "is_group": 1
-                  }, 
-                  "Equivalentes de Efectivo (Bancos)": {
-                      "Bancos Internacionales": {
-                          "HSBC": {
-                              "account_number": "1.9.2.2.1", 
-                              "account_type": "Bank"
-                          }, 
-                          "account_number": "1.9.2.2", 
-                          "account_type": "Bank"
-                      }, 
-                      "Bancos Nacionales": {
-                          "Banco Agromercantil de Guatemala": {
-                              "account_number": "1.9.2.1.2", 
-                              "account_type": "Bank"
-                          }, 
-                          "Banco G&T Continental": {
-                              "account_number": "1.9.2.1.5", 
-                              "account_type": "Bank"
-                          }, 
-                          "Banco Industrial": {
-                              "account_number": "1.9.2.1.1", 
-                              "account_type": "Bank", 
-                              "is_group": 1
-                          }, 
-                          "Banco Internacional": {
-                              "account_number": "1.9.2.1.6", 
-                              "account_type": "Bank"
-                          }, 
-                          "Banco Prom\u00e9rica": {
-                              "account_number": "1.9.2.1.3", 
-                              "account_type": "Bank"
-                          }, 
-                          "Banco de Am\u00e9rica Central": {
-                              "account_number": "1.9.2.1.4", 
-                              "account_type": "Bank"
-                          }, 
-                          "Banco de Desarrollo Rural": {
-                              "account_number": "1.9.2.1.7", 
-                              "account_type": "Bank"
-                          }, 
-                          "Banco de los Trabajadores": {
-                              "account_number": "1.9.2.1.8", 
-                              "account_type": "Bank"
-                          }, 
-                          "Vivibanco": {
-                              "account_number": "1.9.2.1.9", 
-                              "account_type": "Bank"
-                          }, 
-                          "account_number": "1.9.2.1", 
-                          "account_type": "Bank"
-                      }, 
-                      "Cadena de Bloques (Blockchain)": {
-                          "Billetera Bitcoin 1234567890abcdefg": {
-                              "account_number": "1.9.2.3.1", 
-                              "account_type": "Cash"
-                          }, 
-                          "account_number": "1.9.2.3", 
-                          "account_type": "Cash"
-                      }, 
-                      "account_number": "1.9.2", 
-                      "account_type": "Bank"
-                  }, 
-                  "Inversiones a Corto Plazo": {
-                      "account_number": "1.9.3", 
-                      "account_type": "Bank", 
-                      "is_group": 1
-                  }, 
-                  "Otros Equivalentes de Caja y Bancos": {
-                      "account_number": "1.9.4", 
-                      "account_type": "Cash", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1.9", 
-                  "account_type": "Bank"
-              }, 
-              "Cobrables": {
-                  "Activos bajo Contrato": {
-                      "account_number": "1.8.2", 
-                      "account_type": "Receivable", 
-                      "is_group": 1
-                  }, 
-                  "Ajustes": {
-                      "account_number": "1.8.4", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "Otras Cuentas por Cobrar": {
-                      "Cuentas Por Cobrar Compa\u00f1\u00edas Afiliadas": {
-                          "Compa\u00f1\u00eda subsidiaria (EJEMPLO)": {
-                              "account_number": "1.8.3.2.1", 
-                              "account_type": "Receivable"
-                          }, 
-                          "account_number": "1.8.3.2", 
-                          "account_type": "Receivable"
-                      }, 
-                      "Cuentas por Cobrar a Empleados": {
-                          "Prestamo EJEMPLO": {
-                              "account_number": "1.8.3.3.1", 
-                              "account_type": "Receivable"
-                          }, 
-                          "account_number": "1.8.3.3", 
-                          "account_type": "Receivable"
-                      }, 
-                      "Cuentas por Cobrar a Otras Entidades no Afiliadas": {
-                          "Compa\u00f1\u00eda No Afiliada (EJEMPLO)": {
-                              "account_number": "1.8.3.1.1", 
-                              "account_type": "Receivable"
-                          }, 
-                          "account_number": "1.8.3.1", 
-                          "account_type": "Receivable"
-                      }, 
-                      "account_number": "1.8.3", 
-                      "account_type": "Receivable"
-                  }, 
-                  "Ventas al Cr\u00e9dito": {
-                      "account_number": "1.8.1", 
-                      "account_type": "Receivable", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1.8", 
-                  "account_type": "Receivable"
-              }, 
-              "Impuestos por Cobrar": {
-                  "Retenciones de IVA recibidas": {}
-              }, 
-              "Inventario": {
-                  "Art\u00edculos de Inventario Adicionales": {
-                      "account_number": "1.7.8", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Combustibles": {
-                      "account_number": "1.7.5", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Inventarios Pignorados Como Garant\u00eda de Pasivo": {
-                      "account_number": "1.7.10", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Inventarios a Valor Razonable Menos Costos de Venta": {
-                      "account_number": "1.7.11", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Materia Prima": {
-                      "account_number": "1.7.1", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Mercader\u00eda (Mercanc\u00edas)": {
-                      "account_number": "1.7.2", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Otros Inventarios": {
-                      "Merma o Ajuste de Inventario": {
-                          "account_number": "1.7.9.1", 
-                          "account_type": "Stock Adjustment", 
-                          "is_group": 1
-                      }, 
-                      "account_number": "1.7.9", 
-                      "account_type": "Stock"
-                  }, 
-                  "Producto Terminado": {
-                      "account_number": "1.7.7", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Repuestos": {
-                      "Respuestos en Transito": {
-                          "account_number": "1.7.4.0", 
-                          "account_type": "Stock", 
-                          "is_group": 1
-                      }, 
-                      "account_number": "1.7.4", 
-                      "account_type": "Stock"
-                  }, 
-                  "Suministros de Producci\u00f3n y Consumibles": {
-                      "account_number": "1.7.3", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Trabajo en Progeso": {
-                      "account_number": "1.7.6", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1.7", 
-                  "account_type": "Stock"
-              }, 
-              "Inversion en Propiedades": {
-                  "Inversion Inmobiliaria Bajo Construccion": {
-                      "account_number": "1.2.1", 
-                      "account_type": "Chargeable"
-                  }, 
-                  "Inversion Inmobiliaria Construida": {
-                      "account_number": "1.2.2", 
-                      "account_type": "Chargeable", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1.2", 
-                  "account_type": "Chargeable"
-              }, 
-              "account_number": "1.0"
-          }, 
-          "No Corriente": {
-              "Activos Fijos": {
-                  "account_type": "Fixed Asset"
-              }, 
-              "Cargos Diferidos": {}
-          }, 
-          "account_number": "1", 
-          "root_type": "Asset"
-      }, 
-      "Costos": {
-          "Costo de Ventas": {
-              "account_type": "Cost of Goods Sold"
-          }, 
-          "Costos Incluidos en la Valuaci\u00f3n": {
-              "account_type": "Expenses Included In Valuation"
-          }, 
-          "Merma o Ajuste de Inventario": {
-              "account_type": "Stock Adjustment"
-          }, 
-          "account_number": "5", 
-          "root_type": "Expense"
-      }, 
-      "Gastos": {
-          "Alquileres": {}, 
-          "Depreciaciones": {
-              "account_type": "Depreciation"
-          }, 
-          "Gastos Diversos": {}, 
-          "Gastos de Personal": {}, 
-          "Honorarios Profesionales": {}, 
-          "Mantenimiento": {}, 
-          "Seguros": {}, 
-          "Servicios B\u00e1sicos": {}, 
-          "account_number": "6", 
-          "root_type": "Expense"
-      }, 
-      "Ingresos": {
-          "Productos": {}, 
-          "Servicios": {}, 
-          "account_number": "4", 
-          "root_type": "Income"
-      }, 
-      "Otros Gastos y Productos Financieros": {
-          "Otros Gastos": {
-              "Otros Gastos y Productos Financieros 2": {
-                  "Intereses 1": {}, 
-                  "Otros Gastos Financieros 1": {}
-              }
-          }, 
-          "Otros Ingresos": {
-              "Otros Gastos y Productos Financieros 1": {
-                  "Intereses": {}, 
-                  "Otros Gastos Financieros": {}
-              }
-          }, 
-          "account_number": "7", 
-          "root_type": "Expense"
-      }, 
-      "Pasivos": {
-          "Pasivo Corriente": {
-              "Acreedores 1": {
-                  "account_type": "Payable"
-              }, 
-              "Cuentas por Pagar": {}, 
-              "Impuestos por Pagar": {}, 
-              "Otras Cuentas por Pagar": {}, 
-              "Prestaciones": {}, 
-              "Proveedores": {
-                  "Inventario Recibido pero No Cobrado": {
-                      "account_type": "Stock Received But Not Billed"
-                  }
-              }, 
-              "Sueldos por Liquidar": {}
-          }, 
-          "Pasivo No Corriente": {
-              "Acreedores": {}, 
-              "Provisi\u00f3n para Indemnizaciones": {}
-          }, 
-          "account_number": "2", 
-          "root_type": "Liability"
-      }, 
-      "Patrimonio": {
-          "Capital": {}, 
-          "Resultados del Ejercicio": {}, 
-          "Utilidades Retenidas": {}, 
-          "account_number": "3", 
-          "root_type": "Asset"
-      }
+    "Activos": {
+      "Activo Corriente": {
+        "Activos Biol\u00f3gicos": {
+          "Activos Biol\u00f3gicos a Valor Razonable": {
+            "Animales": {
+              "accountNumber": "1.5.2.1",
+              "accountType": "Stock",
+              "isGroup": 1
+            },
+            "Plantas": {
+              "accountNumber": "1.5.2.2",
+              "accountType": "Stock",
+              "isGroup": 1
+            },
+            "accountNumber": "1.5.2",
+            "accountType": "Stock"
+          },
+          "Activos Biol\u00f3gicos al Costo": {
+            "accountNumber": "1.5.1",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "accountNumber": "1.5",
+          "accountType": "Stock"
+        },
+        "Activos Corrientes Adicionales": {
+          "Activos Diferidos o Restringidos": {
+            "Cr\u00e9dito Fiscal (IVA Por Cobrar)": {
+              "accountNumber": "1.1.2.1",
+              "accountType": "Chargeable",
+              "isGroup": 1
+            },
+            "accountNumber": "1.1.2",
+            "accountType": "Chargeable"
+          },
+          "Inversiones Corrientes no Clasificados como Equivalentes de Caja y Bancos": {
+            "accountNumber": "1.1.1"
+          },
+          "accountNumber": "1.1",
+          "accountType": "Chargeable"
+        },
+        "Activos Devengables y Otros Activos": {
+          "Activos Adicionales y Otros": {
+            "accountNumber": "1.6.6",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Cobrables Relacionados con Impuestos": {
+            "accountNumber": "1.6.2",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Contratos de Construccion": {
+            "accountNumber": "1.6.4",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Costos de Montaje": {
+            "accountNumber": "1.6.5",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Pagos Anticipados y Otros Activos Circulantes": {
+            "Seguro Pagado Anticipadamente": {
+              "accountNumber": "1.6.1.0",
+              "accountType": "Chargeable"
+            },
+            "accountNumber": "1.6.1",
+            "accountType": "Chargeable"
+          },
+          "Proveedores de Servicio": {
+            "accountNumber": "1.6.3",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "accountNumber": "1.6",
+          "accountType": "Chargeable"
+        },
+        "Activos Financieros": {
+          "Activos Financieros Clasificados por Designaci\u00f3n": {
+            "accountNumber": "1.4.6",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Activos Financieros Derivados": {
+            "accountNumber": "1.4.3",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Inversion o Participaci\u00f3n Accionaria en Empresas Afiliadas": {
+            "accountNumber": "1.4.1",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Inversiones Burs\u00e1tiles e Instrumentos Financieros": {
+            "accountNumber": "1.4.2",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Otros Activos Financieros": {
+            "accountNumber": "1.4.4",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Provisi\u00f3n por Riesgo de Cr\u00e9dito (agregado) (Contra-activo)": {
+            "accountNumber": "1.4.5",
+            "accountType": "Round Off",
+            "isGroup": 1
+          },
+          "accountNumber": "1.4",
+          "accountType": "Chargeable"
+        },
+        "Activos Intangibles": {
+          "accountNumber": "1.3",
+          "accountType": "Chargeable",
+          "isGroup": 1
+        },
+        "Caja y Equivalentes": {
+          "Caja": {
+            "accountNumber": "1.9.1",
+            "accountType": "Cash",
+            "isGroup": 1
+          },
+          "Equivalentes de Efectivo (Bancos)": {
+            "Bancos Internacionales": {
+              "HSBC": {
+                "accountNumber": "1.9.2.2.1",
+                "accountType": "Bank"
+              },
+              "accountNumber": "1.9.2.2",
+              "accountType": "Bank"
+            },
+            "Bancos Nacionales": {
+              "Banco Agromercantil de Guatemala": {
+                "accountNumber": "1.9.2.1.2",
+                "accountType": "Bank"
+              },
+              "Banco G&T Continental": {
+                "accountNumber": "1.9.2.1.5",
+                "accountType": "Bank"
+              },
+              "Banco Industrial": {
+                "accountNumber": "1.9.2.1.1",
+                "accountType": "Bank",
+                "isGroup": 1
+              },
+              "Banco Internacional": {
+                "accountNumber": "1.9.2.1.6",
+                "accountType": "Bank"
+              },
+              "Banco Prom\u00e9rica": {
+                "accountNumber": "1.9.2.1.3",
+                "accountType": "Bank"
+              },
+              "Banco de Am\u00e9rica Central": {
+                "accountNumber": "1.9.2.1.4",
+                "accountType": "Bank"
+              },
+              "Banco de Desarrollo Rural": {
+                "accountNumber": "1.9.2.1.7",
+                "accountType": "Bank"
+              },
+              "Banco de los Trabajadores": {
+                "accountNumber": "1.9.2.1.8",
+                "accountType": "Bank"
+              },
+              "Vivibanco": {
+                "accountNumber": "1.9.2.1.9",
+                "accountType": "Bank"
+              },
+              "accountNumber": "1.9.2.1",
+              "accountType": "Bank"
+            },
+            "Cadena de Bloques (Blockchain)": {
+              "Billetera Bitcoin 1234567890abcdefg": {
+                "accountNumber": "1.9.2.3.1",
+                "accountType": "Cash"
+              },
+              "accountNumber": "1.9.2.3",
+              "accountType": "Cash"
+            },
+            "accountNumber": "1.9.2",
+            "accountType": "Bank"
+          },
+          "Inversiones a Corto Plazo": {
+            "accountNumber": "1.9.3",
+            "accountType": "Bank",
+            "isGroup": 1
+          },
+          "Otros Equivalentes de Caja y Bancos": {
+            "accountNumber": "1.9.4",
+            "accountType": "Cash",
+            "isGroup": 1
+          },
+          "accountNumber": "1.9",
+          "accountType": "Bank"
+        },
+        "Cobrables": {
+          "Activos bajo Contrato": {
+            "accountNumber": "1.8.2",
+            "accountType": "Receivable",
+            "isGroup": 1
+          },
+          "Ajustes": {
+            "accountNumber": "1.8.4",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "Otras Cuentas por Cobrar": {
+            "Cuentas Por Cobrar Compa\u00f1\u00edas Afiliadas": {
+              "Compa\u00f1\u00eda subsidiaria (EJEMPLO)": {
+                "accountNumber": "1.8.3.2.1",
+                "accountType": "Receivable"
+              },
+              "accountNumber": "1.8.3.2",
+              "accountType": "Receivable"
+            },
+            "Cuentas por Cobrar a Empleados": {
+              "Prestamo EJEMPLO": {
+                "accountNumber": "1.8.3.3.1",
+                "accountType": "Receivable"
+              },
+              "accountNumber": "1.8.3.3",
+              "accountType": "Receivable"
+            },
+            "Cuentas por Cobrar a Otras Entidades no Afiliadas": {
+              "Compa\u00f1\u00eda No Afiliada (EJEMPLO)": {
+                "accountNumber": "1.8.3.1.1",
+                "accountType": "Receivable"
+              },
+              "accountNumber": "1.8.3.1",
+              "accountType": "Receivable"
+            },
+            "accountNumber": "1.8.3",
+            "accountType": "Receivable"
+          },
+          "Ventas al Cr\u00e9dito": {
+            "accountNumber": "1.8.1",
+            "accountType": "Receivable",
+            "isGroup": 1
+          },
+          "accountNumber": "1.8",
+          "accountType": "Receivable"
+        },
+        "Impuestos por Cobrar": {
+          "Retenciones de IVA recibidas": {}
+        },
+        "Inventario": {
+          "Art\u00edculos de Inventario Adicionales": {
+            "accountNumber": "1.7.8",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Combustibles": {
+            "accountNumber": "1.7.5",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Inventarios Pignorados Como Garant\u00eda de Pasivo": {
+            "accountNumber": "1.7.10",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Inventarios a Valor Razonable Menos Costos de Venta": {
+            "accountNumber": "1.7.11",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Materia Prima": {
+            "accountNumber": "1.7.1",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Mercader\u00eda (Mercanc\u00edas)": {
+            "accountNumber": "1.7.2",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Otros Inventarios": {
+            "Merma o Ajuste de Inventario": {
+              "accountNumber": "1.7.9.1",
+              "accountType": "Stock Adjustment",
+              "isGroup": 1
+            },
+            "accountNumber": "1.7.9",
+            "accountType": "Stock"
+          },
+          "Producto Terminado": {
+            "accountNumber": "1.7.7",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Repuestos": {
+            "Respuestos en Transito": {
+              "accountNumber": "1.7.4.0",
+              "accountType": "Stock",
+              "isGroup": 1
+            },
+            "accountNumber": "1.7.4",
+            "accountType": "Stock"
+          },
+          "Suministros de Producci\u00f3n y Consumibles": {
+            "accountNumber": "1.7.3",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Trabajo en Progeso": {
+            "accountNumber": "1.7.6",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "accountNumber": "1.7",
+          "accountType": "Stock"
+        },
+        "Inversion en Propiedades": {
+          "Inversion Inmobiliaria Bajo Construccion": {
+            "accountNumber": "1.2.1",
+            "accountType": "Chargeable"
+          },
+          "Inversion Inmobiliaria Construida": {
+            "accountNumber": "1.2.2",
+            "accountType": "Chargeable",
+            "isGroup": 1
+          },
+          "accountNumber": "1.2",
+          "accountType": "Chargeable"
+        },
+        "accountNumber": "1.0"
+      },
+      "No Corriente": {
+        "Activos Fijos": {
+          "accountType": "Fixed Asset"
+        },
+        "Cargos Diferidos": {}
+      },
+      "accountNumber": "1",
+      "rootType": "Asset"
+    },
+    "Costos": {
+      "Costo de Ventas": {
+        "accountType": "Cost of Goods Sold"
+      },
+      "Costos Incluidos en la Valuaci\u00f3n": {
+        "accountType": "Expenses Included In Valuation"
+      },
+      "Merma o Ajuste de Inventario": {
+        "accountType": "Stock Adjustment"
+      },
+      "accountNumber": "5",
+      "rootType": "Expense"
+    },
+    "Gastos": {
+      "Alquileres": {},
+      "Depreciaciones": {
+        "accountType": "Depreciation"
+      },
+      "Gastos Diversos": {},
+      "Gastos de Personal": {},
+      "Honorarios Profesionales": {},
+      "Mantenimiento": {},
+      "Seguros": {},
+      "Servicios B\u00e1sicos": {},
+      "accountNumber": "6",
+      "rootType": "Expense"
+    },
+    "Ingresos": {
+      "Productos": {},
+      "Servicios": {},
+      "accountNumber": "4",
+      "rootType": "Income"
+    },
+    "Otros Gastos y Productos Financieros": {
+      "Otros Gastos": {
+        "Otros Gastos y Productos Financieros 2": {
+          "Intereses 1": {},
+          "Otros Gastos Financieros 1": {}
+        }
+      },
+      "Otros Ingresos": {
+        "Otros Gastos y Productos Financieros 1": {
+          "Intereses": {},
+          "Otros Gastos Financieros": {}
+        }
+      },
+      "accountNumber": "7",
+      "rootType": "Expense"
+    },
+    "Pasivos": {
+      "Pasivo Corriente": {
+        "Acreedores 1": {
+          "accountType": "Payable"
+        },
+        "Cuentas por Pagar": {},
+        "Impuestos por Pagar": {},
+        "Otras Cuentas por Pagar": {},
+        "Prestaciones": {},
+        "Proveedores": {
+          "Inventario Recibido pero No Cobrado": {
+            "accountType": "Stock Received But Not Billed"
+          }
+        },
+        "Sueldos por Liquidar": {}
+      },
+      "Pasivo No Corriente": {
+        "Acreedores": {},
+        "Provisi\u00f3n para Indemnizaciones": {}
+      },
+      "accountNumber": "2",
+      "rootType": "Liability"
+    },
+    "Patrimonio": {
+      "Capital": {},
+      "Resultados del Ejercicio": {},
+      "Utilidades Retenidas": {},
+      "accountNumber": "3",
+      "rootType": "Asset"
+    }
   }
 }

--- a/fixtures/verified/hu.json
+++ b/fixtures/verified/hu.json
@@ -1,835 +1,835 @@
 {
-	"country_code": "hu", 
-	"name": "Hungary - Chart of Accounts", 
-	"tree": {
-		"1. SZ\u00c1MLAOSZT\u00c1LY BEFEKTETETT ESZK\u00d6Z\u00d6K": {
-			"11. IMMATERI\u00c1LIS JAVAK": {
-				"111. Alap\u00edt\u00e1s-\u00e1tszervez\u00e9s aktiv\u00e1lt \u00e9rt\u00e9ke": {}, 
-				"112. K\u00eds\u00e9rleti fejleszt\u00e9s aktiv\u00e1lt \u00e9rt\u00e9ke": {}, 
-				"113. Vagyoni \u00e9rt\u00e9k\u0171 jogok": {}, 
-				"114. Szellemi term\u00e9kek": {}, 
-				"115. \u00dczleti vagy c\u00e9g\u00e9rt\u00e9k": {}, 
-				"117. Immateri\u00e1lis javak \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {}
-			}, 
-			"12-16. T\u00c1RGYI ESZK\u00d6Z\u00d6K": {
-				"12. INGATLANOK \u00c9S KAPCSOL\u00d3D\u00d3 VAGYONI \u00c9RT\u00c9K\u00db JOGOK": {
-					"121. Telkek, f\u00f6ldter\u00fclet ": {
-						"1211. Telkek, f\u00f6ldter\u00fcletek brutt\u00f3 \u00e9rt\u00e9ke": {
-							"account_type": "Fixed Asset"
-						}, 
-						"1218. Telkek, f\u00f6ldter\u00fcletek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}, 
-						"1219. Telkek, f\u00f6ldter\u00fcletek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
-					}, 
-					"122. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok": {
-						"1221. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok brutt\u00f3 \u00e9rt\u00e9ke": {
-							"account_type": "Fixed Asset"
-						}, 
-						"1228. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}, 
-						"1229. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
-					}, 
-					"123. \u00c9p\u00fcletek, \u00e9p\u00fcletr\u00e9szek, tulajdoni h\u00e1nyadok ": {
-						"account_type": "Fixed Asset", 
-						"is_group": 1
-					}, 
-					"124. Egy\u00e9b ingatlanok": {
-						"is_group": 1
-					}, 
-					"125. \u00dczemk\u00f6r\u00f6n k\u00edv\u00fcli ingatlanok, \u00e9p\u00fcletek ": {
-						"is_group": 1
-					}, 
-					"126. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok": {
-						"is_group": 1
-					}, 
-					"127. Ingatlanok \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {}, 
-					"129. Kis \u00e9rt\u00e9k\u0171 ingatlanok": {}
-				}, 
-				"13. M\u00dbSZAKI BERENDEZ\u00c9SEK, G\u00c9PEK, J\u00c1RM\u00dbVEK": {
-					"131. Termel\u0151 g\u00e9pek, berendez\u00e9sek, szersz\u00e1mok, gy\u00e1rt\u00f3eszk\u00f6z\u00f6k": {
-						"1311. Termel\u0151 g\u00e9pek, berendez\u00e9sek brutt\u00f3 \u00e9rt\u00e9ke": {
-							"account_type": "Fixed Asset"
-						}, 
-						"1318. Termel\u0151 g\u00e9pek, berendez\u00e9sek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}, 
-						"1319. Termel\u0151 g\u00e9pek, berendez\u00e9sek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
-					}, 
-					"132. M\u0171szaki j\u00e1rm\u0171vek": {}, 
-					"133. Ki nem emelt m\u0171szaki berendez\u00e9sek, g\u00e9pek, j\u00e1rm\u0171vek": {}, 
-					"139. Kis \u00e9rt\u00e9k\u0171 m\u0171szaki berendez\u00e9sek, g\u00e9pek, j\u00e1rm\u0171vek": {}
-				}, 
-				"14. EGY\u00c9B BERENDEZ\u00c9SEK, FELSZEREL\u00c9SEK, J\u00c1RM\u00dbVEK": {
-					"141. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek": {
-						"1411. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek brutt\u00f3 \u00e9rt\u00e9ke": {
-							"account_type": "Fixed Asset"
-						}, 
-						"1418. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}, 
-						"1419. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
-					}, 
-					"142. Egy\u00e9b j\u00e1rm\u0171vek": {
-						"1421. Egy\u00e9b j\u00e1rm\u0171vek brutt\u00f3 \u00e9rt\u00e9ke": {
-							"account_type": "Fixed Asset"
-						}, 
-						"1428. Egy\u00e9b j\u00e1rm\u0171vek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}, 
-						"1429. Egy\u00e9b j\u00e1rm\u0171vek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
-					}, 
-					"143. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek": {
-						"1431. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek brutt\u00f3 \u00e9rt\u00e9ke": {
-							"account_type": "Fixed Asset"
-						}, 
-						"1438. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}, 
-						"1439. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
-					}, 
-					"144. Ki nem emelt egy\u00e9b berendez\u00e9sek, felszerel\u00e9sek": {
-						"account_type": "Fixed Asset"
-					}, 
-					"145. J\u00f3l\u00e9ti berendez\u00e9sek, felszerel\u00e9si t\u00e1rgyak \u00e9s k\u00e9pz\u0151m\u0171v\u00e9szeti alkot\u00e1sok": {
-						"account_type": "Fixed Asset"
-					}, 
-					"147. Egy\u00e9b berendez\u00e9sek, felszerel\u00e9sek, j\u00e1rm\u0171vek \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {
-						"account_type": "Fixed Asset"
-					}, 
-					"149. Kis \u00e9rt\u00e9k\u0171 egy\u00e9b berendez\u00e9sek, felszerel\u00e9sek, j\u00e1rm\u0171vek": {
-						"account_type": "Fixed Asset"
-					}
-				}, 
-				"15. TENY\u00c9SZ\u00c1LLATOK": {
-					"151. Teny\u00e9sz\u00e1llatok": {}
-				}, 
-				"16. BERUH\u00c1Z\u00c1SOK, FEL\u00daJ\u00cdT\u00c1SOK": {
-					"161. Befejezetlen beruh\u00e1z\u00e1sok ": {}, 
-					"162. Fel\u00faj\u00edt\u00e1sok": {}, 
-					"168. Beruh\u00e1z\u00e1sok terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
-				}, 
-				"17-19. BEFEKTETETT P\u00c9NZ\u00dcGYI ESZK\u00d6Z\u00d6K": {
-					"17. TULAJDONI R\u00c9SZESED\u00c9ST JELENT\u00d5 BEFEKTET\u00c9SEK (R\u00c9SZESED\u00c9SEK)": {
-						"171. Tart\u00f3s r\u00e9szesed\u00e9s kapcsolt v\u00e1llalkoz\u00e1sban": {}, 
-						"172. Egy\u00e9b tart\u00f3s r\u00e9szesed\u00e9s": {}, 
-						"177. R\u00e9szesed\u00e9sek \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {}, 
-						"179. R\u00e9szesed\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-					}, 
-					"18. HITELVISZONYT MEGTESTES\u00cdT\u00d5 \u00c9RT\u00c9KPAP\u00cdROK": {
-						"181. \u00c1llamk\u00f6tv\u00e9nyek": {}, 
-						"182. Kapcsolt v\u00e1llalkoz\u00e1sok \u00e9rt\u00e9kpap\u00edrjai": {}, 
-						"183. Egy\u00e9b v\u00e1llalkoz\u00e1sok \u00e9rt\u00e9kpap\u00edrjai": {}, 
-						"184. Tart\u00f3s diszkont \u00e9rt\u00e9kpap\u00edrok": {}, 
-						"189. \u00c9rt\u00e9kpap\u00edrok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-					}, 
-					"19. TART\u00d3SAN ADOTT K\u00d6LCS\u00d6N\u00d6K (tart\u00f3s bankbet\u00e9tek)": {
-						"191. Tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6k kapcsolt v\u00e1llalkoz\u00e1sban": {}, 
-						"192. Tart\u00f3s bankbet\u00e9tek": {}, 
-						"193. Egy\u00e9b tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6k": {}, 
-						"194. Tart\u00f3s bankbet\u00e9tek kapcsolt v\u00e1llalkoz\u00e1sban": {}, 
-						"195. Tart\u00f3s bankbet\u00e9tek egy\u00e9b r\u00e9szesed\u00e9si viszonyban \u00e1ll\u00f3 v\u00e1llalkoz\u00e1sban": {}, 
-						"196. Egy\u00e9b tart\u00f3s bankbet\u00e9tek": {}, 
-						"197. P\u00e9nz\u00fcgyi l\u00edzing miatti tart\u00f3s k\u00f6vetel\u00e9s": {}, 
-						"199. Tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6k (\u00e9s bankbet\u00e9tek) \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-					}
-				}
-			}, 
-			"root_type": "Asset"
-		}, 
-		"2. SZ\u00c1MLAOSZT\u00c1LY K\u00c9SZLETEK": {
-			"21-22. ANYAGOK": {
-				"211 - 219. Nyers- \u00e9s alapanyagok ": {}, 
-				"221. Seg\u00e9danyagok": {}, 
-				"222. \u00dczem- \u00e9s f\u0171t\u0151anyagok ": {}, 
-				"223. Fenntart\u00e1si anyagok ": {}, 
-				"224. \u00c9p\u00edt\u00e9si anyagok": {}, 
-				"225. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 anyagi eszk\u00f6z\u00f6k ": {}, 
-				"226. T\u00e1rgyi eszk\u00f6z\u00f6k k\u00f6z\u00fcl \u00e1tsorolt anyagok": {}, 
-				"227. Egy\u00e9b anyagok": {}, 
-				"228. Anyagok \u00e1rk\u00fcl\u00f6nb\u00f6zete": {}, 
-				"229. Anyagok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-			}, 
-			"23. BEFEJEZETLEN TERMEL\u00c9S \u00c9S F\u00c9LK\u00c9SZ TERM\u00c9KEK": {
-				"231 - 234. Befejezetlen termel\u00e9s ": {
-					"231. Befejezetlen termel\u00e9s": {}, 
-					"232. F\u00e9lk\u00e9sz term\u00e9kek": {}
-				}, 
-				"238. F\u00e9lk\u00e9sz term\u00e9kek k\u00e9szlet\u00e9rt\u00e9k-k\u00fcl\u00f6nb\u00f6zete": {}, 
-				"239. Befejezetlen termel\u00e9s \u00e9s f\u00e9lk\u00e9sz term\u00e9kek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-			}, 
-			"24. N\u00d6VEND\u00c9K-, H\u00cdZ\u00d3- \u00c9S EGY\u00c9B \u00c1LLATOK": {
-				"is_group": 1
-			}, 
-			"25. K\u00c9SZTERM\u00c9KEK": {
-				"251-257. K\u00e9szterm\u00e9kek": {}, 
-				"258. K\u00e9szterm\u00e9kek k\u00e9szlet\u00e9rt\u00e9k-k\u00fcl\u00f6nb\u00f6zete": {}, 
-				"259. K\u00e9szterm\u00e9kek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-			}, 
-			"26-28. \u00c1RUK ": {
-				"261. Kereskedelmi \u00e1ruk": {
-					"account_type": "Stock",
-					"is_group": 0
-				}, 
-				"262. Idegen helyen t\u00e1rolt, bizom\u00e1nyba \u00e1tadott \u00e1ruk": {
-					"account_type": "Stock",
-					"is_group": 0
-				}, 
-				"263. T\u00e1rgyi eszk\u00f6z\u00f6k k\u00f6z\u00fcl \u00e1tsorolt \u00e1ruk": {
-					"account_type": "Stock",
-					"is_group": 0
-				}, 
-				"264. Bels\u0151 (egys\u00e9gek, tev\u00e9kenys\u00e9gek k\u00f6z\u00f6tti) \u00e1tad\u00e1s-\u00e1tv\u00e9tel \u00fctk\u00f6z\u0151sz\u00e1mla": {
-					"account_type": "Stock",
-					"is_group": 0
-				}, 
-				"269. Kereskedelmi \u00e1ruk \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {
-					"account_type": "Stock",
-					"is_group": 0
-				}, 
-				"account_type": "Stock"
-			}, 
-			"27. K\u00d6ZVET\u00cdTETT SZOLG\u00c1LTAT\u00c1SOK ": {
-				"271. K\u00f6zvet\u00edtett szolg\u00e1ltat\u00e1sok": {}, 
-				"279. K\u00f6zvet\u00edtett szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-			}, 
-			"28. BET\u00c9TD\u00cdJAS G\u00d6NGY\u00d6LEGEK": {
-				"is_group": 1
-			}, 
-			"root_type": "Asset"
-		}, 
-		"3. SZ\u00c1MLAOSZT\u00c1LY K\u00d6VETEL\u00c9SEK, P\u00c9NZ\u00dcGYI ESZK\u00d6Z\u00d6K \u00c9S AKT\u00cdV ID\u00d5BELI ELHAT\u00c1ROL\u00c1SOK": {
-			"31. K\u00d6VETEL\u00c9SEK \u00c1RUSZ\u00c1LL\u00cdT\u00c1SB\u00d3L \u00c9S SZOLG\u00c1LTAT\u00c1SB\u00d3L (VEV\u00d5K) ": {
-				"311. Belf\u00f6ldi k\u00f6vetel\u00e9sek (forintban)": {
-					"account_type": "Receivable"
-				}, 
-				"312. Belf\u00f6ldi k\u00f6vetel\u00e9sek (deviz\u00e1ban)": {
-					"account_type": "Receivable"
-				}, 
-				"315. Belf\u00f6ldi k\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa ": {}, 
-				"316. K\u00fclf\u00f6ldi k\u00f6vetel\u00e9sek (forintban)": {
-					"account_type": "Receivable"
-				}, 
-				"317. K\u00fclf\u00f6ldi k\u00f6vetel\u00e9sek (deviz\u00e1ban)": {
-					"account_type": "Receivable"
-				}, 
-				"319. K\u00fclf\u00f6ldi k\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-			}, 
-			"32. K\u00d6VETEL\u00c9SEK KAPCSOLT V\u00c1LLALKOZ\u00c1SSAL SZEMBEN": {
-				"is_group": 1
-			}, 
-			"33. K\u00d6VETEL\u00c9SEK EGY\u00c9B R\u00c9SZESED\u00c9SI VISZONYBAN L\u00c9V\u00d5 V\u00c1LLALKOZ\u00c1SSAL SZEMBEN ": {
-				"is_group": 1
-			}, 
-			"34. V\u00c1LT\u00d3K\u00d6VETEL\u00c9SEK": {
-				"is_group": 1
-			}, 
-			"35. ADOTT EL\u00d5LEGEK": {
-				"351. Immateri\u00e1lis javakra adott el\u0151legek": {}, 
-				"352. Beruh\u00e1z\u00e1sokra adott el\u0151legek": {}, 
-				"353. K\u00e9szletekre adott el\u0151legek": {}, 
-				"358. Jegyzett, de m\u00e9g be nem fizetett t\u0151ke r\u00e9szesed\u00e9si viszonyban nem l\u00e9v\u0151 v\u00e1llalkoz\u00e1st\u00f3l": {}, 
-				"359. Adott el\u0151legek \u00e9rt\u00e9kveszt\u00e9se \u00e9s vissza\u00edr\u00e1sa": {}
-			}, 
-			"36. EGY\u00c9B K\u00d6VETEL\u00c9SEK": {
-				"361. Munkav\u00e1llal\u00f3kkal szembeni k\u00f6vetel\u00e9sek": {
-					"3611. Munkav\u00e1llal\u00f3knak foly\u00f3s\u00edtott el\u0151legek": {}, 
-					"3612. El\u0151\u00edrt tartoz\u00e1sok": {}, 
-					"3613. Egy\u00e9b elsz\u00e1mol\u00e1sok a munkav\u00e1llal\u00f3kkal": {}
-				}, 
-				"362. K\u00f6lts\u00e9gvet\u00e9ssel szembeni k\u00f6vetel\u00e9sek": {
-					"is_group": 1
-				}, 
-				"363. R\u00f6vid lej\u00e1ratra k\u00f6lcs\u00f6nadott p\u00e9nzeszk\u00f6z\u00f6k": {
-					"is_group": 1
-				}, 
-				"364. R\u00e9szesed\u00e9sekkel, \u00e9rt\u00e9kpap\u00edrokkal kapcsolatos k\u00f6vetel\u00e9sek": {
-					"3641. R\u00f6vid lej\u00e1rat\u00fa k\u00f6lcs\u00f6n\u00f6k": {}, 
-					"3642. Tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6kb\u0151l \u00e1tsorolt k\u00f6vetel\u00e9sek": {}
-				}, 
-				"365. V\u00e1s\u00e1rolt \u00e9s kapott k\u00f6vetel\u00e9sek ": {
-					"is_group": 1
-				}, 
-				"366. R\u00e9szesed\u00e9sekkel, \u00e9rt\u00e9kpap\u00edrokkal kapcsolatos k\u00f6vetel\u00e9sek": {}, 
-				"367. Hat\u00e1rid\u0151s, opci\u00f3s \u00e9s swap \u00fcgyletekkel kapcsolatos k\u00f6vetel\u00e9sek": {}, 
-				"368. K\u00fcl\u00f6nf\u00e9le egy\u00e9b k\u00f6vetel\u00e9sek ": {
-					"3681. Bizom\u00e1nyosi \u00fcgylettel kapcsolatos elsz\u00e1mol\u00e1sok": {}, 
-					"3682. \u00c9rt\u00e9kpap\u00edr-elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-					"3683. Import beszerz\u00e9sek \u00e1f\u00e1ja": {}, 
-					"3684. Ad\u00f3sok": {}, 
-					"3685. Biztos\u00edt\u00f3int\u00e9zettel szembeni k\u00f6vetel\u00e9sek": {}, 
-					"3686. Barter \u00fcgylet elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-					"3687. \u00c1rfolyam k\u00fcl\u00f6nb\u00f6zetek elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-					"3688. Ki nem emelt egy\u00e9b k\u00f6vetel\u00e9sek": {}
-				}, 
-				"369. Egy\u00e9b k\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-			}, 
-			"37. \u00c9RT\u00c9KPAP\u00cdROK": {
-				"371. R\u00e9szesed\u00e9sek": {
-					"3711. R\u00e9szesed\u00e9s anyav\u00e1llalatban": {}, 
-					"3712. R\u00e9szesed\u00e9s le\u00e1nyv\u00e1llalatban": {}, 
-					"3713. R\u00e9szesed\u00e9s k\u00f6z\u00f6s vezet\u00e9s\u0171 v\u00e1llalkoz\u00e1sban": {}, 
-					"3714. R\u00e9szesed\u00e9s t\u00e1rsult v\u00e1llalkoz\u00e1sban": {}, 
-					"3719. Kapcsolt v\u00e1llalkoz\u00e1sban l\u00e9v\u0151 r\u00e9szesed\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-				}, 
-				"372. Saj\u00e1t r\u00e9szv\u00e9nyek, saj\u00e1t \u00fczletr\u00e9szek": {
-					"3721. Elad\u00e1sra v\u00e1s\u00e1rolt egy\u00e9b r\u00e9szesed\u00e9sek": {}
-				}, 
-				"373. Forgat\u00e1si c\u00e9l\u00fa hitelviszonyt megtestes\u00edt\u0151 \u00e9rt\u00e9kpap\u00edrok ": {
-					"3741. Elad\u00e1sra v\u00e1s\u00e1rolt hitelviszonyt megtestes\u00edt\u0151 \u00e9rt\u00e9kpap\u00edrok": {}, 
-					"3742. Elad\u00e1sra v\u00e1s\u00e1rolt diszkont \u00e9rt\u00e9kpap\u00edrok": {}, 
-					"3749. Forgat\u00e1si c\u00e9l\u00fa hitelviszonyt megtestes\u00edt\u0151 \u00e9rt\u00e9kpap\u00edrok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-				}, 
-				"378. \u00c9rt\u00e9kpap\u00edrok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}, 
-				"379. \u00c9rt\u00e9kpap\u00edr elsz\u00e1mol\u00e1si sz\u00e1mla": {}
-			}, 
-			"38. P\u00c9NZESZK\u00d6Z\u00d6K": {
-				"381. P\u00e9nzt\u00e1r ": {
-					"3811. P\u00e9nzt\u00e1r-sz\u00e1mla": {}, 
-					"3812. Elektronikus p\u00e9nzeszk\u00f6z\u00f6k ": {}, 
-					"account_type": "Cash"
-				}, 
-				"382. Valutap\u00e9nzt\u00e1r ": {
-					"3821. Valutap\u00e9nzt\u00e1r-sz\u00e1mla": {}, 
-					"3829. Valuta \u00e1rfolyamk\u00fcl\u00f6nb\u00f6zeti sz\u00e1mla ": {}
-				}, 
-				"383. Csekkek": {}, 
-				"384. Elsz\u00e1mol\u00e1si bet\u00e9tsz\u00e1mla ": {
-					"account_type": "Bank", 
-					"is_group": 1
-				}, 
-				"385. Elk\u00fcl\u00f6n\u00edtett bet\u00e9tsz\u00e1ml\u00e1k ": {
-					"3851. Kamatoz\u00f3 bet\u00e9tsz\u00e1ml\u00e1k": {}, 
-					"3852. Elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l ": {}, 
-					"3853. Beruh\u00e1z\u00e1sra elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k": {}, 
-					"3854. Fejleszt\u00e9si c\u00e9lra elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k ": {}, 
-					"3855. Egy\u00e9b c\u00e9lra elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k": {}, 
-					"3856. Lak\u00e1s\u00e9p\u00edt\u00e9si bet\u00e9tsz\u00e1mla": {}, 
-					"3857. Elk\u00fcl\u00f6n\u00edtett lak\u00e1s\u00e9p\u00edt\u00e9si c\u00e9l\u00fa p\u00e9nzeszk\u00f6z\u00f6k ": {}, 
-					"3858. Lak\u00e1s\u00e9p\u00edt\u00e9s \u00faton l\u00e9v\u0151 p\u00e9nzeszk\u00f6zei": {}
-				}, 
-				"386. Devizabet\u00e9t-sz\u00e1mla ": {
-					"3861. Devizabet\u00e9t-sz\u00e1mla": {}, 
-					"3862. K\u00fclf\u00f6ld\u00f6n vezetett devizabet\u00e9t-sz\u00e1mla ": {}, 
-					"3863. Devizat\u00f6rzsbet\u00e9t-sz\u00e1mla": {}, 
-					"3868. Egy\u00e9b devizabet\u00e9t-sz\u00e1mla": {}, 
-					"3869. Devizabet\u00e9t \u00e1rfolyamk\u00fcl\u00f6nb\u00f6zeti sz\u00e1mla ": {}
-				}, 
-				"387. Elektronikus p\u00e9nz": {}, 
-				"389. \u00c1tvezet\u00e9si sz\u00e1mla": {}
-			}, 
-			"39. AKT\u00cdV ID\u00d5BELI ELHAT\u00c1ROL\u00c1SOK": {
-				"391. Bev\u00e9telek akt\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
-					"3911. Diszkont \u00e9rt\u00e9kpap\u00edrok id\u0151ar\u00e1nyos kamat\u00e1nak elhat\u00e1rol\u00e1sa": {}, 
-					"3912. \u00c9rt\u00e9kpap\u00edrok beszerz\u00e9s\u00e9hez kapcsol\u00f3d\u00f3 k\u00fcl\u00f6nb\u00f6zetb\u0151l az id\u0151ar\u00e1nyos \u00e1rfolyamnyeres\u00e9g elhat\u00e1rol\u00e1sa": {}, 
-					"3913. \u00c1rbev\u00e9tel, egy\u00e9b kamatbev\u00e9tel, egy\u00e9b bev\u00e9tel elhat\u00e1rol\u00e1sa": {}
-				}, 
-				"392. K\u00f6lts\u00e9gek, r\u00e1ford\u00edt\u00e1sok akt\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
-					"3921. \u00c9rt\u00e9kpap\u00edrok, r\u00e9szesed\u00e9sek beszerz\u00e9s\u00e9hez kapcsol\u00f3d\u00f3 bizom\u00e1nyi d\u00edj, v\u00e1s\u00e1rolt v\u00e9teli opci\u00f3 d\u00edj\u00e1nak elhat\u00e1rol\u00e1sa": {}, 
-					"3922. T\u00f6bbletk\u00f6telezetts\u00e9gek elhat\u00e1rol\u00e1sa": {}, 
-					"3923. K\u00f6lts\u00e9gek, egy\u00e9b fizetett kamatok, egy\u00e9b r\u00e1ford\u00edt\u00e1sok elhat\u00e1rol\u00e1sa": {}
-				}, 
-				"393. Halasztott r\u00e1ford\u00edt\u00e1sok ": {
-					"3931. Tartoz\u00e1s\u00e1tv\u00e1llal\u00e1sok miatti r\u00e1ford\u00edt\u00e1sok elhat\u00e1rol\u00e1sa": {}, 
-					"3932. Devizak\u00f6telezetts\u00e9gek \u00e1rfolyamvesztes\u00e9g\u00e9nek elhat\u00e1rol\u00e1sa ": {}
-				}, 
-				"399. A k\u00f6vetel\u00e9s-jelleg\u0171 akt\u00edv id\u0151beli elhat\u00e1rol\u00e1sok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
-			}, 
-			"root_type": "Asset"
-		}, 
-		"4. SZ\u00c1MLAOSZT\u00c1LY FORR\u00c1SOK": {
-			"41. SAJ\u00c1T T\u00d5KE": {
-				"411. Jegyzett\u0151ke ": {}, 
-				"412. T\u0151ketartal\u00e9k": {}, 
-				"413. Eredm\u00e9nytartal\u00e9k": {}, 
-				"414. Lek\u00f6t\u00f6tt tartal\u00e9k ": {
-					"4141. Lek\u00f6t\u00f6tt tartal\u00e9k t\u0151ketartal\u00e9kb\u00f3l": {}, 
-					"4142. Lek\u00f6t\u00f6tt tartal\u00e9k eredm\u00e9nytartal\u00e9kb\u00f3l": {}, 
-					"4143. Lek\u00f6t\u00f6tt tartal\u00e9k p\u00f3tbefizet\u00e9sb\u0151l ": {}
-				}, 
-				"417. \u00c9rt\u00e9kel\u00e9si tartal\u00e9k": {}, 
-				"418. El\u0151z\u0151 \u00e9vek helyesb\u00edt\u00e9s\u00e9b\u0151l sz\u00e1rmaz\u00f3 m\u00e9rleg szerinti eredm\u00e9ny": {}, 
-				"419. Ad\u00f3zott eredm\u00e9ny": {}
-			}, 
-			"42. C\u00c9LTARTAL\u00c9KOK": {
-				"421. C\u00e9ltartal\u00e9k a v\u00e1rhat\u00f3 k\u00f6telezetts\u00e9gekre ": {}, 
-				"422. C\u00e9ltartal\u00e9k a j\u00f6v\u0151beni k\u00f6lts\u00e9gekre": {}, 
-				"424. \u00c1rfolyamvesztes\u00e9g id\u0151beli elhat\u00e1rol\u00e1sa alapj\u00e1n k\u00e9pzett c\u00e9ltartal\u00e9k ": {}, 
-				"429. Egy\u00e9b c\u00e9ltartal\u00e9k": {}
-			}, 
-			"43-47. K\u00d6TELEZETTS\u00c9GEK": {
-				"43. H\u00c1TRASOROLT K\u00d6TELEZETTS\u00c9GEK": {
-					"431. H\u00e1trasorolt k\u00f6telezetts\u00e9gek kapcsolt v\u00e1llalkoz\u00e1ssal szemben ": {
-						"4311. H\u00e1trasorolt k\u00f6telezetts\u00e9gek anyav\u00e1llalattal szemben ": {}, 
-						"4312. H\u00e1trasorolt k\u00f6telezetts\u00e9gek le\u00e1nyv\u00e1llalattal szemben": {}, 
-						"4313. H\u00e1trasorolt k\u00f6telezetts\u00e9gek k\u00f6z\u00f6s vezet\u00e9s\u0171 v\u00e1llalkoz\u00e1ssal szemben ": {}, 
-						"4314. H\u00e1trasorolt k\u00f6telezetts\u00e9gek t\u00e1rsult v\u00e1llalkoz\u00e1ssal szemben ": {}
-					}, 
-					"432. H\u00e1trasorolt k\u00f6telezetts\u00e9gek egy\u00e9b r\u00e9szesed\u00e9si viszonyban l\u00e9v\u0151 v\u00e1llalkoz\u00e1ssal szemben": {}, 
-					"433. H\u00e1trasorolt k\u00f6telezetts\u00e9gek egy\u00e9b gazd\u00e1lkod\u00f3val szemben": {}
-				}, 
-				"44. HOSSZ\u00da LEJ\u00c1RAT\u00da K\u00d6TELEZETTS\u00c9GEK": {
-					"441. Hossz\u00fa lej\u00e1ratra kapott k\u00f6lcs\u00f6n\u00f6k": {}, 
-					"442. \u00c1tv\u00e1ltoztathat\u00f3 k\u00f6tv\u00e9nyek ": {}, 
-					"443. Tartoz\u00e1sok k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l ": {
-						"4431. Tartoz\u00e1sok k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l forintban ": {}, 
-						"4432. Tartoz\u00e1sok k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l deviz\u00e1ban": {}
-					}, 
-					"444. Beruh\u00e1z\u00e1si \u00e9s fejleszt\u00e9si hitelek ": {
-						"4441. Beruh\u00e1z\u00e1si \u00e9s fejleszt\u00e9si hitelek forintban ": {}, 
-						"4442. Beruh\u00e1z\u00e1si \u00e9s fejleszt\u00e9si hitelek deviz\u00e1ban ": {}
-					}, 
-					"445. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa hitelek ": {
-						"4451. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa hitelek forintban ": {}, 
-						"4452. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa hitelek deviz\u00e1ban": {}
-					}, 
-					"446. Tart\u00f3s k\u00f6telezetts\u00e9gek kapcsolt v\u00e1llalkoz\u00e1ssal szemben ": {
-						"is_group": 1
-					}, 
-					"447. Tart\u00f3s k\u00f6telezetts\u00e9gek egy\u00e9b r\u00e9szesed\u00e9si viszonyban l\u00e9v\u0151 v\u00e1llalkoz\u00e1ssal szemben": {}, 
-					"448. P\u00e9nz\u00fcgyi l\u00edzing miatti k\u00f6telezetts\u00e9gek ": {}, 
-					"449. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek ": {
-						"4491. Kincst\u00e1ri vagyon r\u00e9sz\u00e9t k\u00e9pez\u0151 eszk\u00f6z\u00f6k kezel\u00e9sbe v\u00e9tel\u00e9hez kapcsol\u00f3d\u00f3 k\u00f6telezetts\u00e9g": {}, 
-						"4492. Alap\u00edt\u00f3kkal szembeni hossz\u00fa lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek ": {}
-					}, 
-					"4499. Hossz\u00fa lej\u00e1rat\u00fa egy\u00e9b k\u00f6telezetts\u00e9gek": {}
-				}, 
-				"45-47. R\u00d6VID LEJ\u00c1RAT\u00da K\u00d6TELEZETTS\u00c9GEK": {
-					"451. R\u00f6vid lej\u00e1rat\u00fa k\u00f6lcs\u00f6n\u00f6k ": {
-						"4511. R\u00f6vid lej\u00e1rat\u00fa \u00e1tv\u00e1ltoztathat\u00f3 k\u00f6tv\u00e9nyek ": {}, 
-						"4512. Egy\u00e9b r\u00f6vid lej\u00e1rat\u00fa k\u00f6lcs\u00f6n\u00f6k": {}
-					}, 
-					"452. R\u00f6vid lej\u00e1rat\u00fa hitelek ": {
-						"4521. R\u00f6vid lej\u00e1rat\u00fa hitelek forintban ": {}, 
-						"4522. R\u00f6vid lej\u00e1rat\u00fa hitelek deviz\u00e1ban ": {}
-					}, 
-					"453. Vev\u0151kt\u0151l kapott el\u0151legek": {}, 
-					"454-456. K\u00f6telezetts\u00e9gek \u00e1rusz\u00e1ll\u00edt\u00e1sb\u00f3l \u00e9s szolg\u00e1ltat\u00e1sb\u00f3l (sz\u00e1ll\u00edt\u00f3k)": {
-						"454. Sz\u00e1ll\u00edt\u00f3k ": {
-							"4541. Belf\u00f6ldi anyag- \u00e9s \u00e1rusz\u00e1ll\u00edt\u00f3k ": {
-								"account_type": "Payable"
-							}, 
-							"4542. K\u00fclf\u00f6ldi anyag- \u00e9s \u00e1rusz\u00e1ll\u00edt\u00f3k ": {
-								"account_type": "Payable"
-							}, 
-							"4543. Belf\u00f6ldi szolg\u00e1ltat\u00f3k": {}, 
-							"4544. K\u00fclf\u00f6ldi szolg\u00e1ltat\u00f3k": {}, 
-							"4549. Nem sz\u00e1ml\u00e1zott sz\u00e1ll\u00edt\u00e1sok, szolg\u00e1ltat\u00e1sok ": {
-								"account_type": "Stock Received But Not Billed"
-							}
-						}, 
-						"455. Beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k ": {
-							"4551. Belf\u00f6ldi beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k ": {}, 
-							"4552. K\u00fclf\u00f6ldi beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k": {}, 
-							"4559. Nem sz\u00e1ml\u00e1zott beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k ": {}
-						}, 
-						"456. Nem sz\u00e1ml\u00e1zott sz\u00e1ll\u00edt\u00f3k": {}
-					}, 
-					"457. V\u00e1lt\u00f3tartoz\u00e1sok": {}, 
-					"458. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek kapcsolt v\u00e1llalkoz\u00e1ssal szemben ": {
-						"4581. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek anyav\u00e1llalattal szemben ": {}, 
-						"4582. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek le\u00e1nyv\u00e1llalattal szemben": {}, 
-						"4583. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek k\u00f6z\u00f6s vezet\u00e9s\u0171 v\u00e1llalkoz\u00e1ssal szemben": {}, 
-						"4584. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek t\u00e1rsult v\u00e1llalkoz\u00e1ssal szemben": {}
-					}, 
-					"459. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek egy\u00e9b r\u00e9szesed\u00e9si viszonyban l\u00e9v\u0151 v\u00e1llalkoz\u00e1ssal szemben": {}, 
-					"461-479. Egy\u00e9b r\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek": {
-						"461. Eredm\u00e9nyt terhel\u0151 ad\u00f3k elsz\u00e1mol\u00e1sa": {
-							"4611. T\u00e1rsas\u00e1gi ad\u00f3 elsz\u00e1mol\u00e1sa ": {}, 
-							"4612. K\u00fcl\u00f6nad\u00f3 elsz\u00e1mol\u00e1sa ": {}, 
-							"4613. Egyszer\u0171s\u00edtett v\u00e1llalkoz\u00f3i ad\u00f3 elsz\u00e1mol\u00e1sa ": {}
-						}, 
-						"462. Szem\u00e9lyi j\u00f6vedelemad\u00f3 elsz\u00e1mol\u00e1sa ": {
-							"4612. Mag\u00e1nszem\u00e9lyekt\u0151l levont szem\u00e9lyi j\u00f6vedelem ad\u00f3 elsz\u00e1mol\u00e1sa ": {}, 
-							"4621. Kifizet\u0151t terhel\u0151  szem\u00e9lyi j\u00f6vedelem ad\u00f3 elsz\u00e1mol\u00e1sa ": {}
-						}, 
-						"463. K\u00f6lts\u00e9gvet\u00e9si befizet\u00e9si k\u00f6telezetts\u00e9gek ": {
-							"463-1. Nyugd\u00edjj\u00e1rul\u00e9k ": {}, 
-							"463-10. Innov\u00e1ci\u00f3s j\u00e1rul\u00e9k  ": {}, 
-							"463-11. \u00d6nellen\u0151rz\u00e9si p\u00f3tl\u00e9k  ": {}, 
-							"463-12. Mulaszt\u00e1si b\u00edrs\u00e1g, ad\u00f3b\u00edrs\u00e1g  ": {}, 
-							"463-13. K\u00e9sedelmi p\u00f3tl\u00e9k ": {}, 
-							"463-14. Egy\u00e9b k\u00f6lts\u00e9gvet\u00e9si befizet\u00e9si k\u00f6telezetts\u00e9gek ": {}, 
-							"463-2. Eg\u00e9szs\u00e9gbiztos\u00edt\u00e1si- \u00e9s munkaer\u0151  piaci j\u00e1rul\u00e9k ": {}, 
-							"463-3. Rehabilit\u00e1ci\u00f3s hozz\u00e1j\u00e1rul\u00e1s  ": {}, 
-							"463-4. Szoci\u00e1lis hozz\u00e1j\u00e1rul\u00e1si ad\u00f3  ": {}, 
-							"463-5. Eg\u00e9szs\u00e9g\u00fcgyi szolg\u00e1ltat\u00e1si j\u00e1rul\u00e9k ": {}, 
-							"463-6. Szakk\u00e9pz\u00e9si hozz\u00e1j\u00e1rul\u00e1s ": {}, 
-							"463-7. Eg\u00e9szs\u00e9g\u00fcgyi hozz\u00e1j\u00e1rul\u00e1s  ": {}, 
-							"463-8. Egyszer\u0171s\u00edtett foglalkoztat\u00e1s k\u00f6zterhe ": {}, 
-							"463-9. C\u00e9gaut\u00f3ad\u00f3 ": {}
-						}, 
-						"464. G\u00e9pj\u00e1rm\u0171 ad\u00f3 (c\u00e9gaut\u00f3ad\u00f3) elsz\u00e1mol\u00e1sa": {
-							"is_group": 1
-						}, 
-						"465. V\u00e1m- \u00e9s p\u00e9nz\u00fcgy\u0151rs\u00e9g elsz\u00e1mol\u00e1si sz\u00e1mla ": {
-							"4651. V\u00e1mk\u00f6lts\u00e9gek \u00e9s egy\u00e9b v\u00e1mterhek elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-							"4652. Importbeszerz\u00e9s ut\u00e1n fizetend\u0151 \u00e1ltal\u00e1nos forgalmi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-							"4653. V\u00e1m- \u00e9s p\u00e9nz\u00fcgy\u0151rs\u00e9ggel kapcsolatos egy\u00e9b elsz\u00e1mol\u00e1sok ": {}
-						}, 
-						"466. El\u0151zetesen felsz\u00e1m\u00edtott \u00e1ltal\u00e1nos forgalmi ad\u00f3 ": {
-							"4661. Beszerz\u00e9sek el\u0151zetesen felsz\u00e1m\u00edtott \u00e1ltal\u00e1nos forgalmi ad\u00f3ja ": {}, 
-							"4662. Ar\u00e1nyos\u00edt\u00e1ssal megosztand\u00f3 el\u0151zetesen felsz\u00e1m\u00edtott \u00e1ltal\u00e1nos forgalmi ad\u00f3": {}
-						}, 
-						"467. Fizetend\u0151 \u00e1ltal\u00e1nos forgalmi ad\u00f3": {}, 
-						"468. \u00c1ltal\u00e1nos forgalmi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {}, 
-						"469. Helyi ad\u00f3k elsz\u00e1mol\u00e1si sz\u00e1mla ": {
-							"4691. \u00c9p\u00edtm\u00e9nyad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {}, 
-							"4692. Telekad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-							"4693. Kommun\u00e1lis ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {}, 
-							"4694. Idegenforgalmi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {}, 
-							"4695. Helyi ipar\u0171z\u00e9si ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {}, 
-							"4696. G\u00e9pj\u00e1rm\u0171ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-							"4697. K\u00fclf\u00f6ldi g\u00e9pj\u00e1rm\u0171ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {}, 
-							"4699. Egy\u00e9b helyi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {}
-						}, 
-						"471. J\u00f6vedelemelsz\u00e1mol\u00e1si sz\u00e1mla ": {
-							"4711. Keresetelsz\u00e1mol\u00e1si sz\u00e1mla ": {}, 
-							"4712. T\u00e1rsadalombiztos\u00edt\u00e1si ell\u00e1t\u00e1s ": {}, 
-							"4713. Egy\u00e9b kifizet\u00e9sek elsz\u00e1mol\u00e1sa": {}
-						}, 
-						"472. Fel nem vett j\u00e1rand\u00f3s\u00e1gok": {}, 
-						"473. Elsz\u00e1mol\u00e1s a t\u00e1rsadalombiztos\u00edt\u00e1ssal ": {}, 
-						"474. Szakk\u00e9pz\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {
-							"4741. K\u00f6zponti m\u0171szaki fejleszt\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {}, 
-							"4742. Elsz\u00e1mol\u00e1sra kapott p\u00e9nzeszk\u00f6z\u00f6k": {}, 
-							"4743. K\u00f6rnyezetv\u00e9delmi term\u00e9k d\u00edjfizet\u00e9si k\u00f6telezetts\u00e9g ": {}, 
-							"4749. Egy\u00e9b befizet\u00e9sek az elk\u00fcl\u00f6n\u00edtett alapokba": {}
-						}, 
-						"475. Eg\u00e9szs\u00e9g\u00fcgyi hozz\u00e1j\u00e1rul\u00e1s (EHO) elsz\u00e1mol\u00e1sa": {}, 
-						"476. Egy\u00e9b \u00e1llami ad\u00f3hat\u00f3s\u00e1ggal szembeni k\u00f6telezetts\u00e9g elsz\u00e1mol\u00e1sa": {
-							"4761. K\u00e1rt\u00e9r\u00edt\u00e9s": {}, 
-							"4762. B\u00edr\u00f3i letilt\u00e1s": {}, 
-							"4763. Banki-elsz\u00e1mol\u00e1s": {}, 
-							"4764. Levont szakszervezeti d\u00edj": {}, 
-							"4765. Mag\u00e1n nyugd\u00edjp\u00e9nzt\u00e1ri befizet\u00e9si k\u00f6telezetts\u00e9gek": {}
-						}, 
-						"477. R\u00f6vid lej\u00e1rat\u00fa egy\u00e9b k\u00f6telezetts\u00e9gek munkav\u00e1llal\u00f3kkal \u00e9s tulajdonosokkal szemben": {}, 
-						"478. R\u00e9szesed\u00e9sekkel, \u00e9rt\u00e9kpap\u00edrokkal kapcsolatos k\u00f6telezetts\u00e9gek ": {}, 
-						"479. K\u00fcl\u00f6nf\u00e9le r\u00f6vid lej\u00e1rat\u00fa egy\u00e9b befizet\u00e9si k\u00f6telezetts\u00e9gek ": {
-							"4791. Biztos\u00edt\u00f3 int\u00e9zetekkel szembeni k\u00f6telezetts\u00e9gek": {}, 
-							"4792. Hitelez\u0151k": {}, 
-							"4793. \u00c1tv\u00e1llalt k\u00f6telezetts\u00e9gek": {}, 
-							"4794. Beszerz\u00e9si \u00e1rba beletartoz\u00f3 el\u0151\u00edrt egy\u00e9b k\u00f6telezetts\u00e9gek ": {}, 
-							"4795. Egy\u00e9b r\u00f6vid lej\u00e1rat\u00fa el\u0151\u00edrt k\u00f6telezetts\u00e9gek": {}
-						}
-					}
-				}
-			}, 
-			"48. PASSZ\u00cdV ID\u00d5BELI ELHAT\u00c1ROL\u00c1SOK": {
-				"481. Bev\u00e9telek passz\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
-					"4811. Befolyt, elsz\u00e1molt bev\u00e9telek elhat\u00e1rol\u00e1sa": {}, 
-					"4812. K\u00f6lts\u00e9gek ellent\u00e9telez\u00e9s\u00e9re kapott t\u00e1mogat\u00e1sok elhat\u00e1rol\u00e1sa": {}, 
-					"4813. Devizaeszk\u00f6z\u00f6k \u00e9s devizak\u00f6telezetts\u00e9gek m\u00e9rlegfordul\u00f3napi \u00e9rt\u00e9kel\u00e9se \u00e1rfolyamnyeres\u00e9g\u00e9nek elhat\u00e1rol\u00e1sa": {}
-				}, 
-				"482. K\u00f6lts\u00e9gek, r\u00e1ford\u00edt\u00e1sok passz\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
-					"4821. M\u00e9rlegfordul\u00f3nap el\u0151tti id\u0151szakot terhel\u0151 k\u00f6lts\u00e9gek, r\u00e1ford\u00edt\u00e1sok elhat\u00e1rol\u00e1sa": {}, 
-					"4822. \u00c9rt\u00e9kpap\u00edrok beszerz\u00e9s\u00e9hez kapcsol\u00f3d\u00f3 k\u00fcl\u00f6nb\u00f6zetb\u0151l az id\u0151ar\u00e1nyos \u00e1rfolyam\u008fvesztes\u00e9g elhat\u00e1rol\u00e1sa": {}, 
-					"4823. Fizetend\u0151 kamatok elhat\u00e1rol\u00e1sa ": {}
-				}, 
-				"483. Halasztott bev\u00e9telek ": {}
-			}, 
-			"49. \u00c9VI M\u00c9RLEGSZ\u00c1ML\u00c1K": {
-				"491. Nyit\u00f3m\u00e9rleg sz\u00e1mla ": {}, 
-				"492. Z\u00e1r\u00f3m\u00e9rleg sz\u00e1mla": {}, 
-				"493. Ad\u00f3zott eredm\u00e9ny elsz\u00e1mol\u00e1si sz\u00e1mla": {}, 
-				"494. El\u0151z\u0151 \u00e9vi ad\u00f3zott eredm\u00e9ny elsz\u00e1mol\u00e1sa": {}
-			}, 
-			"root_type": "Liability"
-		}, 
-		"5. SZ\u00c1MLAOSZT\u00c1LY K\u00d6LTS\u00c9GNEMEK": {
-			"51 - 53. ANYAGJELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK ": {
-				"51. ANYAGK\u00d6LTS\u00c9G": {
-					"511. V\u00e1s\u00e1rolt anyagok k\u00f6lts\u00e9gei ": {
-						"5111. Alapanyag k\u00f6lts\u00e9gek": {}, 
-						"5112. Seg\u00e9danyag k\u00f6lts\u00e9gek": {}, 
-						"5113. \u00dczemanyag k\u00f6lts\u00e9gek": {}, 
-						"5114. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 gy\u00e1rt\u00f3eszk\u00f6z\u00f6k, berendez\u00e9sek, felszerel\u00e9sek \u00e9s egy\u00e9b eszk\u00f6z\u00f6k k\u00f6lts\u00e9gei": {}, 
-						"5115. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 munkaruha, v\u00e9d\u0151ruha felhaszn\u00e1l\u00e1s k\u00f6lts\u00e9gei": {}, 
-						"5116. Nyomtatv\u00e1nyok, irodaszerek k\u00f6lts\u00e9gei": {}, 
-						"5117. F\u0171t\u0151anyag k\u00f6lts\u00e9gek": {}, 
-						"5118. Villamosenergia felhaszn\u00e1l\u00e1s \u00e9s v\u00edzfelhaszn\u00e1l\u00e1s k\u00f6lts\u00e9gei": {}, 
-						"5119. Egy\u00e9b anyagfelhaszn\u00e1l\u00e1s k\u00f6lts\u00e9gei": {}, 
-						"512. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 anyagi eszk\u00f6z\u00f6k k\u00f6lts\u00e9gei ": {}, 
-						"5121. V\u00e1s\u00e1rolt n\u00f6vend\u00e9k\u00e1llatok k\u00f6lts\u00e9gei": {}, 
-						"5122. V\u00e1s\u00e1rolt h\u00edz\u00f3\u00e1llatok k\u00f6lts\u00e9gei": {}, 
-						"5123. V\u00e1s\u00e1rolt egy\u00e9b \u00e1llatok k\u00f6lts\u00e9gei": {}, 
-						"513. Egy\u00e9b anyagk\u00f6lts\u00e9g": {}, 
-						"519. Anyagk\u00f6lts\u00e9g megt\u00e9r\u00fcl\u00e9s": {}
-					}
-				}, 
-				"52. IG\u00c9NYBE VETT SZOLG\u00c1LTAT\u00c1SOK K\u00d6LTS\u00c9GEI": {
-					"521. Sz\u00e1ll\u00edt\u00e1s-rakod\u00e1s, rakt\u00e1roz\u00e1s k\u00f6lts\u00e9gei": {}, 
-					"522. B\u00e9rleti d\u00edjak": {}, 
-					"523. Karbantart\u00e1si k\u00f6lts\u00e9gek": {}, 
-					"524. Hirdet\u00e9s, rekl\u00e1m, propaganda k\u00f6lts\u00e9gek": {}, 
-					"525. Oktat\u00e1s \u00e9s tov\u00e1bbk\u00e9pz\u00e9s k\u00f6lts\u00e9gei": {}, 
-					"526. Utaz\u00e1si \u00e9s kik\u00fcldet\u00e9si k\u00f6lts\u00e9gek (napid\u00edj n\u00e9lk\u00fcl)": {}, 
-					"529. Ig\u00e9nybe vett egy\u00e9b szolg\u00e1ltat\u00e1sok k\u00f6lts\u00e9gei": {}
-				}, 
-				"53. EGY\u00c9B SZOLG\u00c1LTAT\u00c1SOK K\u00d6LTS\u00c9GEI": {
-					"531. Hat\u00f3s\u00e1gi igazgat\u00e1si, szolg\u00e1ltat\u00e1si d\u00edjak, illet\u00e9kek": {}, 
-					"532. P\u00e9nz\u00fcgyi, befektet\u00e9si szolg\u00e1ltat\u00e1si d\u00edjak": {}, 
-					"533. Biztos\u00edt\u00e1si d\u00edj ": {}, 
-					"534. K\u00f6lts\u00e9gk\u00e9nt elsz\u00e1moland\u00f3 ad\u00f3k, j\u00e1rul\u00e9kok, term\u00e9kd\u00edjak": {}, 
-					"539. K\u00fcl\u00f6nf\u00e9le egy\u00e9b szolg\u00e1ltat\u00e1sok k\u00f6lts\u00e9gei": {}
-				}
-			}, 
-			"54 - 56. SZEM\u00c9LYI JELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK": {
-				"54. B\u00c9RK\u00d6LTS\u00c9G ": {
-					"541. B\u00e9rk\u00f6lts\u00e9g": {}, 
-					"542. Tulajdonos szem\u00e9lyes k\u00f6zrem\u0171k\u00f6d\u00e9s\u00e9nek ellen\u00e9rt\u00e9ke": {}, 
-					"543. Sz\u00f6vetkezeti tagok munkad\u00edja": {}
-				}, 
-				"55. SZEM\u00c9LYI JELLEG\u00db EGY\u00c9B KIFIZET\u00c9SEK": {
-					"551. Munkav\u00e1llal\u00f3knak, tagoknak fizetett szem\u00e9lyi jelleg\u0171 kifizet\u00e9sek ": {
-						"5511. Betegszabads\u00e1g d\u00edja, munk\u00e1ltat\u00f3t terhel\u0151 t\u00e1pp\u00e9nz, t\u00e1pp\u00e9nz kieg\u00e9sz\u00edt\u00e9s": {}, 
-						"5512. V\u00e9gkiel\u00e9g\u00edt\u00e9s": {}, 
-						"5513. Munk\u00e1baj\u00e1r\u00e1ssal kapcsolatos egy\u00e9b k\u00f6lts\u00e9gek t\u00e9r\u00edt\u00e9se": {}, 
-						"5514. Kik\u00fcldet\u00e9s napid\u00edja": {}, 
-						"5515. Megv\u00e1ltozott munkak\u00e9pess\u00e9g\u0171 munkav\u00e1llal\u00f3k keresetkieg\u00e9sz\u00edt\u00e9se, fizetett seg\u00e9lyek": {}, 
-						"5516. \u00dcd\u00fcl\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {}, 
-						"5517. Lak\u00e1s\u00e9p\u00edt\u00e9sre ny\u00fajtott t\u00e1mogat\u00e1s, alb\u00e9rleti hozz\u00e1j\u00e1rul\u00e1s": {}, 
-						"5518. Jubileumi jutalom, t\u00e1rgyjutalom": {}, 
-						"5519. Sorkatonai vagy polg\u00e1ri szolg\u00e1lat teljes\u00edt\u00e9s\u00e9t k\u00f6vet\u0151en fizetett szem\u00e9lyi alapb\u00e9r": {}
-					}, 
-					"552. J\u00f3l\u00e9ti \u00e9s kultur\u00e1lis k\u00f6lts\u00e9gek": {}, 
-					"559. Egy\u00e9b szem\u00e9lyi jelleg\u0171 kifizet\u00e9sek ": {
-						"5591. Munk\u00e1ltat\u00f3 \u00e1ltal fizetett baleset-, \u00e9let- \u00e9s nyugd\u00edjbiztos\u00edt\u00e1s d\u00edja": {}, 
-						"5592. Munk\u00e1ltat\u00f3 \u00e1ltal \u00f6nk\u00e9ntes p\u00e9nzt\u00e1rba befizetett munk\u00e1ltat\u00f3i tagd\u00edj hozz\u00e1j\u00e1rul\u00e1s": {}, 
-						"5593. Munk\u00e1ltat\u00f3t terhel\u0151 szem\u00e9lyi j\u00f6vedelemad\u00f3": {}, 
-						"5594. Munk\u00e1ltat\u00f3i hozz\u00e1j\u00e1rul\u00e1s a korengedm\u00e9nyes nyugd\u00edj ig\u00e9nybev\u00e9tel\u00e9hez": {}, 
-						"5596. Fizetett szerz\u0151i, \u00edr\u00f3i \u00e9s m\u00e1s jogv\u00e9delmet \u00e9lvez\u0151 munk\u00e1k d\u00edjai \u00e9s ezekkel kapcsolatos k\u00f6zrem\u0171k\u00f6d\u0151i d\u00edjak": {}, 
-						"5597. Fizetett \u00f6szt\u00f6nd\u00edjak": {}, 
-						"5598. Reprezent\u00e1ci\u00f3s k\u00f6lts\u00e9gek, \u00e9tkez\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {}, 
-						"5599. Munk\u00e1ltat\u00f3 \u00e1ltal fizetett mag\u00e1nnyugd\u00edj-p\u00e9nzt\u00e1ri tagd\u00edj kieg\u00e9sz\u00edt\u00e9s, munkav\u00e1llal\u00f3kkal kapcsolatos biztos\u00edt\u00e1si d\u00edjak": {}
-					}
-				}, 
-				"56. B\u00c9RJ\u00c1RUL\u00c9KOK": {
-					"561. Nyugd\u00edjbiztos\u00edt\u00e1si \u00e9s eg\u00e9szs\u00e9gbiztos\u00edt\u00e1si j\u00e1rul\u00e9k ": {}, 
-					"562. Eg\u00e9szs\u00e9g\u00fcgyi hozz\u00e1j\u00e1rul\u00e1s": {}, 
-					"563. Munkaad\u00f3i j\u00e1rul\u00e9k": {}, 
-					"564. Szakk\u00e9pz\u00e9si hozz\u00e1j\u00e1rul\u00e1s ": {}, 
-					"569. Egy\u00e9b hozz\u00e1j\u00e1rul\u00e1s ": {}
-				}
-			}, 
-			"57. \u00c9RT\u00c9KCS\u00d6KKEN\u00c9SI LE\u00cdR\u00c1S": {
-				"571. Terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1s ": {
-					"5711. Terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1s ": {
-						"account_type": "Depreciation"
-					}, 
-					"5712. Kiemelt, kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) eszk\u00f6z\u00f6k terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {}, 
-					"57121. Kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) vagyoni \u00e9rt\u00e9k\u0171 jogok terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {}, 
-					"57122. Kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) szellemi term\u00e9kek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {}, 
-					"57123. Kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) t\u00e1rgyi eszk\u00f6z\u00f6k terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {}
-				}
-			}, 
-			"58. AKTIV\u00c1LT SAJ\u00c1T TELJES\u00cdTM\u00c9NYEK \u00c9RT\u00c9KE": {
-				"581. Saj\u00e1t termel\u00e9s\u0171 k\u00e9szletek \u00e1llom\u00e1nyv\u00e1ltoz\u00e1sa ": {}, 
-				"582. Saj\u00e1t el\u0151\u00e1ll\u00edt\u00e1s\u00fa eszk\u00f6z\u00f6k aktiv\u00e1lt \u00e9rt\u00e9ke": {}, 
-				"589. Aktiv\u00e1lt saj\u00e1t teljes\u00edtm\u00e9nyek \u00e1tvezet\u00e9si sz\u00e1mla": {}
-			},
-			"59. K\u00d6LTS\u00c9GNEM \u00c1TVEZET\u00c9SI SZ\u00c1MLA": {
-				"is_group": 1
-			}, 
-			"root_type": "Expense"
-		}, 
-		"6. SZ\u00c1MLAOSZT\u00c1LY K\u00d6LTS\u00c9GHELYEK, \u00c1LTAL\u00c1NOS K\u00d6LTS\u00c9GEK": {
-			"61. JAV\u00cdT\u00d3-KARBANTART\u00d3 \u00dcZEMEK K\u00d6LTS\u00c9GEI": {}, 
-			"62. SZOLG\u00c1LTAT\u00c1ST V\u00c9GZ\u00d5 \u00dcZEMEK (EGYS\u00c9GEK) K\u00d6LTS\u00c9GEI": {}, 
-			"63. G\u00c9PK\u00d6LTS\u00c9G": {}, 
-			"64-65. \u00dcZEMI IR\u00c1NY\u00cdT\u00c1S \u00c1LTAL\u00c1NOS K\u00d6LTS\u00c9GEI": {}, 
-			"66. K\u00d6ZPONTI IR\u00c1NY\u00cdT\u00c1S \u00c1LTL\u00c1NOS K\u00d6LTS\u00c9GEI": {}, 
-			"67. \u00c9RT\u00c9KES\u00cdT\u00c9SI, FORGALMAZ\u00c1SI K\u00d6LTS\u00c9GEK": {}, 
-			"68. ELK\u00dcL\u00d6N\u00cdTETT EGY\u00c9B \u00c1LTL\u00c1NOS K\u00d6LTS\u00c9GEK": {
-				"681. Alap\u00edt\u00e1s-\u00e1tszervez\u00e9s k\u00f6lts\u00e9gei": {}, 
-				"682. Alap- \u00e9s alkalmazott kutat\u00e1s saj\u00e1t k\u00f6lts\u00e9gei": {}, 
-				"683. V\u00e1llalkoz\u00e1sban adott alap- \u00e9s alkalmazott kutat\u00e1s k\u00f6lts\u00e9gei": {}, 
-				"684. K\u00eds\u00e9rleti fejleszt\u00e9s saj\u00e1t k\u00f6lts\u00e9gei": {}, 
-				"685. V\u00e1llalkoz\u00e1sba adott k\u00eds\u00e9rleti fejleszt\u00e9s k\u00f6lts\u00e9gei": {}, 
-				"686. Kutat\u00e1s-k\u00eds\u00e9rleti fejleszt\u00e9s \u00e1ltal\u00e1nos \u00e9s k\u00f6zvetett k\u00f6lts\u00e9gei": {}, 
-				"687. Kutat\u00e1s-k\u00eds\u00e9rleti fejleszt\u00e9s elsz\u00e1molt \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}, 
-				"688. Garanci\u00e1lis jav\u00edt\u00e1s k\u00f6lts\u00e9gei": {}, 
-				"689. Egy\u00e9b elk\u00fcl\u00f6n\u00edtett k\u00f6lts\u00e9gek": {}
-			}, 
-			"69. K\u00d6LTS\u00c9GHELYEK K\u00d6LTS\u00c9GNEMEK \u00c1TVEZET\u00c9SE": {
-				"691. K\u00f6lts\u00e9ghelyek k\u00f6lts\u00e9geinek \u00e1tvezet\u00e9se": {}
-			}, 
-			"root_type": "Expense"
-		}, 
-		"7. SZ\u00c1MLAOSZT\u00c1LY TEV\u00c9KENYS\u00c9GEKK\u00d6LTS\u00c9GEI": {
-			"is_group": 1, 
-			"root_type": "Expense"
-		}, 
-		"8. SZ\u00c1MLAOSZT\u00c1LY \u00c9RT\u00c9KES\u00cdT\u00c9S ELSZ\u00c1MOLT \u00d6NK\u00d6LTS\u00c9GE \u00c9S R\u00c1FORD\u00cdT\u00c1SOK": {
-			"81-83. SZ\u00c1MLACSOPORTOK (az \u00f6sszk\u00f6lts\u00e9g elj\u00e1r\u00e1ssal k\u00e9sz\u00fcl\u0151 eredm\u00e9ny-kimutat\u00e1shoz)": {
-				"81. ANYAGJELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK": {
-					"811. Anyagk\u00f6lts\u00e9g ": {}, 
-					"812. Ig\u00e9nybe vett szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {}, 
-					"813. Egy\u00e9b szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {}, 
-					"814. Eladott \u00e1ruk beszerz\u00e9si \u00e9rt\u00e9ke": {}, 
-					"815. Eladott (k\u00f6zvet\u00edtett) szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {}
-				}, 
-				"82. SZEM\u00c9LYI JELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK": {
-					"821. B\u00e9rk\u00f6lts\u00e9g": {}, 
-					"822. Szem\u00e9lyi jelleg\u0171 egy\u00e9b kifizet\u00e9sek": {}, 
-					"823. B\u00e9rj\u00e1rul\u00e9kok": {}
-				}, 
-				"83. \u00c9RT\u00c9KCS\u00d6KKEN\u00c9SI LE\u00cdR\u00c1S": {
-					"831. \u00c9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1s ": {}
-				}
-			}, 
-			"81-85. SZ\u00c1MLACSOPORTOK (a forgalmi k\u00f6lts\u00e9g elj\u00e1r\u00e1ssal k\u00e9sz\u00fcl\u0151 eredm\u00e9nykimutat\u00e1shoz)": {
-				"81-82. BELF\u00d6LDI \u00c9RT\u00c9KES\u00cdT\u00c9S K\u00d6ZVETLEN K\u00d6LTS\u00c9GEI": {
-					"811. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s elsz\u00e1molt k\u00f6zvetlen \u00f6nk\u00f6lts\u00e9ge": {
-						"account_type": "Cost of Goods Sold"
-					}, 
-					"812. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s eladott \u00e1ruk beszerz\u00e9si \u00e9rt\u00e9ke": {
-						"account_type": "Stock Adjustment"
-					}, 
-					"813. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s eladott (k\u00f6zvet\u00edtett) szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {
-						"account_type": "Expenses Included In Valuation"
-					}
-				}, 
-				"83-84. EXPORT\u00c9RT\u00c9KES\u00cdT\u00c9S K\u00d6ZVETLEN K\u00d6LTS\u00c9GEI": {
-					"831. Export\u00e9rt\u00e9kes\u00edt\u00e9s elsz\u00e1molt k\u00f6zvetlen \u00f6nk\u00f6lts\u00e9ge": {}, 
-					"832. Export\u00e9rt\u00e9kes\u00edt\u00e9s eladott \u00e1ruk beszerz\u00e9si \u00e9rt\u00e9ke": {}, 
-					"833. Export\u00e9rt\u00e9kes\u00edt\u00e9s eladott (k\u00f6zvet\u00edtett) szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {}
-				}, 
-				"85. \u00c9RT\u00c9KES\u00cdT\u00c9S K\u00d6ZVETETT K\u00d6LTS\u00c9GEI": {
-					"851. \u00c9rt\u00e9kes\u00edt\u00e9si, forgalmaz\u00e1si k\u00f6lts\u00e9gek": {}, 
-					"852. Igazgat\u00e1si k\u00f6lts\u00e9gek": {}, 
-					"853. Egy\u00e9b \u00e1ltal\u00e1nos k\u00f6lts\u00e9gek": {}
-				}
-			}, 
-			"86. EGY\u00c9B R\u00c1FORD\u00cdT\u00c1SOK": {
-				"861. Egy\u00e9b r\u00e1ford\u00edt\u00e1snak min\u0151s\u00fcl\u0151 \u00e9rt\u00e9kes\u00edt\u00e9sek": {
-					"8611. \u00c9rt\u00e9kes\u00edtett immateri\u00e1lis javak, t\u00e1rgyi eszk\u00f6z\u00f6k k\u00f6nyv szerinti \u00e9rt\u00e9ke": {}, 
-					"8612. \u00c9rt\u00e9kes\u00edtett, \u00e1truh\u00e1zott (engedm\u00e9nyezett) k\u00f6vetel\u00e9sek k\u00f6nyv szerinti \u00e9rt\u00e9ke": {}
-				}, 
-				"862. Egy\u00e9b r\u00e1ford\u00edt\u00e1snak min\u0151s\u00fcl\u0151 eszk\u00f6z kivezet\u00e9sek": {
-					"8621. Hi\u00e1nyz\u00f3, megsemmis\u00fclt, kiselejtezett immateri\u00e1lis javak, t\u00e1rgyi eszk\u00f6z\u00f6k nett\u00f3 \u00e9rt\u00e9ke": {}, 
-					"8622. Hi\u00e1nyz\u00f3, megsemmis\u00fclt, \u00e1llom\u00e1nyb\u00f3l kivezetett k\u00e9szletek k\u00f6nyv szerinti \u00e9rt\u00e9ke": {}
-				}, 
-				"863. Behajthatatlan k\u00f6vetel\u00e9sek le\u00edrt \u00f6sszege": {}, 
-				"864. C\u00e9ltartal\u00e9k k\u00e9pz\u00e9s": {
-					"8641. C\u00e9ltartal\u00e9k-k\u00e9pz\u00e9s a v\u00e1rhat\u00f3 k\u00f6telezetts\u00e9gekre": {}, 
-					"8642. C\u00e9ltartal\u00e9k-k\u00e9pz\u00e9s a j\u00f6v\u0151beni k\u00f6lts\u00e9gekre": {}, 
-					"8643. C\u00e9ltartal\u00e9k-k\u00e9pz\u00e9s egy\u00e9b c\u00edmen": {}
-				}, 
-				"865. Ut\u00f3lag adott, nem sz\u00e1ml\u00e1zott engedm\u00e9ny": {}, 
-				"866. Egy\u00e9b r\u00e1ford\u00edt\u00e1sk\u00e9nt elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {
-					"8661. K\u00f6zponti k\u00f6lts\u00e9gvet\u00e9ssel elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {}, 
-					"8662. Helyi \u00f6nkorm\u00e1nyzatokkal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {}, 
-					"8663. Elk\u00fcl\u00f6n\u00edtett \u00e1llami p\u00e9nzalapokkal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {}, 
-					"8664. T\u00e1rsadalombiztos\u00edt\u00e1ssal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {}, 
-					"8665. EU p\u00e9nz\u00fcgyi alapokkal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {}, 
-					"8666. R\u00e1ford\u00edt\u00e1sk\u00e9nt elsz\u00e1molt egy\u00e9b ad\u00f3k \u00e9s ad\u00f3jelleg\u0171 t\u00e9telek": {}
-				}, 
-				"867. Egy\u00e9b r\u00e1ford\u00edt\u00e1sk\u00e9nt elsz\u00e1molt, ad\u00f3nak nem min\u0151s\u00fcl\u0151 kifizet\u00e9sek": {
-					"8671. K\u00e1resem\u00e9nnyel kapcsolatos fizetett, fizetend\u0151 \u00f6sszegek": {}, 
-					"8672. K\u00f6lts\u00e9gek (r\u00e1ford\u00edt\u00e1sok) ellent\u00e9telez\u00e9s\u00e9re visszafizet\u00e9si k\u00f6telezetts\u00e9g n\u00e9lk\u00fcl adott t\u00e1mogat\u00e1s, juttat\u00e1": {}, 
-					"8673. Fejleszt\u00e9si c\u00e9lra, visszafizet\u00e9si k\u00f6telezetts\u00e9g n\u00e9lk\u00fcl adott t\u00e1mogat\u00e1s, juttat\u00e1s": {}, 
-					"8674. Fejleszt\u00e9si c\u00e9lra kapott t\u00e1mogat\u00e1s visszafizetend\u0151 \u00f6sszege": {}, 
-					"8675. Tao \u00e1ltal elismert b\u00edrs\u00e1gok, k\u00f6tb\u00e9rek, k\u00e9sedelmi kamatok, p\u00f3tl\u00e9kok, k\u00e1rt\u00e9r\u00edt\u00e9sek, s\u00e9relemd\u00edjak": {}, 
-					"8676. Tao \u00e1ltal el nem ismert b\u00edrs\u00e1gok, k\u00f6tb\u00e9rek, k\u00e9sedelmi kamatok, p\u00f3tl\u00e9kok, k\u00e1rt\u00e9r\u00edt\u00e9sek, s\u00e9relemd\u00edjak": {}
-				}, 
-				"868. Terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9sek, \u00e9rt\u00e9kveszt\u00e9sek": {
-					"8681. Immateri\u00e1lis javak terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}, 
-					"8682. T\u00e1rgyi eszk\u00f6z\u00f6k terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}, 
-					"8683. K\u00e9szletek \u00e9rt\u00e9kveszt\u00e9se": {}, 
-					"8684. K\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se": {}
-				}, 
-				"869. K\u00fcl\u00f6nf\u00e9le egy\u00e9b r\u00e1ford\u00edt\u00e1sok": {
-					"8691. T\u00e1rsas\u00e1gba bevitt, \u00e9rt\u00e9kpap\u00edrnak vagy r\u00e9szesed\u00e9snek nem min\u0151s\u00fcl\u0151 vagyont.": {}, 
-					"8692. Ellent\u00e9telez\u00e9s n\u00e9lk\u00fcl \u00e1tv\u00e1llalt k\u00f6telezetts\u00e9g szerz\u0151d\u00e9s szerinti \u00f6sszege": {}, 
-					"8693. T\u00e9r\u00edt\u00e9s n\u00e9lk\u00fcl \u00e1tadott, r\u00e9szesed\u00e9snek vagy \u00e9rt\u00e9kpap\u00edrnak nem min\u0151s\u00fcl\u0151 eszk\u00f6z\u00f6k nyilv\u00e1ntart\u00e1s szerinti \u00e9rt\u00e9ke": {}, 
-					"8694. T\u00e9r\u00edt\u00e9s n\u00e9lk\u00fcl ny\u00fajtott szolg\u00e1ltat\u00e1sok beker\u00fcl\u00e9si \u00e9rt\u00e9ke": {}, 
-					"8695. Elengedett k\u00f6vetel\u00e9sek k\u00f6nyv szerinti \u00e9rt\u00e9ke": {}, 
-					"8696. Egy\u00e9b, vagyoncs\u00f6kken\u00e9ssel j\u00e1r\u00f3 r\u00e1ford\u00edt\u00e1sok": {}
-				}
-			}, 
-			"87. P\u00c9NZ\u00dcGYI M\u0170VELETEK R\u00c1FORD\u00cdT\u00c1SAI": {
-				"871. R\u00e9szesed\u00e9sekb\u0151l sz\u00e1rmaz\u00f3 r\u00e1ford\u00edt\u00e1sok, \u00e1rfolyamvesztes\u00e9gek": {}, 
-				"872. Befektetett p\u00e9nz\u00fcgyi eszk\u00f6z\u00f6kb\u0151l (\u00e9rt\u00e9kpap\u00edrokb\u00f3l, k\u00f6lcs\u00f6n\u00f6kb\u0151l) sz\u00e1rmaz\u00f3 r\u00e1ford\u00edt\u00e1sok \u00e1rfolyamvesztes\u00e9gek": {}, 
-				"873. Hitelint\u00e9zetnek fizetend\u0151 kamatok \u00e9s kamatjelleg\u0171 r\u00e1ford\u00edt\u00e1sok": {}, 
-				"874. Nem hitelint\u00e9zetnek fizetend\u0151 kamatok \u00e9s kamatjelleg\u0171 r\u00e1ford\u00edt\u00e1sok": {}, 
-				"875. R\u00e9szesed\u00e9sek, \u00e9rt\u00e9kpap\u00edrok, bankbet\u00e9tek \u00e9rt\u00e9kveszt\u00e9se \u00e9s vissza\u00edr\u00e1sa": {
-					"8751. R\u00e9szesed\u00e9sek, \u00e9rt\u00e9kpap\u00edrok, bankbet\u00e9tek \u00e9rt\u00e9kveszt\u00e9se": {}, 
-					"8752. R\u00e9szesed\u00e9sek, \u00e9rt\u00e9kpap\u00edrok, bankbet\u00e9tek \u00e9rt\u00e9kveszt\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {}
-				}, 
-				"876. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek \u00e1rfolyamvesztes\u00e9gei": {
-					"8761. Deviza- \u00e9s valutak\u00e9szletek forintra \u00e1tv\u00e1lt\u00e1s\u00e1nak \u00e1rfolyamvesztes\u00e9ge": {}, 
-					"8762. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek p\u00e9nz\u00fcgyileg rendezett \u00e1rfolyamvesztes\u00e9ge": {}
-				}, 
-				"877. P\u00e9nz\u00fcgyi m\u0171veletek egy\u00e9b r\u00e1ford\u00edt\u00e1sai": {}, 
-				"878. P\u00e9nz\u00fcgyi rendez\u00e9shez kapcsol\u00f3d\u00f3an adott engedm\u00e9ny": {}, 
-				"879. Egy\u00e9b vagyoncs\u00f6kken\u00e9ssel j\u00e1r\u00f3 p\u00e9nz\u00fcgyi r\u00e1ford\u00edt\u00e1sok": {}
-			}, 
-			"88. RENDK\u00cdV\u00dcLI R\u00c1FORD\u00cdT\u00c1SOK": {
-				"881. T\u00e1rsas\u00e1gba bevitt eszk\u00f6z\u00f6k nyilv\u00e1ntart\u00e1s szerinti \u00e9rt\u00e9ke": {}
-			}, 
-			"89. EREDM\u00c9NYT TERHEL\u0150 AD\u00d3K": {
-				"891. T\u00e1rsas\u00e1gi ad\u00f3": {}, 
-				"892. Egyszer\u0171s\u00edtett v\u00e1llalkoz\u00f3i ad\u00f3": {}, 
-				"893. Kisv\u00e1llalati ad\u00f3": {}, 
-				"899. Eredm\u00e9nyt terhel\u0151 egy\u00e9b ad\u00f3k": {}
-			}, 
-			"root_type": "Expense"
-		}, 
-		"9. SZ\u00c1MLAOSZT\u00c1LY BEV\u00c9TELEK": {
-			"91. BELF\u00d6LDI \u00c9RT\u00c9KES\u00cdT\u00c9S \u00c1RBEV\u00c9TELE": {
-				"911. Belf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett saj\u00e1t termel\u00e9s\u0171 k\u00e9szletek \u00e1rbev\u00e9tele": {}, 
-				"912. Belf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett v\u00e1s\u00e1rolt k\u00e9szletek \u00e1rbev\u00e9tele": {}, 
-				"913. Belf\u00f6ldinek ny\u00fajtott szolg\u00e1ltat\u00e1sok \u00e1rbev\u00e9tele": {}, 
-				"918. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9ssel kapcsolatos \u00e1rt\u00e1mogat\u00e1s": {}, 
-				"919. Egy\u00e9b belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s \u00e1rbev\u00e9tele": {}
-			}, 
-			"92. EXPORT\u00c9RT\u00c9KES\u00cdT\u00c9S \u00c1RBEV\u00c9TELE": {
-				"921. K\u00fclf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett saj\u00e1t termel\u00e9s\u0171 k\u00e9szletek \u00e1rbev\u00e9tele": {}, 
-				"922. K\u00fclf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett v\u00e1s\u00e1rolt k\u00e9szletek \u00e1rbev\u00e9tele": {}, 
-				"923. K\u00fclf\u00f6ldinek ny\u00fajtott szolg\u00e1ltat\u00e1sok \u00e1rbev\u00e9tele": {}, 
-				"928. K\u00fclf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9ssel kapcsolatos \u00e1rt\u00e1mogat\u00e1s": {}, 
-				"929. Egy\u00e9b k\u00fclf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s \u00e1rbev\u00e9tele": {}
-			}, 
-			"96. EGY\u00c9B BEV\u00c9TELEK": {
-				"961. Egy\u00e9b bev\u00e9telnek min\u0151s\u00fcl\u0151 \u00e9rt\u00e9kes\u00edt\u00e9sek": {
-					"9611. \u00c9rt\u00e9kes\u00edtett immateri\u00e1lis javak, t\u00e1rgyi eszk\u00f6z\u00f6k ellen\u00e9rt\u00e9ke": {}, 
-					"9612. \u00c9rt\u00e9kes\u00edtett, \u00e1truh\u00e1zott (engedm\u00e9nyezett) k\u00f6vetel\u00e9sek ellen\u00e9rt\u00e9ke": {}
-				}, 
-				"963. K\u00f6vetel\u00e9s k\u00f6nyv szerinti \u00e9rt\u00e9k\u00e9t meghalad\u00f3an realiz\u00e1lt \u00f6sszeg": {}, 
-				"964. C\u00e9ltartal\u00e9k felold\u00e1s": {
-					"9651. V\u00e1rhat\u00f3 k\u00f6telezetts\u00e9gek fedezet\u00e9re k\u00e9pzett  c\u00e9ltartal\u00e9k felhaszn\u00e1l\u00e1sa   ": {}, 
-					"9652. J\u00f6v\u0151beni k\u00f6lts\u00e9gekre k\u00e9pzett c\u00e9ltartal\u00e9k felhaszn\u00e1l\u00e1sa ": {}, 
-					"9653. Egy\u00e9b c\u00edmen k\u00e9pzett c\u00e9ltartal\u00e9k felhaszn\u00e1l\u00e1sa ": {}
-				}, 
-				"965. Ut\u00f3lag kapott, nem sz\u00e1ml\u00e1zott engedm\u00e9ny": {}, 
-				"966. Ut\u00f3lag kapott, nem sz\u00e1ml\u00e1zott engedm\u00e9ny": {
-					"9661. K\u00f6zponti k\u00f6lts\u00e9gvet\u00e9sb\u0151l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {}, 
-					"9662. Helyi \u00f6nkorm\u00e1nyzatokt\u00f3l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {}, 
-					"9663. Eur\u00f3pai Uni\u00f3t\u00f3l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {}, 
-					"9664. Egy\u00e9b forr\u00e1sb\u00f3l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {}
-				}, 
-				"967. Egy\u00e9b bev\u00e9telk\u00e9nt elsz\u00e1molt p\u00e9nzbev\u00e9telek": {
-					"9671. K\u00e1resem\u00e9nnyel kapcsolatos t\u00e9r\u00edt\u00e9sek": {}, 
-					"9672. K\u00f6lts\u00e9gek (r\u00e1ford\u00edt\u00e1sok) ellent\u00e9telez\u00e9s\u00e9re kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {}, 
-					"9673. Fejleszt\u00e9si c\u00e9lra kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {}, 
-					"9674. Kapott b\u00edrs\u00e1gok, k\u00f6tb\u00e9rek, fekb\u00e9rek, k\u00e9sedelmi kamatok, k\u00e1rt\u00e9r\u00edt\u00e9sek": {}
-				}, 
-				"968. Terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9sek, \u00e9rt\u00e9kveszt\u00e9sek vissza\u00edr\u00e1sa": {
-					"9681. Immateri\u00e1lis javak terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {}, 
-					"9682. T\u00e1rgyi eszk\u00f6z\u00f6k terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {}, 
-					"9683. K\u00e9szletek \u00e9rt\u00e9kveszt\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {}, 
-					"9684. R\u00e9szesed\u00e9sek \u00e9rt\u00e9kveszt\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {}
-				}, 
-				"969. K\u00fcl\u00f6nf\u00e9le egy\u00e9b bev\u00e9telek": {
-					"is_group": 1
-				}
-			}, 
-			"97. P\u00c9NZ\u00dcGYI M\u0170VELETEK BEV\u00c9TELEI": {
-				"971. R\u00e9szesed\u00e9sekb\u0151l sz\u00e1rmaz\u00f3 bev\u00e9telek, \u00e1rfolyamnyeres\u00e9gek": {}, 
-				"972. Befektetett p\u00e9nz\u00fcgyi eszk\u00f6z\u00f6kb\u0151l (\u00e9rt\u00e9kpap\u00edrokb\u00f3l, k\u00f6lcs\u00f6n\u00f6kb\u0151l) sz\u00e1rmaz\u00f3 bev\u00e9telek, \u00e1rfolyamnyeres\u00e9gek": {}, 
-				"973. Hitelint\u00e9zett\u0151l kapott kamatok \u00e9s kamatjelleg\u0171 bev\u00e9telek": {}, 
-				"974. Nem hitelint\u00e9zett\u0151l kapott kamatok \u00e9s kamatjelleg\u0171 bev\u00e9telek": {}, 
-				"975. Kapott (j\u00e1r\u00f3) osztal\u00e9k \u00e9s r\u00e9szesed\u00e9s": {}, 
-				"976. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek \u00e1rfolyamnyeres\u00e9gei": {
-					"9761. Deviza- \u00e9s valutak\u00e9szletek forintra \u00e1tv\u00e1lt\u00e1s\u00e1nak \u00e1rfolyamnyeres\u00e9ge": {}, 
-					"9762. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek p\u00e9nz\u00fcgyileg rendezett \u00e1rfolyamnyeres\u00e9ge": {}
-				}, 
-				"977. P\u00e9nz\u00fcgyi m\u0171veletek egy\u00e9b bev\u00e9telei": {}, 
-				"978. P\u00e9nz\u00fcgyi rendez\u00e9shez kapcsol\u00f3d\u00f3an kapott engedm\u00e9ny": {}, 
-				"979. Egy\u00e9b vagyonn\u00f6veked\u00e9ssel j\u00e1r\u00f3 p\u00e9nz\u00fcgyi bev\u00e9telek": {}
-			}, 
-			"root_type": "Income"
-		}
-	}
+  "countryCode": "hu",
+  "name": "Hungary - Chart of Accounts",
+  "tree": {
+    "1. SZ\u00c1MLAOSZT\u00c1LY BEFEKTETETT ESZK\u00d6Z\u00d6K": {
+      "11. IMMATERI\u00c1LIS JAVAK": {
+        "111. Alap\u00edt\u00e1s-\u00e1tszervez\u00e9s aktiv\u00e1lt \u00e9rt\u00e9ke": {},
+        "112. K\u00eds\u00e9rleti fejleszt\u00e9s aktiv\u00e1lt \u00e9rt\u00e9ke": {},
+        "113. Vagyoni \u00e9rt\u00e9k\u0171 jogok": {},
+        "114. Szellemi term\u00e9kek": {},
+        "115. \u00dczleti vagy c\u00e9g\u00e9rt\u00e9k": {},
+        "117. Immateri\u00e1lis javak \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {}
+      },
+      "12-16. T\u00c1RGYI ESZK\u00d6Z\u00d6K": {
+        "12. INGATLANOK \u00c9S KAPCSOL\u00d3D\u00d3 VAGYONI \u00c9RT\u00c9K\u00db JOGOK": {
+          "121. Telkek, f\u00f6ldter\u00fclet ": {
+            "1211. Telkek, f\u00f6ldter\u00fcletek brutt\u00f3 \u00e9rt\u00e9ke": {
+              "accountType": "Fixed Asset"
+            },
+            "1218. Telkek, f\u00f6ldter\u00fcletek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {},
+            "1219. Telkek, f\u00f6ldter\u00fcletek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
+          },
+          "122. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok": {
+            "1221. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok brutt\u00f3 \u00e9rt\u00e9ke": {
+              "accountType": "Fixed Asset"
+            },
+            "1228. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {},
+            "1229. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
+          },
+          "123. \u00c9p\u00fcletek, \u00e9p\u00fcletr\u00e9szek, tulajdoni h\u00e1nyadok ": {
+            "accountType": "Fixed Asset",
+            "isGroup": 1
+          },
+          "124. Egy\u00e9b ingatlanok": {
+            "isGroup": 1
+          },
+          "125. \u00dczemk\u00f6r\u00f6n k\u00edv\u00fcli ingatlanok, \u00e9p\u00fcletek ": {
+            "isGroup": 1
+          },
+          "126. Ingatlanokhoz kapcsol\u00f3d\u00f3 vagyoni \u00e9rt\u00e9k\u0171 jogok": {
+            "isGroup": 1
+          },
+          "127. Ingatlanok \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {},
+          "129. Kis \u00e9rt\u00e9k\u0171 ingatlanok": {}
+        },
+        "13. M\u00dbSZAKI BERENDEZ\u00c9SEK, G\u00c9PEK, J\u00c1RM\u00dbVEK": {
+          "131. Termel\u0151 g\u00e9pek, berendez\u00e9sek, szersz\u00e1mok, gy\u00e1rt\u00f3eszk\u00f6z\u00f6k": {
+            "1311. Termel\u0151 g\u00e9pek, berendez\u00e9sek brutt\u00f3 \u00e9rt\u00e9ke": {
+              "accountType": "Fixed Asset"
+            },
+            "1318. Termel\u0151 g\u00e9pek, berendez\u00e9sek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {},
+            "1319. Termel\u0151 g\u00e9pek, berendez\u00e9sek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
+          },
+          "132. M\u0171szaki j\u00e1rm\u0171vek": {},
+          "133. Ki nem emelt m\u0171szaki berendez\u00e9sek, g\u00e9pek, j\u00e1rm\u0171vek": {},
+          "139. Kis \u00e9rt\u00e9k\u0171 m\u0171szaki berendez\u00e9sek, g\u00e9pek, j\u00e1rm\u0171vek": {}
+        },
+        "14. EGY\u00c9B BERENDEZ\u00c9SEK, FELSZEREL\u00c9SEK, J\u00c1RM\u00dbVEK": {
+          "141. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek": {
+            "1411. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek brutt\u00f3 \u00e9rt\u00e9ke": {
+              "accountType": "Fixed Asset"
+            },
+            "1418. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {},
+            "1419. Egy\u00e9b (\u00fczemi \u2013 \u00fczleti), berendez\u00e9sek, felszerel\u00e9sek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
+          },
+          "142. Egy\u00e9b j\u00e1rm\u0171vek": {
+            "1421. Egy\u00e9b j\u00e1rm\u0171vek brutt\u00f3 \u00e9rt\u00e9ke": {
+              "accountType": "Fixed Asset"
+            },
+            "1428. Egy\u00e9b j\u00e1rm\u0171vek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {},
+            "1429. Egy\u00e9b j\u00e1rm\u0171vek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
+          },
+          "143. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek": {
+            "1431. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek brutt\u00f3 \u00e9rt\u00e9ke": {
+              "accountType": "Fixed Asset"
+            },
+            "1438. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {},
+            "1439. Irodai, igazgat\u00e1si berendez\u00e9sek \u00e9s felszerel\u00e9sek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
+          },
+          "144. Ki nem emelt egy\u00e9b berendez\u00e9sek, felszerel\u00e9sek": {
+            "accountType": "Fixed Asset"
+          },
+          "145. J\u00f3l\u00e9ti berendez\u00e9sek, felszerel\u00e9si t\u00e1rgyak \u00e9s k\u00e9pz\u0151m\u0171v\u00e9szeti alkot\u00e1sok": {
+            "accountType": "Fixed Asset"
+          },
+          "147. Egy\u00e9b berendez\u00e9sek, felszerel\u00e9sek, j\u00e1rm\u0171vek \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {
+            "accountType": "Fixed Asset"
+          },
+          "149. Kis \u00e9rt\u00e9k\u0171 egy\u00e9b berendez\u00e9sek, felszerel\u00e9sek, j\u00e1rm\u0171vek": {
+            "accountType": "Fixed Asset"
+          }
+        },
+        "15. TENY\u00c9SZ\u00c1LLATOK": {
+          "151. Teny\u00e9sz\u00e1llatok": {}
+        },
+        "16. BERUH\u00c1Z\u00c1SOK, FEL\u00daJ\u00cdT\u00c1SOK": {
+          "161. Befejezetlen beruh\u00e1z\u00e1sok ": {},
+          "162. Fel\u00faj\u00edt\u00e1sok": {},
+          "168. Beruh\u00e1z\u00e1sok terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {}
+        },
+        "17-19. BEFEKTETETT P\u00c9NZ\u00dcGYI ESZK\u00d6Z\u00d6K": {
+          "17. TULAJDONI R\u00c9SZESED\u00c9ST JELENT\u00d5 BEFEKTET\u00c9SEK (R\u00c9SZESED\u00c9SEK)": {
+            "171. Tart\u00f3s r\u00e9szesed\u00e9s kapcsolt v\u00e1llalkoz\u00e1sban": {},
+            "172. Egy\u00e9b tart\u00f3s r\u00e9szesed\u00e9s": {},
+            "177. R\u00e9szesed\u00e9sek \u00e9rt\u00e9khelyesb\u00edt\u00e9se": {},
+            "179. R\u00e9szesed\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+          },
+          "18. HITELVISZONYT MEGTESTES\u00cdT\u00d5 \u00c9RT\u00c9KPAP\u00cdROK": {
+            "181. \u00c1llamk\u00f6tv\u00e9nyek": {},
+            "182. Kapcsolt v\u00e1llalkoz\u00e1sok \u00e9rt\u00e9kpap\u00edrjai": {},
+            "183. Egy\u00e9b v\u00e1llalkoz\u00e1sok \u00e9rt\u00e9kpap\u00edrjai": {},
+            "184. Tart\u00f3s diszkont \u00e9rt\u00e9kpap\u00edrok": {},
+            "189. \u00c9rt\u00e9kpap\u00edrok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+          },
+          "19. TART\u00d3SAN ADOTT K\u00d6LCS\u00d6N\u00d6K (tart\u00f3s bankbet\u00e9tek)": {
+            "191. Tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6k kapcsolt v\u00e1llalkoz\u00e1sban": {},
+            "192. Tart\u00f3s bankbet\u00e9tek": {},
+            "193. Egy\u00e9b tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6k": {},
+            "194. Tart\u00f3s bankbet\u00e9tek kapcsolt v\u00e1llalkoz\u00e1sban": {},
+            "195. Tart\u00f3s bankbet\u00e9tek egy\u00e9b r\u00e9szesed\u00e9si viszonyban \u00e1ll\u00f3 v\u00e1llalkoz\u00e1sban": {},
+            "196. Egy\u00e9b tart\u00f3s bankbet\u00e9tek": {},
+            "197. P\u00e9nz\u00fcgyi l\u00edzing miatti tart\u00f3s k\u00f6vetel\u00e9s": {},
+            "199. Tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6k (\u00e9s bankbet\u00e9tek) \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+          }
+        }
+      },
+      "rootType": "Asset"
+    },
+    "2. SZ\u00c1MLAOSZT\u00c1LY K\u00c9SZLETEK": {
+      "21-22. ANYAGOK": {
+        "211 - 219. Nyers- \u00e9s alapanyagok ": {},
+        "221. Seg\u00e9danyagok": {},
+        "222. \u00dczem- \u00e9s f\u0171t\u0151anyagok ": {},
+        "223. Fenntart\u00e1si anyagok ": {},
+        "224. \u00c9p\u00edt\u00e9si anyagok": {},
+        "225. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 anyagi eszk\u00f6z\u00f6k ": {},
+        "226. T\u00e1rgyi eszk\u00f6z\u00f6k k\u00f6z\u00fcl \u00e1tsorolt anyagok": {},
+        "227. Egy\u00e9b anyagok": {},
+        "228. Anyagok \u00e1rk\u00fcl\u00f6nb\u00f6zete": {},
+        "229. Anyagok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+      },
+      "23. BEFEJEZETLEN TERMEL\u00c9S \u00c9S F\u00c9LK\u00c9SZ TERM\u00c9KEK": {
+        "231 - 234. Befejezetlen termel\u00e9s ": {
+          "231. Befejezetlen termel\u00e9s": {},
+          "232. F\u00e9lk\u00e9sz term\u00e9kek": {}
+        },
+        "238. F\u00e9lk\u00e9sz term\u00e9kek k\u00e9szlet\u00e9rt\u00e9k-k\u00fcl\u00f6nb\u00f6zete": {},
+        "239. Befejezetlen termel\u00e9s \u00e9s f\u00e9lk\u00e9sz term\u00e9kek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+      },
+      "24. N\u00d6VEND\u00c9K-, H\u00cdZ\u00d3- \u00c9S EGY\u00c9B \u00c1LLATOK": {
+        "isGroup": 1
+      },
+      "25. K\u00c9SZTERM\u00c9KEK": {
+        "251-257. K\u00e9szterm\u00e9kek": {},
+        "258. K\u00e9szterm\u00e9kek k\u00e9szlet\u00e9rt\u00e9k-k\u00fcl\u00f6nb\u00f6zete": {},
+        "259. K\u00e9szterm\u00e9kek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+      },
+      "26-28. \u00c1RUK ": {
+        "261. Kereskedelmi \u00e1ruk": {
+          "accountType": "Stock",
+          "isGroup": 0
+        },
+        "262. Idegen helyen t\u00e1rolt, bizom\u00e1nyba \u00e1tadott \u00e1ruk": {
+          "accountType": "Stock",
+          "isGroup": 0
+        },
+        "263. T\u00e1rgyi eszk\u00f6z\u00f6k k\u00f6z\u00fcl \u00e1tsorolt \u00e1ruk": {
+          "accountType": "Stock",
+          "isGroup": 0
+        },
+        "264. Bels\u0151 (egys\u00e9gek, tev\u00e9kenys\u00e9gek k\u00f6z\u00f6tti) \u00e1tad\u00e1s-\u00e1tv\u00e9tel \u00fctk\u00f6z\u0151sz\u00e1mla": {
+          "accountType": "Stock",
+          "isGroup": 0
+        },
+        "269. Kereskedelmi \u00e1ruk \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {
+          "accountType": "Stock",
+          "isGroup": 0
+        },
+        "accountType": "Stock"
+      },
+      "27. K\u00d6ZVET\u00cdTETT SZOLG\u00c1LTAT\u00c1SOK ": {
+        "271. K\u00f6zvet\u00edtett szolg\u00e1ltat\u00e1sok": {},
+        "279. K\u00f6zvet\u00edtett szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+      },
+      "28. BET\u00c9TD\u00cdJAS G\u00d6NGY\u00d6LEGEK": {
+        "isGroup": 1
+      },
+      "rootType": "Asset"
+    },
+    "3. SZ\u00c1MLAOSZT\u00c1LY K\u00d6VETEL\u00c9SEK, P\u00c9NZ\u00dcGYI ESZK\u00d6Z\u00d6K \u00c9S AKT\u00cdV ID\u00d5BELI ELHAT\u00c1ROL\u00c1SOK": {
+      "31. K\u00d6VETEL\u00c9SEK \u00c1RUSZ\u00c1LL\u00cdT\u00c1SB\u00d3L \u00c9S SZOLG\u00c1LTAT\u00c1SB\u00d3L (VEV\u00d5K) ": {
+        "311. Belf\u00f6ldi k\u00f6vetel\u00e9sek (forintban)": {
+          "accountType": "Receivable"
+        },
+        "312. Belf\u00f6ldi k\u00f6vetel\u00e9sek (deviz\u00e1ban)": {
+          "accountType": "Receivable"
+        },
+        "315. Belf\u00f6ldi k\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa ": {},
+        "316. K\u00fclf\u00f6ldi k\u00f6vetel\u00e9sek (forintban)": {
+          "accountType": "Receivable"
+        },
+        "317. K\u00fclf\u00f6ldi k\u00f6vetel\u00e9sek (deviz\u00e1ban)": {
+          "accountType": "Receivable"
+        },
+        "319. K\u00fclf\u00f6ldi k\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+      },
+      "32. K\u00d6VETEL\u00c9SEK KAPCSOLT V\u00c1LLALKOZ\u00c1SSAL SZEMBEN": {
+        "isGroup": 1
+      },
+      "33. K\u00d6VETEL\u00c9SEK EGY\u00c9B R\u00c9SZESED\u00c9SI VISZONYBAN L\u00c9V\u00d5 V\u00c1LLALKOZ\u00c1SSAL SZEMBEN ": {
+        "isGroup": 1
+      },
+      "34. V\u00c1LT\u00d3K\u00d6VETEL\u00c9SEK": {
+        "isGroup": 1
+      },
+      "35. ADOTT EL\u00d5LEGEK": {
+        "351. Immateri\u00e1lis javakra adott el\u0151legek": {},
+        "352. Beruh\u00e1z\u00e1sokra adott el\u0151legek": {},
+        "353. K\u00e9szletekre adott el\u0151legek": {},
+        "358. Jegyzett, de m\u00e9g be nem fizetett t\u0151ke r\u00e9szesed\u00e9si viszonyban nem l\u00e9v\u0151 v\u00e1llalkoz\u00e1st\u00f3l": {},
+        "359. Adott el\u0151legek \u00e9rt\u00e9kveszt\u00e9se \u00e9s vissza\u00edr\u00e1sa": {}
+      },
+      "36. EGY\u00c9B K\u00d6VETEL\u00c9SEK": {
+        "361. Munkav\u00e1llal\u00f3kkal szembeni k\u00f6vetel\u00e9sek": {
+          "3611. Munkav\u00e1llal\u00f3knak foly\u00f3s\u00edtott el\u0151legek": {},
+          "3612. El\u0151\u00edrt tartoz\u00e1sok": {},
+          "3613. Egy\u00e9b elsz\u00e1mol\u00e1sok a munkav\u00e1llal\u00f3kkal": {}
+        },
+        "362. K\u00f6lts\u00e9gvet\u00e9ssel szembeni k\u00f6vetel\u00e9sek": {
+          "isGroup": 1
+        },
+        "363. R\u00f6vid lej\u00e1ratra k\u00f6lcs\u00f6nadott p\u00e9nzeszk\u00f6z\u00f6k": {
+          "isGroup": 1
+        },
+        "364. R\u00e9szesed\u00e9sekkel, \u00e9rt\u00e9kpap\u00edrokkal kapcsolatos k\u00f6vetel\u00e9sek": {
+          "3641. R\u00f6vid lej\u00e1rat\u00fa k\u00f6lcs\u00f6n\u00f6k": {},
+          "3642. Tart\u00f3san adott k\u00f6lcs\u00f6n\u00f6kb\u0151l \u00e1tsorolt k\u00f6vetel\u00e9sek": {}
+        },
+        "365. V\u00e1s\u00e1rolt \u00e9s kapott k\u00f6vetel\u00e9sek ": {
+          "isGroup": 1
+        },
+        "366. R\u00e9szesed\u00e9sekkel, \u00e9rt\u00e9kpap\u00edrokkal kapcsolatos k\u00f6vetel\u00e9sek": {},
+        "367. Hat\u00e1rid\u0151s, opci\u00f3s \u00e9s swap \u00fcgyletekkel kapcsolatos k\u00f6vetel\u00e9sek": {},
+        "368. K\u00fcl\u00f6nf\u00e9le egy\u00e9b k\u00f6vetel\u00e9sek ": {
+          "3681. Bizom\u00e1nyosi \u00fcgylettel kapcsolatos elsz\u00e1mol\u00e1sok": {},
+          "3682. \u00c9rt\u00e9kpap\u00edr-elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+          "3683. Import beszerz\u00e9sek \u00e1f\u00e1ja": {},
+          "3684. Ad\u00f3sok": {},
+          "3685. Biztos\u00edt\u00f3int\u00e9zettel szembeni k\u00f6vetel\u00e9sek": {},
+          "3686. Barter \u00fcgylet elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+          "3687. \u00c1rfolyam k\u00fcl\u00f6nb\u00f6zetek elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+          "3688. Ki nem emelt egy\u00e9b k\u00f6vetel\u00e9sek": {}
+        },
+        "369. Egy\u00e9b k\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+      },
+      "37. \u00c9RT\u00c9KPAP\u00cdROK": {
+        "371. R\u00e9szesed\u00e9sek": {
+          "3711. R\u00e9szesed\u00e9s anyav\u00e1llalatban": {},
+          "3712. R\u00e9szesed\u00e9s le\u00e1nyv\u00e1llalatban": {},
+          "3713. R\u00e9szesed\u00e9s k\u00f6z\u00f6s vezet\u00e9s\u0171 v\u00e1llalkoz\u00e1sban": {},
+          "3714. R\u00e9szesed\u00e9s t\u00e1rsult v\u00e1llalkoz\u00e1sban": {},
+          "3719. Kapcsolt v\u00e1llalkoz\u00e1sban l\u00e9v\u0151 r\u00e9szesed\u00e9sek \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+        },
+        "372. Saj\u00e1t r\u00e9szv\u00e9nyek, saj\u00e1t \u00fczletr\u00e9szek": {
+          "3721. Elad\u00e1sra v\u00e1s\u00e1rolt egy\u00e9b r\u00e9szesed\u00e9sek": {}
+        },
+        "373. Forgat\u00e1si c\u00e9l\u00fa hitelviszonyt megtestes\u00edt\u0151 \u00e9rt\u00e9kpap\u00edrok ": {
+          "3741. Elad\u00e1sra v\u00e1s\u00e1rolt hitelviszonyt megtestes\u00edt\u0151 \u00e9rt\u00e9kpap\u00edrok": {},
+          "3742. Elad\u00e1sra v\u00e1s\u00e1rolt diszkont \u00e9rt\u00e9kpap\u00edrok": {},
+          "3749. Forgat\u00e1si c\u00e9l\u00fa hitelviszonyt megtestes\u00edt\u0151 \u00e9rt\u00e9kpap\u00edrok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+        },
+        "378. \u00c9rt\u00e9kpap\u00edrok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {},
+        "379. \u00c9rt\u00e9kpap\u00edr elsz\u00e1mol\u00e1si sz\u00e1mla": {}
+      },
+      "38. P\u00c9NZESZK\u00d6Z\u00d6K": {
+        "381. P\u00e9nzt\u00e1r ": {
+          "3811. P\u00e9nzt\u00e1r-sz\u00e1mla": {},
+          "3812. Elektronikus p\u00e9nzeszk\u00f6z\u00f6k ": {},
+          "accountType": "Cash"
+        },
+        "382. Valutap\u00e9nzt\u00e1r ": {
+          "3821. Valutap\u00e9nzt\u00e1r-sz\u00e1mla": {},
+          "3829. Valuta \u00e1rfolyamk\u00fcl\u00f6nb\u00f6zeti sz\u00e1mla ": {}
+        },
+        "383. Csekkek": {},
+        "384. Elsz\u00e1mol\u00e1si bet\u00e9tsz\u00e1mla ": {
+          "accountType": "Bank",
+          "isGroup": 1
+        },
+        "385. Elk\u00fcl\u00f6n\u00edtett bet\u00e9tsz\u00e1ml\u00e1k ": {
+          "3851. Kamatoz\u00f3 bet\u00e9tsz\u00e1ml\u00e1k": {},
+          "3852. Elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l ": {},
+          "3853. Beruh\u00e1z\u00e1sra elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k": {},
+          "3854. Fejleszt\u00e9si c\u00e9lra elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k ": {},
+          "3855. Egy\u00e9b c\u00e9lra elk\u00fcl\u00f6n\u00edtett p\u00e9nzeszk\u00f6z\u00f6k": {},
+          "3856. Lak\u00e1s\u00e9p\u00edt\u00e9si bet\u00e9tsz\u00e1mla": {},
+          "3857. Elk\u00fcl\u00f6n\u00edtett lak\u00e1s\u00e9p\u00edt\u00e9si c\u00e9l\u00fa p\u00e9nzeszk\u00f6z\u00f6k ": {},
+          "3858. Lak\u00e1s\u00e9p\u00edt\u00e9s \u00faton l\u00e9v\u0151 p\u00e9nzeszk\u00f6zei": {}
+        },
+        "386. Devizabet\u00e9t-sz\u00e1mla ": {
+          "3861. Devizabet\u00e9t-sz\u00e1mla": {},
+          "3862. K\u00fclf\u00f6ld\u00f6n vezetett devizabet\u00e9t-sz\u00e1mla ": {},
+          "3863. Devizat\u00f6rzsbet\u00e9t-sz\u00e1mla": {},
+          "3868. Egy\u00e9b devizabet\u00e9t-sz\u00e1mla": {},
+          "3869. Devizabet\u00e9t \u00e1rfolyamk\u00fcl\u00f6nb\u00f6zeti sz\u00e1mla ": {}
+        },
+        "387. Elektronikus p\u00e9nz": {},
+        "389. \u00c1tvezet\u00e9si sz\u00e1mla": {}
+      },
+      "39. AKT\u00cdV ID\u00d5BELI ELHAT\u00c1ROL\u00c1SOK": {
+        "391. Bev\u00e9telek akt\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
+          "3911. Diszkont \u00e9rt\u00e9kpap\u00edrok id\u0151ar\u00e1nyos kamat\u00e1nak elhat\u00e1rol\u00e1sa": {},
+          "3912. \u00c9rt\u00e9kpap\u00edrok beszerz\u00e9s\u00e9hez kapcsol\u00f3d\u00f3 k\u00fcl\u00f6nb\u00f6zetb\u0151l az id\u0151ar\u00e1nyos \u00e1rfolyamnyeres\u00e9g elhat\u00e1rol\u00e1sa": {},
+          "3913. \u00c1rbev\u00e9tel, egy\u00e9b kamatbev\u00e9tel, egy\u00e9b bev\u00e9tel elhat\u00e1rol\u00e1sa": {}
+        },
+        "392. K\u00f6lts\u00e9gek, r\u00e1ford\u00edt\u00e1sok akt\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
+          "3921. \u00c9rt\u00e9kpap\u00edrok, r\u00e9szesed\u00e9sek beszerz\u00e9s\u00e9hez kapcsol\u00f3d\u00f3 bizom\u00e1nyi d\u00edj, v\u00e1s\u00e1rolt v\u00e9teli opci\u00f3 d\u00edj\u00e1nak elhat\u00e1rol\u00e1sa": {},
+          "3922. T\u00f6bbletk\u00f6telezetts\u00e9gek elhat\u00e1rol\u00e1sa": {},
+          "3923. K\u00f6lts\u00e9gek, egy\u00e9b fizetett kamatok, egy\u00e9b r\u00e1ford\u00edt\u00e1sok elhat\u00e1rol\u00e1sa": {}
+        },
+        "393. Halasztott r\u00e1ford\u00edt\u00e1sok ": {
+          "3931. Tartoz\u00e1s\u00e1tv\u00e1llal\u00e1sok miatti r\u00e1ford\u00edt\u00e1sok elhat\u00e1rol\u00e1sa": {},
+          "3932. Devizak\u00f6telezetts\u00e9gek \u00e1rfolyamvesztes\u00e9g\u00e9nek elhat\u00e1rol\u00e1sa ": {}
+        },
+        "399. A k\u00f6vetel\u00e9s-jelleg\u0171 akt\u00edv id\u0151beli elhat\u00e1rol\u00e1sok \u00e9rt\u00e9kveszt\u00e9se \u00e9s annak vissza\u00edr\u00e1sa": {}
+      },
+      "rootType": "Asset"
+    },
+    "4. SZ\u00c1MLAOSZT\u00c1LY FORR\u00c1SOK": {
+      "41. SAJ\u00c1T T\u00d5KE": {
+        "411. Jegyzett\u0151ke ": {},
+        "412. T\u0151ketartal\u00e9k": {},
+        "413. Eredm\u00e9nytartal\u00e9k": {},
+        "414. Lek\u00f6t\u00f6tt tartal\u00e9k ": {
+          "4141. Lek\u00f6t\u00f6tt tartal\u00e9k t\u0151ketartal\u00e9kb\u00f3l": {},
+          "4142. Lek\u00f6t\u00f6tt tartal\u00e9k eredm\u00e9nytartal\u00e9kb\u00f3l": {},
+          "4143. Lek\u00f6t\u00f6tt tartal\u00e9k p\u00f3tbefizet\u00e9sb\u0151l ": {}
+        },
+        "417. \u00c9rt\u00e9kel\u00e9si tartal\u00e9k": {},
+        "418. El\u0151z\u0151 \u00e9vek helyesb\u00edt\u00e9s\u00e9b\u0151l sz\u00e1rmaz\u00f3 m\u00e9rleg szerinti eredm\u00e9ny": {},
+        "419. Ad\u00f3zott eredm\u00e9ny": {}
+      },
+      "42. C\u00c9LTARTAL\u00c9KOK": {
+        "421. C\u00e9ltartal\u00e9k a v\u00e1rhat\u00f3 k\u00f6telezetts\u00e9gekre ": {},
+        "422. C\u00e9ltartal\u00e9k a j\u00f6v\u0151beni k\u00f6lts\u00e9gekre": {},
+        "424. \u00c1rfolyamvesztes\u00e9g id\u0151beli elhat\u00e1rol\u00e1sa alapj\u00e1n k\u00e9pzett c\u00e9ltartal\u00e9k ": {},
+        "429. Egy\u00e9b c\u00e9ltartal\u00e9k": {}
+      },
+      "43-47. K\u00d6TELEZETTS\u00c9GEK": {
+        "43. H\u00c1TRASOROLT K\u00d6TELEZETTS\u00c9GEK": {
+          "431. H\u00e1trasorolt k\u00f6telezetts\u00e9gek kapcsolt v\u00e1llalkoz\u00e1ssal szemben ": {
+            "4311. H\u00e1trasorolt k\u00f6telezetts\u00e9gek anyav\u00e1llalattal szemben ": {},
+            "4312. H\u00e1trasorolt k\u00f6telezetts\u00e9gek le\u00e1nyv\u00e1llalattal szemben": {},
+            "4313. H\u00e1trasorolt k\u00f6telezetts\u00e9gek k\u00f6z\u00f6s vezet\u00e9s\u0171 v\u00e1llalkoz\u00e1ssal szemben ": {},
+            "4314. H\u00e1trasorolt k\u00f6telezetts\u00e9gek t\u00e1rsult v\u00e1llalkoz\u00e1ssal szemben ": {}
+          },
+          "432. H\u00e1trasorolt k\u00f6telezetts\u00e9gek egy\u00e9b r\u00e9szesed\u00e9si viszonyban l\u00e9v\u0151 v\u00e1llalkoz\u00e1ssal szemben": {},
+          "433. H\u00e1trasorolt k\u00f6telezetts\u00e9gek egy\u00e9b gazd\u00e1lkod\u00f3val szemben": {}
+        },
+        "44. HOSSZ\u00da LEJ\u00c1RAT\u00da K\u00d6TELEZETTS\u00c9GEK": {
+          "441. Hossz\u00fa lej\u00e1ratra kapott k\u00f6lcs\u00f6n\u00f6k": {},
+          "442. \u00c1tv\u00e1ltoztathat\u00f3 k\u00f6tv\u00e9nyek ": {},
+          "443. Tartoz\u00e1sok k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l ": {
+            "4431. Tartoz\u00e1sok k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l forintban ": {},
+            "4432. Tartoz\u00e1sok k\u00f6tv\u00e9nykibocs\u00e1t\u00e1sb\u00f3l deviz\u00e1ban": {}
+          },
+          "444. Beruh\u00e1z\u00e1si \u00e9s fejleszt\u00e9si hitelek ": {
+            "4441. Beruh\u00e1z\u00e1si \u00e9s fejleszt\u00e9si hitelek forintban ": {},
+            "4442. Beruh\u00e1z\u00e1si \u00e9s fejleszt\u00e9si hitelek deviz\u00e1ban ": {}
+          },
+          "445. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa hitelek ": {
+            "4451. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa hitelek forintban ": {},
+            "4452. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa hitelek deviz\u00e1ban": {}
+          },
+          "446. Tart\u00f3s k\u00f6telezetts\u00e9gek kapcsolt v\u00e1llalkoz\u00e1ssal szemben ": {
+            "isGroup": 1
+          },
+          "447. Tart\u00f3s k\u00f6telezetts\u00e9gek egy\u00e9b r\u00e9szesed\u00e9si viszonyban l\u00e9v\u0151 v\u00e1llalkoz\u00e1ssal szemben": {},
+          "448. P\u00e9nz\u00fcgyi l\u00edzing miatti k\u00f6telezetts\u00e9gek ": {},
+          "449. Egy\u00e9b hossz\u00fa lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek ": {
+            "4491. Kincst\u00e1ri vagyon r\u00e9sz\u00e9t k\u00e9pez\u0151 eszk\u00f6z\u00f6k kezel\u00e9sbe v\u00e9tel\u00e9hez kapcsol\u00f3d\u00f3 k\u00f6telezetts\u00e9g": {},
+            "4492. Alap\u00edt\u00f3kkal szembeni hossz\u00fa lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek ": {}
+          },
+          "4499. Hossz\u00fa lej\u00e1rat\u00fa egy\u00e9b k\u00f6telezetts\u00e9gek": {}
+        },
+        "45-47. R\u00d6VID LEJ\u00c1RAT\u00da K\u00d6TELEZETTS\u00c9GEK": {
+          "451. R\u00f6vid lej\u00e1rat\u00fa k\u00f6lcs\u00f6n\u00f6k ": {
+            "4511. R\u00f6vid lej\u00e1rat\u00fa \u00e1tv\u00e1ltoztathat\u00f3 k\u00f6tv\u00e9nyek ": {},
+            "4512. Egy\u00e9b r\u00f6vid lej\u00e1rat\u00fa k\u00f6lcs\u00f6n\u00f6k": {}
+          },
+          "452. R\u00f6vid lej\u00e1rat\u00fa hitelek ": {
+            "4521. R\u00f6vid lej\u00e1rat\u00fa hitelek forintban ": {},
+            "4522. R\u00f6vid lej\u00e1rat\u00fa hitelek deviz\u00e1ban ": {}
+          },
+          "453. Vev\u0151kt\u0151l kapott el\u0151legek": {},
+          "454-456. K\u00f6telezetts\u00e9gek \u00e1rusz\u00e1ll\u00edt\u00e1sb\u00f3l \u00e9s szolg\u00e1ltat\u00e1sb\u00f3l (sz\u00e1ll\u00edt\u00f3k)": {
+            "454. Sz\u00e1ll\u00edt\u00f3k ": {
+              "4541. Belf\u00f6ldi anyag- \u00e9s \u00e1rusz\u00e1ll\u00edt\u00f3k ": {
+                "accountType": "Payable"
+              },
+              "4542. K\u00fclf\u00f6ldi anyag- \u00e9s \u00e1rusz\u00e1ll\u00edt\u00f3k ": {
+                "accountType": "Payable"
+              },
+              "4543. Belf\u00f6ldi szolg\u00e1ltat\u00f3k": {},
+              "4544. K\u00fclf\u00f6ldi szolg\u00e1ltat\u00f3k": {},
+              "4549. Nem sz\u00e1ml\u00e1zott sz\u00e1ll\u00edt\u00e1sok, szolg\u00e1ltat\u00e1sok ": {
+                "accountType": "Stock Received But Not Billed"
+              }
+            },
+            "455. Beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k ": {
+              "4551. Belf\u00f6ldi beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k ": {},
+              "4552. K\u00fclf\u00f6ldi beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k": {},
+              "4559. Nem sz\u00e1ml\u00e1zott beruh\u00e1z\u00e1si sz\u00e1ll\u00edt\u00f3k ": {}
+            },
+            "456. Nem sz\u00e1ml\u00e1zott sz\u00e1ll\u00edt\u00f3k": {}
+          },
+          "457. V\u00e1lt\u00f3tartoz\u00e1sok": {},
+          "458. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek kapcsolt v\u00e1llalkoz\u00e1ssal szemben ": {
+            "4581. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek anyav\u00e1llalattal szemben ": {},
+            "4582. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek le\u00e1nyv\u00e1llalattal szemben": {},
+            "4583. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek k\u00f6z\u00f6s vezet\u00e9s\u0171 v\u00e1llalkoz\u00e1ssal szemben": {},
+            "4584. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek t\u00e1rsult v\u00e1llalkoz\u00e1ssal szemben": {}
+          },
+          "459. R\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek egy\u00e9b r\u00e9szesed\u00e9si viszonyban l\u00e9v\u0151 v\u00e1llalkoz\u00e1ssal szemben": {},
+          "461-479. Egy\u00e9b r\u00f6vid lej\u00e1rat\u00fa k\u00f6telezetts\u00e9gek": {
+            "461. Eredm\u00e9nyt terhel\u0151 ad\u00f3k elsz\u00e1mol\u00e1sa": {
+              "4611. T\u00e1rsas\u00e1gi ad\u00f3 elsz\u00e1mol\u00e1sa ": {},
+              "4612. K\u00fcl\u00f6nad\u00f3 elsz\u00e1mol\u00e1sa ": {},
+              "4613. Egyszer\u0171s\u00edtett v\u00e1llalkoz\u00f3i ad\u00f3 elsz\u00e1mol\u00e1sa ": {}
+            },
+            "462. Szem\u00e9lyi j\u00f6vedelemad\u00f3 elsz\u00e1mol\u00e1sa ": {
+              "4612. Mag\u00e1nszem\u00e9lyekt\u0151l levont szem\u00e9lyi j\u00f6vedelem ad\u00f3 elsz\u00e1mol\u00e1sa ": {},
+              "4621. Kifizet\u0151t terhel\u0151  szem\u00e9lyi j\u00f6vedelem ad\u00f3 elsz\u00e1mol\u00e1sa ": {}
+            },
+            "463. K\u00f6lts\u00e9gvet\u00e9si befizet\u00e9si k\u00f6telezetts\u00e9gek ": {
+              "463-1. Nyugd\u00edjj\u00e1rul\u00e9k ": {},
+              "463-10. Innov\u00e1ci\u00f3s j\u00e1rul\u00e9k  ": {},
+              "463-11. \u00d6nellen\u0151rz\u00e9si p\u00f3tl\u00e9k  ": {},
+              "463-12. Mulaszt\u00e1si b\u00edrs\u00e1g, ad\u00f3b\u00edrs\u00e1g  ": {},
+              "463-13. K\u00e9sedelmi p\u00f3tl\u00e9k ": {},
+              "463-14. Egy\u00e9b k\u00f6lts\u00e9gvet\u00e9si befizet\u00e9si k\u00f6telezetts\u00e9gek ": {},
+              "463-2. Eg\u00e9szs\u00e9gbiztos\u00edt\u00e1si- \u00e9s munkaer\u0151  piaci j\u00e1rul\u00e9k ": {},
+              "463-3. Rehabilit\u00e1ci\u00f3s hozz\u00e1j\u00e1rul\u00e1s  ": {},
+              "463-4. Szoci\u00e1lis hozz\u00e1j\u00e1rul\u00e1si ad\u00f3  ": {},
+              "463-5. Eg\u00e9szs\u00e9g\u00fcgyi szolg\u00e1ltat\u00e1si j\u00e1rul\u00e9k ": {},
+              "463-6. Szakk\u00e9pz\u00e9si hozz\u00e1j\u00e1rul\u00e1s ": {},
+              "463-7. Eg\u00e9szs\u00e9g\u00fcgyi hozz\u00e1j\u00e1rul\u00e1s  ": {},
+              "463-8. Egyszer\u0171s\u00edtett foglalkoztat\u00e1s k\u00f6zterhe ": {},
+              "463-9. C\u00e9gaut\u00f3ad\u00f3 ": {}
+            },
+            "464. G\u00e9pj\u00e1rm\u0171 ad\u00f3 (c\u00e9gaut\u00f3ad\u00f3) elsz\u00e1mol\u00e1sa": {
+              "isGroup": 1
+            },
+            "465. V\u00e1m- \u00e9s p\u00e9nz\u00fcgy\u0151rs\u00e9g elsz\u00e1mol\u00e1si sz\u00e1mla ": {
+              "4651. V\u00e1mk\u00f6lts\u00e9gek \u00e9s egy\u00e9b v\u00e1mterhek elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+              "4652. Importbeszerz\u00e9s ut\u00e1n fizetend\u0151 \u00e1ltal\u00e1nos forgalmi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+              "4653. V\u00e1m- \u00e9s p\u00e9nz\u00fcgy\u0151rs\u00e9ggel kapcsolatos egy\u00e9b elsz\u00e1mol\u00e1sok ": {}
+            },
+            "466. El\u0151zetesen felsz\u00e1m\u00edtott \u00e1ltal\u00e1nos forgalmi ad\u00f3 ": {
+              "4661. Beszerz\u00e9sek el\u0151zetesen felsz\u00e1m\u00edtott \u00e1ltal\u00e1nos forgalmi ad\u00f3ja ": {},
+              "4662. Ar\u00e1nyos\u00edt\u00e1ssal megosztand\u00f3 el\u0151zetesen felsz\u00e1m\u00edtott \u00e1ltal\u00e1nos forgalmi ad\u00f3": {}
+            },
+            "467. Fizetend\u0151 \u00e1ltal\u00e1nos forgalmi ad\u00f3": {},
+            "468. \u00c1ltal\u00e1nos forgalmi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {},
+            "469. Helyi ad\u00f3k elsz\u00e1mol\u00e1si sz\u00e1mla ": {
+              "4691. \u00c9p\u00edtm\u00e9nyad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {},
+              "4692. Telekad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+              "4693. Kommun\u00e1lis ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {},
+              "4694. Idegenforgalmi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {},
+              "4695. Helyi ipar\u0171z\u00e9si ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {},
+              "4696. G\u00e9pj\u00e1rm\u0171ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+              "4697. K\u00fclf\u00f6ldi g\u00e9pj\u00e1rm\u0171ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla ": {},
+              "4699. Egy\u00e9b helyi ad\u00f3 elsz\u00e1mol\u00e1si sz\u00e1mla": {}
+            },
+            "471. J\u00f6vedelemelsz\u00e1mol\u00e1si sz\u00e1mla ": {
+              "4711. Keresetelsz\u00e1mol\u00e1si sz\u00e1mla ": {},
+              "4712. T\u00e1rsadalombiztos\u00edt\u00e1si ell\u00e1t\u00e1s ": {},
+              "4713. Egy\u00e9b kifizet\u00e9sek elsz\u00e1mol\u00e1sa": {}
+            },
+            "472. Fel nem vett j\u00e1rand\u00f3s\u00e1gok": {},
+            "473. Elsz\u00e1mol\u00e1s a t\u00e1rsadalombiztos\u00edt\u00e1ssal ": {},
+            "474. Szakk\u00e9pz\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {
+              "4741. K\u00f6zponti m\u0171szaki fejleszt\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {},
+              "4742. Elsz\u00e1mol\u00e1sra kapott p\u00e9nzeszk\u00f6z\u00f6k": {},
+              "4743. K\u00f6rnyezetv\u00e9delmi term\u00e9k d\u00edjfizet\u00e9si k\u00f6telezetts\u00e9g ": {},
+              "4749. Egy\u00e9b befizet\u00e9sek az elk\u00fcl\u00f6n\u00edtett alapokba": {}
+            },
+            "475. Eg\u00e9szs\u00e9g\u00fcgyi hozz\u00e1j\u00e1rul\u00e1s (EHO) elsz\u00e1mol\u00e1sa": {},
+            "476. Egy\u00e9b \u00e1llami ad\u00f3hat\u00f3s\u00e1ggal szembeni k\u00f6telezetts\u00e9g elsz\u00e1mol\u00e1sa": {
+              "4761. K\u00e1rt\u00e9r\u00edt\u00e9s": {},
+              "4762. B\u00edr\u00f3i letilt\u00e1s": {},
+              "4763. Banki-elsz\u00e1mol\u00e1s": {},
+              "4764. Levont szakszervezeti d\u00edj": {},
+              "4765. Mag\u00e1n nyugd\u00edjp\u00e9nzt\u00e1ri befizet\u00e9si k\u00f6telezetts\u00e9gek": {}
+            },
+            "477. R\u00f6vid lej\u00e1rat\u00fa egy\u00e9b k\u00f6telezetts\u00e9gek munkav\u00e1llal\u00f3kkal \u00e9s tulajdonosokkal szemben": {},
+            "478. R\u00e9szesed\u00e9sekkel, \u00e9rt\u00e9kpap\u00edrokkal kapcsolatos k\u00f6telezetts\u00e9gek ": {},
+            "479. K\u00fcl\u00f6nf\u00e9le r\u00f6vid lej\u00e1rat\u00fa egy\u00e9b befizet\u00e9si k\u00f6telezetts\u00e9gek ": {
+              "4791. Biztos\u00edt\u00f3 int\u00e9zetekkel szembeni k\u00f6telezetts\u00e9gek": {},
+              "4792. Hitelez\u0151k": {},
+              "4793. \u00c1tv\u00e1llalt k\u00f6telezetts\u00e9gek": {},
+              "4794. Beszerz\u00e9si \u00e1rba beletartoz\u00f3 el\u0151\u00edrt egy\u00e9b k\u00f6telezetts\u00e9gek ": {},
+              "4795. Egy\u00e9b r\u00f6vid lej\u00e1rat\u00fa el\u0151\u00edrt k\u00f6telezetts\u00e9gek": {}
+            }
+          }
+        }
+      },
+      "48. PASSZ\u00cdV ID\u00d5BELI ELHAT\u00c1ROL\u00c1SOK": {
+        "481. Bev\u00e9telek passz\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
+          "4811. Befolyt, elsz\u00e1molt bev\u00e9telek elhat\u00e1rol\u00e1sa": {},
+          "4812. K\u00f6lts\u00e9gek ellent\u00e9telez\u00e9s\u00e9re kapott t\u00e1mogat\u00e1sok elhat\u00e1rol\u00e1sa": {},
+          "4813. Devizaeszk\u00f6z\u00f6k \u00e9s devizak\u00f6telezetts\u00e9gek m\u00e9rlegfordul\u00f3napi \u00e9rt\u00e9kel\u00e9se \u00e1rfolyamnyeres\u00e9g\u00e9nek elhat\u00e1rol\u00e1sa": {}
+        },
+        "482. K\u00f6lts\u00e9gek, r\u00e1ford\u00edt\u00e1sok passz\u00edv id\u0151beli elhat\u00e1rol\u00e1sa ": {
+          "4821. M\u00e9rlegfordul\u00f3nap el\u0151tti id\u0151szakot terhel\u0151 k\u00f6lts\u00e9gek, r\u00e1ford\u00edt\u00e1sok elhat\u00e1rol\u00e1sa": {},
+          "4822. \u00c9rt\u00e9kpap\u00edrok beszerz\u00e9s\u00e9hez kapcsol\u00f3d\u00f3 k\u00fcl\u00f6nb\u00f6zetb\u0151l az id\u0151ar\u00e1nyos \u00e1rfolyam\u008fvesztes\u00e9g elhat\u00e1rol\u00e1sa": {},
+          "4823. Fizetend\u0151 kamatok elhat\u00e1rol\u00e1sa ": {}
+        },
+        "483. Halasztott bev\u00e9telek ": {}
+      },
+      "49. \u00c9VI M\u00c9RLEGSZ\u00c1ML\u00c1K": {
+        "491. Nyit\u00f3m\u00e9rleg sz\u00e1mla ": {},
+        "492. Z\u00e1r\u00f3m\u00e9rleg sz\u00e1mla": {},
+        "493. Ad\u00f3zott eredm\u00e9ny elsz\u00e1mol\u00e1si sz\u00e1mla": {},
+        "494. El\u0151z\u0151 \u00e9vi ad\u00f3zott eredm\u00e9ny elsz\u00e1mol\u00e1sa": {}
+      },
+      "rootType": "Liability"
+    },
+    "5. SZ\u00c1MLAOSZT\u00c1LY K\u00d6LTS\u00c9GNEMEK": {
+      "51 - 53. ANYAGJELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK ": {
+        "51. ANYAGK\u00d6LTS\u00c9G": {
+          "511. V\u00e1s\u00e1rolt anyagok k\u00f6lts\u00e9gei ": {
+            "5111. Alapanyag k\u00f6lts\u00e9gek": {},
+            "5112. Seg\u00e9danyag k\u00f6lts\u00e9gek": {},
+            "5113. \u00dczemanyag k\u00f6lts\u00e9gek": {},
+            "5114. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 gy\u00e1rt\u00f3eszk\u00f6z\u00f6k, berendez\u00e9sek, felszerel\u00e9sek \u00e9s egy\u00e9b eszk\u00f6z\u00f6k k\u00f6lts\u00e9gei": {},
+            "5115. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 munkaruha, v\u00e9d\u0151ruha felhaszn\u00e1l\u00e1s k\u00f6lts\u00e9gei": {},
+            "5116. Nyomtatv\u00e1nyok, irodaszerek k\u00f6lts\u00e9gei": {},
+            "5117. F\u0171t\u0151anyag k\u00f6lts\u00e9gek": {},
+            "5118. Villamosenergia felhaszn\u00e1l\u00e1s \u00e9s v\u00edzfelhaszn\u00e1l\u00e1s k\u00f6lts\u00e9gei": {},
+            "5119. Egy\u00e9b anyagfelhaszn\u00e1l\u00e1s k\u00f6lts\u00e9gei": {},
+            "512. Egy \u00e9ven bel\u00fcl elhaszn\u00e1l\u00f3d\u00f3 anyagi eszk\u00f6z\u00f6k k\u00f6lts\u00e9gei ": {},
+            "5121. V\u00e1s\u00e1rolt n\u00f6vend\u00e9k\u00e1llatok k\u00f6lts\u00e9gei": {},
+            "5122. V\u00e1s\u00e1rolt h\u00edz\u00f3\u00e1llatok k\u00f6lts\u00e9gei": {},
+            "5123. V\u00e1s\u00e1rolt egy\u00e9b \u00e1llatok k\u00f6lts\u00e9gei": {},
+            "513. Egy\u00e9b anyagk\u00f6lts\u00e9g": {},
+            "519. Anyagk\u00f6lts\u00e9g megt\u00e9r\u00fcl\u00e9s": {}
+          }
+        },
+        "52. IG\u00c9NYBE VETT SZOLG\u00c1LTAT\u00c1SOK K\u00d6LTS\u00c9GEI": {
+          "521. Sz\u00e1ll\u00edt\u00e1s-rakod\u00e1s, rakt\u00e1roz\u00e1s k\u00f6lts\u00e9gei": {},
+          "522. B\u00e9rleti d\u00edjak": {},
+          "523. Karbantart\u00e1si k\u00f6lts\u00e9gek": {},
+          "524. Hirdet\u00e9s, rekl\u00e1m, propaganda k\u00f6lts\u00e9gek": {},
+          "525. Oktat\u00e1s \u00e9s tov\u00e1bbk\u00e9pz\u00e9s k\u00f6lts\u00e9gei": {},
+          "526. Utaz\u00e1si \u00e9s kik\u00fcldet\u00e9si k\u00f6lts\u00e9gek (napid\u00edj n\u00e9lk\u00fcl)": {},
+          "529. Ig\u00e9nybe vett egy\u00e9b szolg\u00e1ltat\u00e1sok k\u00f6lts\u00e9gei": {}
+        },
+        "53. EGY\u00c9B SZOLG\u00c1LTAT\u00c1SOK K\u00d6LTS\u00c9GEI": {
+          "531. Hat\u00f3s\u00e1gi igazgat\u00e1si, szolg\u00e1ltat\u00e1si d\u00edjak, illet\u00e9kek": {},
+          "532. P\u00e9nz\u00fcgyi, befektet\u00e9si szolg\u00e1ltat\u00e1si d\u00edjak": {},
+          "533. Biztos\u00edt\u00e1si d\u00edj ": {},
+          "534. K\u00f6lts\u00e9gk\u00e9nt elsz\u00e1moland\u00f3 ad\u00f3k, j\u00e1rul\u00e9kok, term\u00e9kd\u00edjak": {},
+          "539. K\u00fcl\u00f6nf\u00e9le egy\u00e9b szolg\u00e1ltat\u00e1sok k\u00f6lts\u00e9gei": {}
+        }
+      },
+      "54 - 56. SZEM\u00c9LYI JELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK": {
+        "54. B\u00c9RK\u00d6LTS\u00c9G ": {
+          "541. B\u00e9rk\u00f6lts\u00e9g": {},
+          "542. Tulajdonos szem\u00e9lyes k\u00f6zrem\u0171k\u00f6d\u00e9s\u00e9nek ellen\u00e9rt\u00e9ke": {},
+          "543. Sz\u00f6vetkezeti tagok munkad\u00edja": {}
+        },
+        "55. SZEM\u00c9LYI JELLEG\u00db EGY\u00c9B KIFIZET\u00c9SEK": {
+          "551. Munkav\u00e1llal\u00f3knak, tagoknak fizetett szem\u00e9lyi jelleg\u0171 kifizet\u00e9sek ": {
+            "5511. Betegszabads\u00e1g d\u00edja, munk\u00e1ltat\u00f3t terhel\u0151 t\u00e1pp\u00e9nz, t\u00e1pp\u00e9nz kieg\u00e9sz\u00edt\u00e9s": {},
+            "5512. V\u00e9gkiel\u00e9g\u00edt\u00e9s": {},
+            "5513. Munk\u00e1baj\u00e1r\u00e1ssal kapcsolatos egy\u00e9b k\u00f6lts\u00e9gek t\u00e9r\u00edt\u00e9se": {},
+            "5514. Kik\u00fcldet\u00e9s napid\u00edja": {},
+            "5515. Megv\u00e1ltozott munkak\u00e9pess\u00e9g\u0171 munkav\u00e1llal\u00f3k keresetkieg\u00e9sz\u00edt\u00e9se, fizetett seg\u00e9lyek": {},
+            "5516. \u00dcd\u00fcl\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {},
+            "5517. Lak\u00e1s\u00e9p\u00edt\u00e9sre ny\u00fajtott t\u00e1mogat\u00e1s, alb\u00e9rleti hozz\u00e1j\u00e1rul\u00e1s": {},
+            "5518. Jubileumi jutalom, t\u00e1rgyjutalom": {},
+            "5519. Sorkatonai vagy polg\u00e1ri szolg\u00e1lat teljes\u00edt\u00e9s\u00e9t k\u00f6vet\u0151en fizetett szem\u00e9lyi alapb\u00e9r": {}
+          },
+          "552. J\u00f3l\u00e9ti \u00e9s kultur\u00e1lis k\u00f6lts\u00e9gek": {},
+          "559. Egy\u00e9b szem\u00e9lyi jelleg\u0171 kifizet\u00e9sek ": {
+            "5591. Munk\u00e1ltat\u00f3 \u00e1ltal fizetett baleset-, \u00e9let- \u00e9s nyugd\u00edjbiztos\u00edt\u00e1s d\u00edja": {},
+            "5592. Munk\u00e1ltat\u00f3 \u00e1ltal \u00f6nk\u00e9ntes p\u00e9nzt\u00e1rba befizetett munk\u00e1ltat\u00f3i tagd\u00edj hozz\u00e1j\u00e1rul\u00e1s": {},
+            "5593. Munk\u00e1ltat\u00f3t terhel\u0151 szem\u00e9lyi j\u00f6vedelemad\u00f3": {},
+            "5594. Munk\u00e1ltat\u00f3i hozz\u00e1j\u00e1rul\u00e1s a korengedm\u00e9nyes nyugd\u00edj ig\u00e9nybev\u00e9tel\u00e9hez": {},
+            "5596. Fizetett szerz\u0151i, \u00edr\u00f3i \u00e9s m\u00e1s jogv\u00e9delmet \u00e9lvez\u0151 munk\u00e1k d\u00edjai \u00e9s ezekkel kapcsolatos k\u00f6zrem\u0171k\u00f6d\u0151i d\u00edjak": {},
+            "5597. Fizetett \u00f6szt\u00f6nd\u00edjak": {},
+            "5598. Reprezent\u00e1ci\u00f3s k\u00f6lts\u00e9gek, \u00e9tkez\u00e9si hozz\u00e1j\u00e1rul\u00e1s": {},
+            "5599. Munk\u00e1ltat\u00f3 \u00e1ltal fizetett mag\u00e1nnyugd\u00edj-p\u00e9nzt\u00e1ri tagd\u00edj kieg\u00e9sz\u00edt\u00e9s, munkav\u00e1llal\u00f3kkal kapcsolatos biztos\u00edt\u00e1si d\u00edjak": {}
+          }
+        },
+        "56. B\u00c9RJ\u00c1RUL\u00c9KOK": {
+          "561. Nyugd\u00edjbiztos\u00edt\u00e1si \u00e9s eg\u00e9szs\u00e9gbiztos\u00edt\u00e1si j\u00e1rul\u00e9k ": {},
+          "562. Eg\u00e9szs\u00e9g\u00fcgyi hozz\u00e1j\u00e1rul\u00e1s": {},
+          "563. Munkaad\u00f3i j\u00e1rul\u00e9k": {},
+          "564. Szakk\u00e9pz\u00e9si hozz\u00e1j\u00e1rul\u00e1s ": {},
+          "569. Egy\u00e9b hozz\u00e1j\u00e1rul\u00e1s ": {}
+        }
+      },
+      "57. \u00c9RT\u00c9KCS\u00d6KKEN\u00c9SI LE\u00cdR\u00c1S": {
+        "571. Terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1s ": {
+          "5711. Terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1s ": {
+            "accountType": "Depreciation"
+          },
+          "5712. Kiemelt, kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) eszk\u00f6z\u00f6k terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {},
+          "57121. Kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) vagyoni \u00e9rt\u00e9k\u0171 jogok terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {},
+          "57122. Kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) szellemi term\u00e9kek terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {},
+          "57123. Kis \u00e9rt\u00e9k\u0171 (50 eFt egyedi beszerz\u00e9si \u00e9rt\u00e9k alatti) t\u00e1rgyi eszk\u00f6z\u00f6k terv szerinti \u00e9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1sa": {}
+        }
+      },
+      "58. AKTIV\u00c1LT SAJ\u00c1T TELJES\u00cdTM\u00c9NYEK \u00c9RT\u00c9KE": {
+        "581. Saj\u00e1t termel\u00e9s\u0171 k\u00e9szletek \u00e1llom\u00e1nyv\u00e1ltoz\u00e1sa ": {},
+        "582. Saj\u00e1t el\u0151\u00e1ll\u00edt\u00e1s\u00fa eszk\u00f6z\u00f6k aktiv\u00e1lt \u00e9rt\u00e9ke": {},
+        "589. Aktiv\u00e1lt saj\u00e1t teljes\u00edtm\u00e9nyek \u00e1tvezet\u00e9si sz\u00e1mla": {}
+      },
+      "59. K\u00d6LTS\u00c9GNEM \u00c1TVEZET\u00c9SI SZ\u00c1MLA": {
+        "isGroup": 1
+      },
+      "rootType": "Expense"
+    },
+    "6. SZ\u00c1MLAOSZT\u00c1LY K\u00d6LTS\u00c9GHELYEK, \u00c1LTAL\u00c1NOS K\u00d6LTS\u00c9GEK": {
+      "61. JAV\u00cdT\u00d3-KARBANTART\u00d3 \u00dcZEMEK K\u00d6LTS\u00c9GEI": {},
+      "62. SZOLG\u00c1LTAT\u00c1ST V\u00c9GZ\u00d5 \u00dcZEMEK (EGYS\u00c9GEK) K\u00d6LTS\u00c9GEI": {},
+      "63. G\u00c9PK\u00d6LTS\u00c9G": {},
+      "64-65. \u00dcZEMI IR\u00c1NY\u00cdT\u00c1S \u00c1LTAL\u00c1NOS K\u00d6LTS\u00c9GEI": {},
+      "66. K\u00d6ZPONTI IR\u00c1NY\u00cdT\u00c1S \u00c1LTL\u00c1NOS K\u00d6LTS\u00c9GEI": {},
+      "67. \u00c9RT\u00c9KES\u00cdT\u00c9SI, FORGALMAZ\u00c1SI K\u00d6LTS\u00c9GEK": {},
+      "68. ELK\u00dcL\u00d6N\u00cdTETT EGY\u00c9B \u00c1LTL\u00c1NOS K\u00d6LTS\u00c9GEK": {
+        "681. Alap\u00edt\u00e1s-\u00e1tszervez\u00e9s k\u00f6lts\u00e9gei": {},
+        "682. Alap- \u00e9s alkalmazott kutat\u00e1s saj\u00e1t k\u00f6lts\u00e9gei": {},
+        "683. V\u00e1llalkoz\u00e1sban adott alap- \u00e9s alkalmazott kutat\u00e1s k\u00f6lts\u00e9gei": {},
+        "684. K\u00eds\u00e9rleti fejleszt\u00e9s saj\u00e1t k\u00f6lts\u00e9gei": {},
+        "685. V\u00e1llalkoz\u00e1sba adott k\u00eds\u00e9rleti fejleszt\u00e9s k\u00f6lts\u00e9gei": {},
+        "686. Kutat\u00e1s-k\u00eds\u00e9rleti fejleszt\u00e9s \u00e1ltal\u00e1nos \u00e9s k\u00f6zvetett k\u00f6lts\u00e9gei": {},
+        "687. Kutat\u00e1s-k\u00eds\u00e9rleti fejleszt\u00e9s elsz\u00e1molt \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {},
+        "688. Garanci\u00e1lis jav\u00edt\u00e1s k\u00f6lts\u00e9gei": {},
+        "689. Egy\u00e9b elk\u00fcl\u00f6n\u00edtett k\u00f6lts\u00e9gek": {}
+      },
+      "69. K\u00d6LTS\u00c9GHELYEK K\u00d6LTS\u00c9GNEMEK \u00c1TVEZET\u00c9SE": {
+        "691. K\u00f6lts\u00e9ghelyek k\u00f6lts\u00e9geinek \u00e1tvezet\u00e9se": {}
+      },
+      "rootType": "Expense"
+    },
+    "7. SZ\u00c1MLAOSZT\u00c1LY TEV\u00c9KENYS\u00c9GEKK\u00d6LTS\u00c9GEI": {
+      "isGroup": 1,
+      "rootType": "Expense"
+    },
+    "8. SZ\u00c1MLAOSZT\u00c1LY \u00c9RT\u00c9KES\u00cdT\u00c9S ELSZ\u00c1MOLT \u00d6NK\u00d6LTS\u00c9GE \u00c9S R\u00c1FORD\u00cdT\u00c1SOK": {
+      "81-83. SZ\u00c1MLACSOPORTOK (az \u00f6sszk\u00f6lts\u00e9g elj\u00e1r\u00e1ssal k\u00e9sz\u00fcl\u0151 eredm\u00e9ny-kimutat\u00e1shoz)": {
+        "81. ANYAGJELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK": {
+          "811. Anyagk\u00f6lts\u00e9g ": {},
+          "812. Ig\u00e9nybe vett szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {},
+          "813. Egy\u00e9b szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {},
+          "814. Eladott \u00e1ruk beszerz\u00e9si \u00e9rt\u00e9ke": {},
+          "815. Eladott (k\u00f6zvet\u00edtett) szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {}
+        },
+        "82. SZEM\u00c9LYI JELLEG\u00db R\u00c1FORD\u00cdT\u00c1SOK": {
+          "821. B\u00e9rk\u00f6lts\u00e9g": {},
+          "822. Szem\u00e9lyi jelleg\u0171 egy\u00e9b kifizet\u00e9sek": {},
+          "823. B\u00e9rj\u00e1rul\u00e9kok": {}
+        },
+        "83. \u00c9RT\u00c9KCS\u00d6KKEN\u00c9SI LE\u00cdR\u00c1S": {
+          "831. \u00c9rt\u00e9kcs\u00f6kken\u00e9si le\u00edr\u00e1s ": {}
+        }
+      },
+      "81-85. SZ\u00c1MLACSOPORTOK (a forgalmi k\u00f6lts\u00e9g elj\u00e1r\u00e1ssal k\u00e9sz\u00fcl\u0151 eredm\u00e9nykimutat\u00e1shoz)": {
+        "81-82. BELF\u00d6LDI \u00c9RT\u00c9KES\u00cdT\u00c9S K\u00d6ZVETLEN K\u00d6LTS\u00c9GEI": {
+          "811. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s elsz\u00e1molt k\u00f6zvetlen \u00f6nk\u00f6lts\u00e9ge": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "812. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s eladott \u00e1ruk beszerz\u00e9si \u00e9rt\u00e9ke": {
+            "accountType": "Stock Adjustment"
+          },
+          "813. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s eladott (k\u00f6zvet\u00edtett) szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {
+            "accountType": "Expenses Included In Valuation"
+          }
+        },
+        "83-84. EXPORT\u00c9RT\u00c9KES\u00cdT\u00c9S K\u00d6ZVETLEN K\u00d6LTS\u00c9GEI": {
+          "831. Export\u00e9rt\u00e9kes\u00edt\u00e9s elsz\u00e1molt k\u00f6zvetlen \u00f6nk\u00f6lts\u00e9ge": {},
+          "832. Export\u00e9rt\u00e9kes\u00edt\u00e9s eladott \u00e1ruk beszerz\u00e9si \u00e9rt\u00e9ke": {},
+          "833. Export\u00e9rt\u00e9kes\u00edt\u00e9s eladott (k\u00f6zvet\u00edtett) szolg\u00e1ltat\u00e1sok \u00e9rt\u00e9ke": {}
+        },
+        "85. \u00c9RT\u00c9KES\u00cdT\u00c9S K\u00d6ZVETETT K\u00d6LTS\u00c9GEI": {
+          "851. \u00c9rt\u00e9kes\u00edt\u00e9si, forgalmaz\u00e1si k\u00f6lts\u00e9gek": {},
+          "852. Igazgat\u00e1si k\u00f6lts\u00e9gek": {},
+          "853. Egy\u00e9b \u00e1ltal\u00e1nos k\u00f6lts\u00e9gek": {}
+        }
+      },
+      "86. EGY\u00c9B R\u00c1FORD\u00cdT\u00c1SOK": {
+        "861. Egy\u00e9b r\u00e1ford\u00edt\u00e1snak min\u0151s\u00fcl\u0151 \u00e9rt\u00e9kes\u00edt\u00e9sek": {
+          "8611. \u00c9rt\u00e9kes\u00edtett immateri\u00e1lis javak, t\u00e1rgyi eszk\u00f6z\u00f6k k\u00f6nyv szerinti \u00e9rt\u00e9ke": {},
+          "8612. \u00c9rt\u00e9kes\u00edtett, \u00e1truh\u00e1zott (engedm\u00e9nyezett) k\u00f6vetel\u00e9sek k\u00f6nyv szerinti \u00e9rt\u00e9ke": {}
+        },
+        "862. Egy\u00e9b r\u00e1ford\u00edt\u00e1snak min\u0151s\u00fcl\u0151 eszk\u00f6z kivezet\u00e9sek": {
+          "8621. Hi\u00e1nyz\u00f3, megsemmis\u00fclt, kiselejtezett immateri\u00e1lis javak, t\u00e1rgyi eszk\u00f6z\u00f6k nett\u00f3 \u00e9rt\u00e9ke": {},
+          "8622. Hi\u00e1nyz\u00f3, megsemmis\u00fclt, \u00e1llom\u00e1nyb\u00f3l kivezetett k\u00e9szletek k\u00f6nyv szerinti \u00e9rt\u00e9ke": {}
+        },
+        "863. Behajthatatlan k\u00f6vetel\u00e9sek le\u00edrt \u00f6sszege": {},
+        "864. C\u00e9ltartal\u00e9k k\u00e9pz\u00e9s": {
+          "8641. C\u00e9ltartal\u00e9k-k\u00e9pz\u00e9s a v\u00e1rhat\u00f3 k\u00f6telezetts\u00e9gekre": {},
+          "8642. C\u00e9ltartal\u00e9k-k\u00e9pz\u00e9s a j\u00f6v\u0151beni k\u00f6lts\u00e9gekre": {},
+          "8643. C\u00e9ltartal\u00e9k-k\u00e9pz\u00e9s egy\u00e9b c\u00edmen": {}
+        },
+        "865. Ut\u00f3lag adott, nem sz\u00e1ml\u00e1zott engedm\u00e9ny": {},
+        "866. Egy\u00e9b r\u00e1ford\u00edt\u00e1sk\u00e9nt elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {
+          "8661. K\u00f6zponti k\u00f6lts\u00e9gvet\u00e9ssel elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {},
+          "8662. Helyi \u00f6nkorm\u00e1nyzatokkal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {},
+          "8663. Elk\u00fcl\u00f6n\u00edtett \u00e1llami p\u00e9nzalapokkal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {},
+          "8664. T\u00e1rsadalombiztos\u00edt\u00e1ssal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {},
+          "8665. EU p\u00e9nz\u00fcgyi alapokkal elsz\u00e1molt ad\u00f3k, illet\u00e9kek, hozz\u00e1j\u00e1rul\u00e1sok": {},
+          "8666. R\u00e1ford\u00edt\u00e1sk\u00e9nt elsz\u00e1molt egy\u00e9b ad\u00f3k \u00e9s ad\u00f3jelleg\u0171 t\u00e9telek": {}
+        },
+        "867. Egy\u00e9b r\u00e1ford\u00edt\u00e1sk\u00e9nt elsz\u00e1molt, ad\u00f3nak nem min\u0151s\u00fcl\u0151 kifizet\u00e9sek": {
+          "8671. K\u00e1resem\u00e9nnyel kapcsolatos fizetett, fizetend\u0151 \u00f6sszegek": {},
+          "8672. K\u00f6lts\u00e9gek (r\u00e1ford\u00edt\u00e1sok) ellent\u00e9telez\u00e9s\u00e9re visszafizet\u00e9si k\u00f6telezetts\u00e9g n\u00e9lk\u00fcl adott t\u00e1mogat\u00e1s, juttat\u00e1": {},
+          "8673. Fejleszt\u00e9si c\u00e9lra, visszafizet\u00e9si k\u00f6telezetts\u00e9g n\u00e9lk\u00fcl adott t\u00e1mogat\u00e1s, juttat\u00e1s": {},
+          "8674. Fejleszt\u00e9si c\u00e9lra kapott t\u00e1mogat\u00e1s visszafizetend\u0151 \u00f6sszege": {},
+          "8675. Tao \u00e1ltal elismert b\u00edrs\u00e1gok, k\u00f6tb\u00e9rek, k\u00e9sedelmi kamatok, p\u00f3tl\u00e9kok, k\u00e1rt\u00e9r\u00edt\u00e9sek, s\u00e9relemd\u00edjak": {},
+          "8676. Tao \u00e1ltal el nem ismert b\u00edrs\u00e1gok, k\u00f6tb\u00e9rek, k\u00e9sedelmi kamatok, p\u00f3tl\u00e9kok, k\u00e1rt\u00e9r\u00edt\u00e9sek, s\u00e9relemd\u00edjak": {}
+        },
+        "868. Terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9sek, \u00e9rt\u00e9kveszt\u00e9sek": {
+          "8681. Immateri\u00e1lis javak terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {},
+          "8682. T\u00e1rgyi eszk\u00f6z\u00f6k terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9se": {},
+          "8683. K\u00e9szletek \u00e9rt\u00e9kveszt\u00e9se": {},
+          "8684. K\u00f6vetel\u00e9sek \u00e9rt\u00e9kveszt\u00e9se": {}
+        },
+        "869. K\u00fcl\u00f6nf\u00e9le egy\u00e9b r\u00e1ford\u00edt\u00e1sok": {
+          "8691. T\u00e1rsas\u00e1gba bevitt, \u00e9rt\u00e9kpap\u00edrnak vagy r\u00e9szesed\u00e9snek nem min\u0151s\u00fcl\u0151 vagyont.": {},
+          "8692. Ellent\u00e9telez\u00e9s n\u00e9lk\u00fcl \u00e1tv\u00e1llalt k\u00f6telezetts\u00e9g szerz\u0151d\u00e9s szerinti \u00f6sszege": {},
+          "8693. T\u00e9r\u00edt\u00e9s n\u00e9lk\u00fcl \u00e1tadott, r\u00e9szesed\u00e9snek vagy \u00e9rt\u00e9kpap\u00edrnak nem min\u0151s\u00fcl\u0151 eszk\u00f6z\u00f6k nyilv\u00e1ntart\u00e1s szerinti \u00e9rt\u00e9ke": {},
+          "8694. T\u00e9r\u00edt\u00e9s n\u00e9lk\u00fcl ny\u00fajtott szolg\u00e1ltat\u00e1sok beker\u00fcl\u00e9si \u00e9rt\u00e9ke": {},
+          "8695. Elengedett k\u00f6vetel\u00e9sek k\u00f6nyv szerinti \u00e9rt\u00e9ke": {},
+          "8696. Egy\u00e9b, vagyoncs\u00f6kken\u00e9ssel j\u00e1r\u00f3 r\u00e1ford\u00edt\u00e1sok": {}
+        }
+      },
+      "87. P\u00c9NZ\u00dcGYI M\u0170VELETEK R\u00c1FORD\u00cdT\u00c1SAI": {
+        "871. R\u00e9szesed\u00e9sekb\u0151l sz\u00e1rmaz\u00f3 r\u00e1ford\u00edt\u00e1sok, \u00e1rfolyamvesztes\u00e9gek": {},
+        "872. Befektetett p\u00e9nz\u00fcgyi eszk\u00f6z\u00f6kb\u0151l (\u00e9rt\u00e9kpap\u00edrokb\u00f3l, k\u00f6lcs\u00f6n\u00f6kb\u0151l) sz\u00e1rmaz\u00f3 r\u00e1ford\u00edt\u00e1sok \u00e1rfolyamvesztes\u00e9gek": {},
+        "873. Hitelint\u00e9zetnek fizetend\u0151 kamatok \u00e9s kamatjelleg\u0171 r\u00e1ford\u00edt\u00e1sok": {},
+        "874. Nem hitelint\u00e9zetnek fizetend\u0151 kamatok \u00e9s kamatjelleg\u0171 r\u00e1ford\u00edt\u00e1sok": {},
+        "875. R\u00e9szesed\u00e9sek, \u00e9rt\u00e9kpap\u00edrok, bankbet\u00e9tek \u00e9rt\u00e9kveszt\u00e9se \u00e9s vissza\u00edr\u00e1sa": {
+          "8751. R\u00e9szesed\u00e9sek, \u00e9rt\u00e9kpap\u00edrok, bankbet\u00e9tek \u00e9rt\u00e9kveszt\u00e9se": {},
+          "8752. R\u00e9szesed\u00e9sek, \u00e9rt\u00e9kpap\u00edrok, bankbet\u00e9tek \u00e9rt\u00e9kveszt\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {}
+        },
+        "876. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek \u00e1rfolyamvesztes\u00e9gei": {
+          "8761. Deviza- \u00e9s valutak\u00e9szletek forintra \u00e1tv\u00e1lt\u00e1s\u00e1nak \u00e1rfolyamvesztes\u00e9ge": {},
+          "8762. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek p\u00e9nz\u00fcgyileg rendezett \u00e1rfolyamvesztes\u00e9ge": {}
+        },
+        "877. P\u00e9nz\u00fcgyi m\u0171veletek egy\u00e9b r\u00e1ford\u00edt\u00e1sai": {},
+        "878. P\u00e9nz\u00fcgyi rendez\u00e9shez kapcsol\u00f3d\u00f3an adott engedm\u00e9ny": {},
+        "879. Egy\u00e9b vagyoncs\u00f6kken\u00e9ssel j\u00e1r\u00f3 p\u00e9nz\u00fcgyi r\u00e1ford\u00edt\u00e1sok": {}
+      },
+      "88. RENDK\u00cdV\u00dcLI R\u00c1FORD\u00cdT\u00c1SOK": {
+        "881. T\u00e1rsas\u00e1gba bevitt eszk\u00f6z\u00f6k nyilv\u00e1ntart\u00e1s szerinti \u00e9rt\u00e9ke": {}
+      },
+      "89. EREDM\u00c9NYT TERHEL\u0150 AD\u00d3K": {
+        "891. T\u00e1rsas\u00e1gi ad\u00f3": {},
+        "892. Egyszer\u0171s\u00edtett v\u00e1llalkoz\u00f3i ad\u00f3": {},
+        "893. Kisv\u00e1llalati ad\u00f3": {},
+        "899. Eredm\u00e9nyt terhel\u0151 egy\u00e9b ad\u00f3k": {}
+      },
+      "rootType": "Expense"
+    },
+    "9. SZ\u00c1MLAOSZT\u00c1LY BEV\u00c9TELEK": {
+      "91. BELF\u00d6LDI \u00c9RT\u00c9KES\u00cdT\u00c9S \u00c1RBEV\u00c9TELE": {
+        "911. Belf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett saj\u00e1t termel\u00e9s\u0171 k\u00e9szletek \u00e1rbev\u00e9tele": {},
+        "912. Belf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett v\u00e1s\u00e1rolt k\u00e9szletek \u00e1rbev\u00e9tele": {},
+        "913. Belf\u00f6ldinek ny\u00fajtott szolg\u00e1ltat\u00e1sok \u00e1rbev\u00e9tele": {},
+        "918. Belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9ssel kapcsolatos \u00e1rt\u00e1mogat\u00e1s": {},
+        "919. Egy\u00e9b belf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s \u00e1rbev\u00e9tele": {}
+      },
+      "92. EXPORT\u00c9RT\u00c9KES\u00cdT\u00c9S \u00c1RBEV\u00c9TELE": {
+        "921. K\u00fclf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett saj\u00e1t termel\u00e9s\u0171 k\u00e9szletek \u00e1rbev\u00e9tele": {},
+        "922. K\u00fclf\u00f6ldinek \u00e9rt\u00e9kes\u00edtett v\u00e1s\u00e1rolt k\u00e9szletek \u00e1rbev\u00e9tele": {},
+        "923. K\u00fclf\u00f6ldinek ny\u00fajtott szolg\u00e1ltat\u00e1sok \u00e1rbev\u00e9tele": {},
+        "928. K\u00fclf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9ssel kapcsolatos \u00e1rt\u00e1mogat\u00e1s": {},
+        "929. Egy\u00e9b k\u00fclf\u00f6ldi \u00e9rt\u00e9kes\u00edt\u00e9s \u00e1rbev\u00e9tele": {}
+      },
+      "96. EGY\u00c9B BEV\u00c9TELEK": {
+        "961. Egy\u00e9b bev\u00e9telnek min\u0151s\u00fcl\u0151 \u00e9rt\u00e9kes\u00edt\u00e9sek": {
+          "9611. \u00c9rt\u00e9kes\u00edtett immateri\u00e1lis javak, t\u00e1rgyi eszk\u00f6z\u00f6k ellen\u00e9rt\u00e9ke": {},
+          "9612. \u00c9rt\u00e9kes\u00edtett, \u00e1truh\u00e1zott (engedm\u00e9nyezett) k\u00f6vetel\u00e9sek ellen\u00e9rt\u00e9ke": {}
+        },
+        "963. K\u00f6vetel\u00e9s k\u00f6nyv szerinti \u00e9rt\u00e9k\u00e9t meghalad\u00f3an realiz\u00e1lt \u00f6sszeg": {},
+        "964. C\u00e9ltartal\u00e9k felold\u00e1s": {
+          "9651. V\u00e1rhat\u00f3 k\u00f6telezetts\u00e9gek fedezet\u00e9re k\u00e9pzett  c\u00e9ltartal\u00e9k felhaszn\u00e1l\u00e1sa   ": {},
+          "9652. J\u00f6v\u0151beni k\u00f6lts\u00e9gekre k\u00e9pzett c\u00e9ltartal\u00e9k felhaszn\u00e1l\u00e1sa ": {},
+          "9653. Egy\u00e9b c\u00edmen k\u00e9pzett c\u00e9ltartal\u00e9k felhaszn\u00e1l\u00e1sa ": {}
+        },
+        "965. Ut\u00f3lag kapott, nem sz\u00e1ml\u00e1zott engedm\u00e9ny": {},
+        "966. Ut\u00f3lag kapott, nem sz\u00e1ml\u00e1zott engedm\u00e9ny": {
+          "9661. K\u00f6zponti k\u00f6lts\u00e9gvet\u00e9sb\u0151l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {},
+          "9662. Helyi \u00f6nkorm\u00e1nyzatokt\u00f3l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {},
+          "9663. Eur\u00f3pai Uni\u00f3t\u00f3l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {},
+          "9664. Egy\u00e9b forr\u00e1sb\u00f3l kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {}
+        },
+        "967. Egy\u00e9b bev\u00e9telk\u00e9nt elsz\u00e1molt p\u00e9nzbev\u00e9telek": {
+          "9671. K\u00e1resem\u00e9nnyel kapcsolatos t\u00e9r\u00edt\u00e9sek": {},
+          "9672. K\u00f6lts\u00e9gek (r\u00e1ford\u00edt\u00e1sok) ellent\u00e9telez\u00e9s\u00e9re kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {},
+          "9673. Fejleszt\u00e9si c\u00e9lra kapott t\u00e1mogat\u00e1s, juttat\u00e1s": {},
+          "9674. Kapott b\u00edrs\u00e1gok, k\u00f6tb\u00e9rek, fekb\u00e9rek, k\u00e9sedelmi kamatok, k\u00e1rt\u00e9r\u00edt\u00e9sek": {}
+        },
+        "968. Terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9sek, \u00e9rt\u00e9kveszt\u00e9sek vissza\u00edr\u00e1sa": {
+          "9681. Immateri\u00e1lis javak terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {},
+          "9682. T\u00e1rgyi eszk\u00f6z\u00f6k terven fel\u00fcli \u00e9rt\u00e9kcs\u00f6kken\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {},
+          "9683. K\u00e9szletek \u00e9rt\u00e9kveszt\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {},
+          "9684. R\u00e9szesed\u00e9sek \u00e9rt\u00e9kveszt\u00e9s\u00e9nek vissza\u00edr\u00e1sa": {}
+        },
+        "969. K\u00fcl\u00f6nf\u00e9le egy\u00e9b bev\u00e9telek": {
+          "isGroup": 1
+        }
+      },
+      "97. P\u00c9NZ\u00dcGYI M\u0170VELETEK BEV\u00c9TELEI": {
+        "971. R\u00e9szesed\u00e9sekb\u0151l sz\u00e1rmaz\u00f3 bev\u00e9telek, \u00e1rfolyamnyeres\u00e9gek": {},
+        "972. Befektetett p\u00e9nz\u00fcgyi eszk\u00f6z\u00f6kb\u0151l (\u00e9rt\u00e9kpap\u00edrokb\u00f3l, k\u00f6lcs\u00f6n\u00f6kb\u0151l) sz\u00e1rmaz\u00f3 bev\u00e9telek, \u00e1rfolyamnyeres\u00e9gek": {},
+        "973. Hitelint\u00e9zett\u0151l kapott kamatok \u00e9s kamatjelleg\u0171 bev\u00e9telek": {},
+        "974. Nem hitelint\u00e9zett\u0151l kapott kamatok \u00e9s kamatjelleg\u0171 bev\u00e9telek": {},
+        "975. Kapott (j\u00e1r\u00f3) osztal\u00e9k \u00e9s r\u00e9szesed\u00e9s": {},
+        "976. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek \u00e1rfolyamnyeres\u00e9gei": {
+          "9761. Deviza- \u00e9s valutak\u00e9szletek forintra \u00e1tv\u00e1lt\u00e1s\u00e1nak \u00e1rfolyamnyeres\u00e9ge": {},
+          "9762. K\u00fclf\u00f6ldi p\u00e9nz\u00e9rt\u00e9kre sz\u00f3l\u00f3 eszk\u00f6z\u00f6k \u00e9s k\u00f6telezetts\u00e9gek p\u00e9nz\u00fcgyileg rendezett \u00e1rfolyamnyeres\u00e9ge": {}
+        },
+        "977. P\u00e9nz\u00fcgyi m\u0171veletek egy\u00e9b bev\u00e9telei": {},
+        "978. P\u00e9nz\u00fcgyi rendez\u00e9shez kapcsol\u00f3d\u00f3an kapott engedm\u00e9ny": {},
+        "979. Egy\u00e9b vagyonn\u00f6veked\u00e9ssel j\u00e1r\u00f3 p\u00e9nz\u00fcgyi bev\u00e9telek": {}
+      },
+      "rootType": "Income"
+    }
+  }
 }

--- a/fixtures/verified/id.json
+++ b/fixtures/verified/id.json
@@ -1,687 +1,687 @@
 {
-  "country_code": "id", 
-  "name": "Indonesia - Chart of Accounts", 
+  "countryCode": "id",
+  "name": "Indonesia - Chart of Accounts",
   "tree": {
-      "Aktiva": {
-          "Aktiva Lancar": {
-              "Akun sementara": {
-                  "Pembukaan sementara": {
-                      "account_number": "1171.000", 
-                      "account_type": "Temporary"
-                  }, 
-                  "account_number": "1170.000"
-              }, 
-              "Bank ": {
-                  "Bank Other Currency": {
-                      "account_number": "1122.000", 
-                      "is_group": 1
-                  }, 
-                  "Bank Rupiah": {
-                      "account_number": "1121.000", 
-                      "is_group": 1
-                  }, 
-                  "account_number": "1120.000", 
-                  "account_type": "Bank"
-              }, 
-              "Biaya di Bayar di Muka": {
-                  "Biaya di Bayar di Muka": {
-                      "Biaya di Bayar di Muka": {
-                          "Biaya d Bayar di Muka": {
-                              "account_number": "1151.00111"
-                          }, 
-                          "account_number": "1151.001"
-                      }, 
-                      "account_number": "1151.000"
-                  }, 
-                  "account_number": "1150.000"
-              }, 
-              "Kas": {
-                  "Kas Mata Uang Lain": {
-                      "Kas USD": {
-                          "account_number": "1112.0010", 
-                          "account_type": "Cash"
-                      }, 
-                      "account_number": "1112.000"
-                  }, 
-                  "Kas Rupiah": {
-                      "Kas Besar": {
-                          "account_number": "1111.0020", 
-                          "account_type": "Cash"
-                      }, 
-                      "Kas Kecil": {
-                          "account_number": "1111.0010", 
-                          "account_type": "Cash"
-                      }, 
-                      "account_number": "1111.000", 
-                      "account_type": "Cash"
-                  }, 
-                  "account_number": "1110.0000"
-              }, 
-              "Pendapatan Yang Akan di Terima": {
-                  "Pendapatan Yang di Terima": {
-                      "Pendapatan Yang Akan di Terima": {
-                          "account_number": "1161.001"
-                      }, 
-                      "account_number": "1161.000"
-                  }, 
-                  "account_number": "1160.000"
-              }, 
-              "Persediaan Barang": {
-                  "Persediaan Barang": {
-                      "account_number": "1141.000", 
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "Uang Muka Pembelian": {
-                      "Uang Muka Pembelian": {
-                          "account_number": "1142.001", 
-                          "account_type": "Bank"
-                      }, 
-                      "account_number": "1142.000"
-                  }, 
-                  "account_number": "1140.000"
-              }, 
-              "Piutang": {
-                  "Piutang Dagang": {
-                      "Piutang Dagang": {
-                          "account_number": "1131.0010", 
-                          "account_type": "Receivable"
-                      }, 
-                      "account_number": "1131.000"
-                  }, 
-                  "Piutang Lain lain": {
-                      "Piutang Lain-lain 1": {
-                          "account_number": "1132.001", 
-                          "account_type": "Receivable"
-                      }, 
-                      "account_number": "1132.000"
-                  }, 
-                  "account_number": "1130.000"
-              }, 
-              "account_number": "1100.0000"
-          }, 
-          "Aktiva Tetap": {
-              "Aktiva": {
-                  "Aktiva": {
-                      "Aktiva": {
-                          "account_number": "1211.001", 
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "account_number": "1211.000"
-                  }, 
-                  "Akumulasi Penyusutan Aktiva": {
-                      "Akumulasi Penyusutan Aktiva": {
-                          "account_number": "1212.001", 
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "account_number": "1212.000"
-                  }, 
-                  "account_number": "1210.000"
-              }, 
-              "Investasi": {
-                  "Investasi": {
-                      "Deposito": {
-                          "account_number": "1231.003", 
-                          "is_group": 1
-                      }, 
-                      "Investai Saham": {
-                          "Investasi Saham": {
-                              "account_number": "1231.0011"
-                          }, 
-                          "account_number": "1231.001"
-                      }, 
-                      "Investasi Perumahan": {
-                          "Investasi Perumahan": {
-                              "account_number": "1231.0021"
-                          }, 
-                          "account_number": "1231.002"
-                      }, 
-                      "account_number": "1231.000"
-                  }, 
-                  "account_number": "1230.000"
-              }, 
-              "account_number": "1200.000"
-          }, 
-          "account_number": "1000.0000", 
-          "root_type": "Asset"
-      }, 
-      "Beban": {
-          "Beban Lain lain": {
-              "Beban Lain lain": {
-                  "Beban Adm Bank": {
-                      "account_number": "5510.001"
-                  }, 
-                  "Beban Bunga Kredit Rekening Koran Bank": {
-                      "account_number": "5510.004"
-                  }, 
-                  "Beban Bunga Pinjaman Pada Pihak Ke 3": {
-                      "account_number": "5510.005"
-                  }, 
-                  "Beban Notaris Dan ADM Kredit Bank": {
-                      "account_number": "5510.003"
-                  }, 
-                  "Beban Pajak Bumi & Bangunan": {
-                      "account_number": "5510.006"
-                  }, 
-                  "Beban Pajak PPN": {
-                      "account_number": "5510.008"
-                  }, 
-                  "Beban Pajak Penghasilan ": {
-                      "account_number": "5510.007"
-                  }, 
-                  "Beban Provisi Pinjaman Bank": {
-                      "account_number": "5510.002"
-                  }, 
-                  "Selisih Kurs": {
-                      "account_number": "5510.010", 
-                      "account_type": "Round Off"
-                  }, 
-                  "Selisih Pembayaran Customer": {
-                      "account_number": "5510.009", 
-                      "account_type": "Round Off"
-                  }, 
-                  "account_number": "5510.000"
-              }, 
-              "account_number": "5500.000"
-          }, 
-          "Beban Langsung": {
-              "Beban Penjualan": {
-                  "Biaya Asuransi Kendaraan Operasional": {
-                      "account_number": "5110.009"
-                  }, 
-                  "Biaya BBM": {
-                      "account_number": "5110.001"
-                  }, 
-                  "Biaya Barang Rusak": {
-                      "account_number": "5110.007"
-                  }, 
-                  "Biaya Bonus, Hadiah, dan Sampel": {
-                      "account_number": "5110.013"
-                  }, 
-                  "Biaya Entertainment dan Pergaulan": {
-                      "account_number": "5110.014"
-                  }, 
-                  "Biaya Kebutuhan Penjualan": {
-                      "account_number": "5110.011"
-                  }, 
-                  "Biaya Kuli": {
-                      "account_number": "5110.005"
-                  }, 
-                  "Biaya Leasing Kendaraan Operasional": {
-                      "account_number": "5110.010"
-                  }, 
-                  "Biaya Parkir": {
-                      "account_number": "5110.003"
-                  }, 
-                  "Biaya Penjualan Lain Lain": {
-                      "account_number": "5110.019"
-                  }, 
-                  "Biaya Perbaikan Kendaraan Operasional": {
-                      "account_number": "5110.008"
-                  }, 
-                  "Biaya Perjalanan Dinas": {
-                      "account_number": "5110.006"
-                  }, 
-                  "Biaya Piutang Tak Tertagih": {
-                      "account_number": "5110.017"
-                  }, 
-                  "Biaya Sample": {
-                      "account_number": "5110.012"
-                  }, 
-                  "Biaya Sewa Gudang": {
-                      "account_number": "5110.015"
-                  }, 
-                  "Biaya Sewa Peralatan Gudang": {
-                      "account_number": "5110.016"
-                  }, 
-                  "Biaya Susut Barang": {
-                      "account_number": "5110.021"
-                  }, 
-                  "Biaya Tol": {
-                      "account_number": "5110.002"
-                  }, 
-                  "Biaya Upah Angkat/Turun Barang": {
-                      "account_number": "5110.004"
-                  }, 
-                  "Penyesuaian Stock": {
-                      "account_number": "5110.020", 
-                      "account_type": "Stock Adjustment"
-                  }, 
-                  "Potongan Supplier": {
-                      "account_number": "5110.018"
-                  }, 
-                  "account_number": "5110.000"
-              }, 
-              "Biaya Gaji & Kesejahteraan Pegawai": {
-                  "Biaya Asuransi Kesehatan Pegawai": {
-                      "account_number": "5120.004"
-                  }, 
-                  "Biaya Gaji & Kesejahteraan Lainnya": {
-                      "account_number": "5120.007"
-                  }, 
-                  "Biaya Gaji Karyawan Harian": {
-                      "account_number": "5120.002"
-                  }, 
-                  "Biaya Gaji Staff & Karyawan Tetap": {
-                      "account_number": "5120.001"
-                  }, 
-                  "Biaya Konsumsi": {
-                      "account_number": "5120.006"
-                  }, 
-                  "Biaya Pengobatan": {
-                      "account_number": "5120.003"
-                  }, 
-                  "Biaya THR, Bonus, dan Komisi": {
-                      "account_number": "5120.005"
-                  }, 
-                  "account_number": "5120.000"
-              }, 
-              "Biaya Kantor & Gudang": {
-                  "Biaya Alat Tulis Kantor": {
-                      "account_number": "5130.005"
-                  }, 
-                  "Biaya Asuransi Bangunan": {
-                      "account_number": "5130.014"
-                  }, 
-                  "Biaya Fotocopy, Photo, Print Out": {
-                      "account_number": "5130.004"
-                  }, 
-                  "Biaya Humas & Pergaulan": {
-                      "account_number": "5130.009"
-                  }, 
-                  "Biaya KTR & GDG Lain Lain": {
-                      "account_number": "5130.018"
-                  }, 
-                  "Biaya PAM Gudang & Kantor": {
-                      "account_number": "5130.002"
-                  }, 
-                  "Biaya PLN Gudang & Kantor": {
-                      "account_number": "5130.001"
-                  }, 
-                  "Biaya Pemeliharaan Bgn Gudang": {
-                      "account_number": "5130.008"
-                  }, 
-                  "Biaya Perizinan Kendaraan Operasional": {
-                      "account_number": "5130.017"
-                  }, 
-                  "Biaya Perizinan Usaha dan Bangunan": {
-                      "account_number": "5130.016"
-                  }, 
-                  "Biaya Perlengkapan Gudang": {
-                      "account_number": "5130.010"
-                  }, 
-                  "Biaya Serba Serbi": {
-                      "account_number": "5130.012"
-                  }, 
-                  "Biaya Servis Peralatan Gudang": {
-                      "account_number": "5130.007"
-                  }, 
-                  "Biaya Sewa Kantor": {
-                      "account_number": "5130.013"
-                  }, 
-                  "Biaya Stamp Duty & Pos": {
-                      "account_number": "5130.006"
-                  }, 
-                  "Biaya Sumbangan": {
-                      "account_number": "5130.015"
-                  }, 
-                  "Biaya TLP Gudang & Kantor": {
-                      "account_number": "5130.003"
-                  }, 
-                  "Iuran Bulanan": {
-                      "account_number": "5130.011"
-                  }, 
-                  "account_number": "5130.000"
-              }, 
-              "account_number": "5100.000"
-          }, 
-          "Beban Tidak Langsung": {
-              "Biaya Gaji & Kesejahteraan Pegawai Indirect": {
-                  "Biaya Gaji Lain Lain": {
-                      "account_number": "5210.005"
-                  }, 
-                  "Biaya Gaji Staff": {
-                      "account_number": "5210.001"
-                  }, 
-                  "Biaya Konsumsi": {
-                      "account_number": "5210.004"
-                  }, 
-                  "Biaya Pengobatan & Kesehatan": {
-                      "account_number": "5210.003"
-                  }, 
-                  "Biaya THR dan Bonus Staff": {
-                      "account_number": "5210.002"
-                  }, 
-                  "account_number": "5210.000"
-              }, 
-              "Biaya Kantor Indirect": {
-                  "Biaya Alat Tulis Kantor": {
-                      "account_number": "5230.006"
-                  }, 
-                  "Biaya Asuransi Bangunan": {
-                      "account_number": "5230.005"
-                  }, 
-                  "Biaya Fotocopy, Photo, Print Out": {
-                      "account_number": "5230.007"
-                  }, 
-                  "Biaya Iuran Bulanan": {
-                      "account_number": "5230.012"
-                  }, 
-                  "Biaya KTR Lain Lain": {
-                      "account_number": "5230.016"
-                  }, 
-                  "Biaya Kirim Dokumen": {
-                      "account_number": "5230.008"
-                  }, 
-                  "Biaya PAM Kantor": {
-                      "account_number": "5230.002"
-                  }, 
-                  "Biaya PLN Kantor": {
-                      "account_number": "5230.001"
-                  }, 
-                  "Biaya Pemeliharaan Bangunan Kantor": {
-                      "account_number": "5230.011"
-                  }, 
-                  "Biaya Perizinan Bangunan": {
-                      "account_number": "5230.014"
-                  }, 
-                  "Biaya Perizinan Kendaraan Dinas": {
-                      "account_number": "5230.015"
-                  }, 
-                  "Biaya Perlengkapan & Peralatan Kantor": {
-                      "account_number": "5230.009"
-                  }, 
-                  "Biaya Sewa Kantor": {
-                      "account_number": "5230.004"
-                  }, 
-                  "Biaya Stamp Duty & Pos": {
-                      "account_number": "5230.017"
-                  }, 
-                  "Biaya Sumbangan": {
-                      "account_number": "5230.013"
-                  }, 
-                  "Biaya TLP Kantor": {
-                      "account_number": "5230.003"
-                  }, 
-                  "Service Peralatan Kantor": {
-                      "account_number": "5230.010"
-                  }, 
-                  "account_number": "5230.000"
-              }, 
-              "Biaya Operational Indirect": {
-                  "Biaya Asuransi Kendaraan Dinas": {
-                      "account_number": "5220.006"
-                  }, 
-                  "Biaya BBM": {
-                      "account_number": "5220.001"
-                  }, 
-                  "Biaya Entertainment dan Pergaulan": {
-                      "account_number": "5220.008"
-                  }, 
-                  "Biaya Hadiah dan Bonus": {
-                      "account_number": "5220.009"
-                  }, 
-                  "Biaya Leasing Kendaraan Dinas": {
-                      "account_number": "5220.007"
-                  }, 
-                  "Biaya Perbaikan Kendaraan Dinas": {
-                      "account_number": "5220.005"
-                  }, 
-                  "Biaya Perjalanan Dinas": {
-                      "account_number": "5220.004"
-                  }, 
-                  "Biaya TLP & HP": {
-                      "account_number": "5220.003"
-                  }, 
-                  "Biaya Tol & Parkir": {
-                      "account_number": "5220.002"
-                  }, 
-                  "account_number": "5220.000"
-              }, 
-              "account_number": "5200.000"
-          }, 
-          "Biaya Amortisasi": {
-              "Biaya Amortisasi": {
-                  "account_number": "5410.000"
-              }, 
-              "account_number": "5400.000"
-          }, 
-          "Biaya Penyusutan": {
-              "Biaya Penyusutan": {
-                  "By Peny Aktiva ": {
-                      "account_number": "5310.001", 
-                      "account_type": "Depreciation"
-                  }, 
-                  "account_number": "5310.000"
-              }, 
-              "account_number": "5300.000"
-          }, 
-          "account_number": "5000.000", 
-          "root_type": "Expense"
-      }, 
+    "Aktiva": {
+      "Aktiva Lancar": {
+        "Akun sementara": {
+          "Pembukaan sementara": {
+            "accountNumber": "1171.000",
+            "accountType": "Temporary"
+          },
+          "accountNumber": "1170.000"
+        },
+        "Bank ": {
+          "Bank Other Currency": {
+            "accountNumber": "1122.000",
+            "isGroup": 1
+          },
+          "Bank Rupiah": {
+            "accountNumber": "1121.000",
+            "isGroup": 1
+          },
+          "accountNumber": "1120.000",
+          "accountType": "Bank"
+        },
+        "Biaya di Bayar di Muka": {
+          "Biaya di Bayar di Muka": {
+            "Biaya di Bayar di Muka": {
+              "Biaya d Bayar di Muka": {
+                "accountNumber": "1151.00111"
+              },
+              "accountNumber": "1151.001"
+            },
+            "accountNumber": "1151.000"
+          },
+          "accountNumber": "1150.000"
+        },
+        "Kas": {
+          "Kas Mata Uang Lain": {
+            "Kas USD": {
+              "accountNumber": "1112.0010",
+              "accountType": "Cash"
+            },
+            "accountNumber": "1112.000"
+          },
+          "Kas Rupiah": {
+            "Kas Besar": {
+              "accountNumber": "1111.0020",
+              "accountType": "Cash"
+            },
+            "Kas Kecil": {
+              "accountNumber": "1111.0010",
+              "accountType": "Cash"
+            },
+            "accountNumber": "1111.000",
+            "accountType": "Cash"
+          },
+          "accountNumber": "1110.0000"
+        },
+        "Pendapatan Yang Akan di Terima": {
+          "Pendapatan Yang di Terima": {
+            "Pendapatan Yang Akan di Terima": {
+              "accountNumber": "1161.001"
+            },
+            "accountNumber": "1161.000"
+          },
+          "accountNumber": "1160.000"
+        },
+        "Persediaan Barang": {
+          "Persediaan Barang": {
+            "accountNumber": "1141.000",
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "Uang Muka Pembelian": {
+            "Uang Muka Pembelian": {
+              "accountNumber": "1142.001",
+              "accountType": "Bank"
+            },
+            "accountNumber": "1142.000"
+          },
+          "accountNumber": "1140.000"
+        },
+        "Piutang": {
+          "Piutang Dagang": {
+            "Piutang Dagang": {
+              "accountNumber": "1131.0010",
+              "accountType": "Receivable"
+            },
+            "accountNumber": "1131.000"
+          },
+          "Piutang Lain lain": {
+            "Piutang Lain-lain 1": {
+              "accountNumber": "1132.001",
+              "accountType": "Receivable"
+            },
+            "accountNumber": "1132.000"
+          },
+          "accountNumber": "1130.000"
+        },
+        "accountNumber": "1100.0000"
+      },
+      "Aktiva Tetap": {
+        "Aktiva": {
+          "Aktiva": {
+            "Aktiva": {
+              "accountNumber": "1211.001",
+              "accountType": "Fixed Asset"
+            },
+            "accountNumber": "1211.000"
+          },
+          "Akumulasi Penyusutan Aktiva": {
+            "Akumulasi Penyusutan Aktiva": {
+              "accountNumber": "1212.001",
+              "accountType": "Accumulated Depreciation"
+            },
+            "accountNumber": "1212.000"
+          },
+          "accountNumber": "1210.000"
+        },
+        "Investasi": {
+          "Investasi": {
+            "Deposito": {
+              "accountNumber": "1231.003",
+              "isGroup": 1
+            },
+            "Investai Saham": {
+              "Investasi Saham": {
+                "accountNumber": "1231.0011"
+              },
+              "accountNumber": "1231.001"
+            },
+            "Investasi Perumahan": {
+              "Investasi Perumahan": {
+                "accountNumber": "1231.0021"
+              },
+              "accountNumber": "1231.002"
+            },
+            "accountNumber": "1231.000"
+          },
+          "accountNumber": "1230.000"
+        },
+        "accountNumber": "1200.000"
+      },
+      "accountNumber": "1000.0000",
+      "rootType": "Asset"
+    },
+    "Beban": {
+      "Beban Lain lain": {
+        "Beban Lain lain": {
+          "Beban Adm Bank": {
+            "accountNumber": "5510.001"
+          },
+          "Beban Bunga Kredit Rekening Koran Bank": {
+            "accountNumber": "5510.004"
+          },
+          "Beban Bunga Pinjaman Pada Pihak Ke 3": {
+            "accountNumber": "5510.005"
+          },
+          "Beban Notaris Dan ADM Kredit Bank": {
+            "accountNumber": "5510.003"
+          },
+          "Beban Pajak Bumi & Bangunan": {
+            "accountNumber": "5510.006"
+          },
+          "Beban Pajak PPN": {
+            "accountNumber": "5510.008"
+          },
+          "Beban Pajak Penghasilan ": {
+            "accountNumber": "5510.007"
+          },
+          "Beban Provisi Pinjaman Bank": {
+            "accountNumber": "5510.002"
+          },
+          "Selisih Kurs": {
+            "accountNumber": "5510.010",
+            "accountType": "Round Off"
+          },
+          "Selisih Pembayaran Customer": {
+            "accountNumber": "5510.009",
+            "accountType": "Round Off"
+          },
+          "accountNumber": "5510.000"
+        },
+        "accountNumber": "5500.000"
+      },
+      "Beban Langsung": {
+        "Beban Penjualan": {
+          "Biaya Asuransi Kendaraan Operasional": {
+            "accountNumber": "5110.009"
+          },
+          "Biaya BBM": {
+            "accountNumber": "5110.001"
+          },
+          "Biaya Barang Rusak": {
+            "accountNumber": "5110.007"
+          },
+          "Biaya Bonus, Hadiah, dan Sampel": {
+            "accountNumber": "5110.013"
+          },
+          "Biaya Entertainment dan Pergaulan": {
+            "accountNumber": "5110.014"
+          },
+          "Biaya Kebutuhan Penjualan": {
+            "accountNumber": "5110.011"
+          },
+          "Biaya Kuli": {
+            "accountNumber": "5110.005"
+          },
+          "Biaya Leasing Kendaraan Operasional": {
+            "accountNumber": "5110.010"
+          },
+          "Biaya Parkir": {
+            "accountNumber": "5110.003"
+          },
+          "Biaya Penjualan Lain Lain": {
+            "accountNumber": "5110.019"
+          },
+          "Biaya Perbaikan Kendaraan Operasional": {
+            "accountNumber": "5110.008"
+          },
+          "Biaya Perjalanan Dinas": {
+            "accountNumber": "5110.006"
+          },
+          "Biaya Piutang Tak Tertagih": {
+            "accountNumber": "5110.017"
+          },
+          "Biaya Sample": {
+            "accountNumber": "5110.012"
+          },
+          "Biaya Sewa Gudang": {
+            "accountNumber": "5110.015"
+          },
+          "Biaya Sewa Peralatan Gudang": {
+            "accountNumber": "5110.016"
+          },
+          "Biaya Susut Barang": {
+            "accountNumber": "5110.021"
+          },
+          "Biaya Tol": {
+            "accountNumber": "5110.002"
+          },
+          "Biaya Upah Angkat/Turun Barang": {
+            "accountNumber": "5110.004"
+          },
+          "Penyesuaian Stock": {
+            "accountNumber": "5110.020",
+            "accountType": "Stock Adjustment"
+          },
+          "Potongan Supplier": {
+            "accountNumber": "5110.018"
+          },
+          "accountNumber": "5110.000"
+        },
+        "Biaya Gaji & Kesejahteraan Pegawai": {
+          "Biaya Asuransi Kesehatan Pegawai": {
+            "accountNumber": "5120.004"
+          },
+          "Biaya Gaji & Kesejahteraan Lainnya": {
+            "accountNumber": "5120.007"
+          },
+          "Biaya Gaji Karyawan Harian": {
+            "accountNumber": "5120.002"
+          },
+          "Biaya Gaji Staff & Karyawan Tetap": {
+            "accountNumber": "5120.001"
+          },
+          "Biaya Konsumsi": {
+            "accountNumber": "5120.006"
+          },
+          "Biaya Pengobatan": {
+            "accountNumber": "5120.003"
+          },
+          "Biaya THR, Bonus, dan Komisi": {
+            "accountNumber": "5120.005"
+          },
+          "accountNumber": "5120.000"
+        },
+        "Biaya Kantor & Gudang": {
+          "Biaya Alat Tulis Kantor": {
+            "accountNumber": "5130.005"
+          },
+          "Biaya Asuransi Bangunan": {
+            "accountNumber": "5130.014"
+          },
+          "Biaya Fotocopy, Photo, Print Out": {
+            "accountNumber": "5130.004"
+          },
+          "Biaya Humas & Pergaulan": {
+            "accountNumber": "5130.009"
+          },
+          "Biaya KTR & GDG Lain Lain": {
+            "accountNumber": "5130.018"
+          },
+          "Biaya PAM Gudang & Kantor": {
+            "accountNumber": "5130.002"
+          },
+          "Biaya PLN Gudang & Kantor": {
+            "accountNumber": "5130.001"
+          },
+          "Biaya Pemeliharaan Bgn Gudang": {
+            "accountNumber": "5130.008"
+          },
+          "Biaya Perizinan Kendaraan Operasional": {
+            "accountNumber": "5130.017"
+          },
+          "Biaya Perizinan Usaha dan Bangunan": {
+            "accountNumber": "5130.016"
+          },
+          "Biaya Perlengkapan Gudang": {
+            "accountNumber": "5130.010"
+          },
+          "Biaya Serba Serbi": {
+            "accountNumber": "5130.012"
+          },
+          "Biaya Servis Peralatan Gudang": {
+            "accountNumber": "5130.007"
+          },
+          "Biaya Sewa Kantor": {
+            "accountNumber": "5130.013"
+          },
+          "Biaya Stamp Duty & Pos": {
+            "accountNumber": "5130.006"
+          },
+          "Biaya Sumbangan": {
+            "accountNumber": "5130.015"
+          },
+          "Biaya TLP Gudang & Kantor": {
+            "accountNumber": "5130.003"
+          },
+          "Iuran Bulanan": {
+            "accountNumber": "5130.011"
+          },
+          "accountNumber": "5130.000"
+        },
+        "accountNumber": "5100.000"
+      },
+      "Beban Tidak Langsung": {
+        "Biaya Gaji & Kesejahteraan Pegawai Indirect": {
+          "Biaya Gaji Lain Lain": {
+            "accountNumber": "5210.005"
+          },
+          "Biaya Gaji Staff": {
+            "accountNumber": "5210.001"
+          },
+          "Biaya Konsumsi": {
+            "accountNumber": "5210.004"
+          },
+          "Biaya Pengobatan & Kesehatan": {
+            "accountNumber": "5210.003"
+          },
+          "Biaya THR dan Bonus Staff": {
+            "accountNumber": "5210.002"
+          },
+          "accountNumber": "5210.000"
+        },
+        "Biaya Kantor Indirect": {
+          "Biaya Alat Tulis Kantor": {
+            "accountNumber": "5230.006"
+          },
+          "Biaya Asuransi Bangunan": {
+            "accountNumber": "5230.005"
+          },
+          "Biaya Fotocopy, Photo, Print Out": {
+            "accountNumber": "5230.007"
+          },
+          "Biaya Iuran Bulanan": {
+            "accountNumber": "5230.012"
+          },
+          "Biaya KTR Lain Lain": {
+            "accountNumber": "5230.016"
+          },
+          "Biaya Kirim Dokumen": {
+            "accountNumber": "5230.008"
+          },
+          "Biaya PAM Kantor": {
+            "accountNumber": "5230.002"
+          },
+          "Biaya PLN Kantor": {
+            "accountNumber": "5230.001"
+          },
+          "Biaya Pemeliharaan Bangunan Kantor": {
+            "accountNumber": "5230.011"
+          },
+          "Biaya Perizinan Bangunan": {
+            "accountNumber": "5230.014"
+          },
+          "Biaya Perizinan Kendaraan Dinas": {
+            "accountNumber": "5230.015"
+          },
+          "Biaya Perlengkapan & Peralatan Kantor": {
+            "accountNumber": "5230.009"
+          },
+          "Biaya Sewa Kantor": {
+            "accountNumber": "5230.004"
+          },
+          "Biaya Stamp Duty & Pos": {
+            "accountNumber": "5230.017"
+          },
+          "Biaya Sumbangan": {
+            "accountNumber": "5230.013"
+          },
+          "Biaya TLP Kantor": {
+            "accountNumber": "5230.003"
+          },
+          "Service Peralatan Kantor": {
+            "accountNumber": "5230.010"
+          },
+          "accountNumber": "5230.000"
+        },
+        "Biaya Operational Indirect": {
+          "Biaya Asuransi Kendaraan Dinas": {
+            "accountNumber": "5220.006"
+          },
+          "Biaya BBM": {
+            "accountNumber": "5220.001"
+          },
+          "Biaya Entertainment dan Pergaulan": {
+            "accountNumber": "5220.008"
+          },
+          "Biaya Hadiah dan Bonus": {
+            "accountNumber": "5220.009"
+          },
+          "Biaya Leasing Kendaraan Dinas": {
+            "accountNumber": "5220.007"
+          },
+          "Biaya Perbaikan Kendaraan Dinas": {
+            "accountNumber": "5220.005"
+          },
+          "Biaya Perjalanan Dinas": {
+            "accountNumber": "5220.004"
+          },
+          "Biaya TLP & HP": {
+            "accountNumber": "5220.003"
+          },
+          "Biaya Tol & Parkir": {
+            "accountNumber": "5220.002"
+          },
+          "accountNumber": "5220.000"
+        },
+        "accountNumber": "5200.000"
+      },
+      "Biaya Amortisasi": {
+        "Biaya Amortisasi": {
+          "accountNumber": "5410.000"
+        },
+        "accountNumber": "5400.000"
+      },
+      "Biaya Penyusutan": {
+        "Biaya Penyusutan": {
+          "By Peny Aktiva ": {
+            "accountNumber": "5310.001",
+            "accountType": "Depreciation"
+          },
+          "accountNumber": "5310.000"
+        },
+        "accountNumber": "5300.000"
+      },
+      "accountNumber": "5000.000",
+      "rootType": "Expense"
+    },
+    "Modal": {
+      "Laba": {
+        "Laba Periode Berjalan": {
+          "accountNumber": "3230.000"
+        },
+        "Laba Tahun Berjalan": {
+          "accountNumber": "3220.000"
+        },
+        "Laba di Tahan": {
+          "accountNumber": "3210.000"
+        },
+        "accountNumber": "3200.000"
+      },
       "Modal": {
-          "Laba": {
-              "Laba Periode Berjalan": {
-                  "account_number": "3230.000"
-              }, 
-              "Laba Tahun Berjalan": {
-                  "account_number": "3220.000"
-              }, 
-              "Laba di Tahan": {
-                  "account_number": "3210.000"
-              }, 
-              "account_number": "3200.000"
-          }, 
-          "Modal": {
-              "Modal di Setor": {
-                  "account_number": "3110.000"
-              }, 
-              "Prive P.Saham": {
-                  "account_number": "3120.000"
-              }, 
-              "Saldo pembukaan Equity": {
-                  "account_number": "3130.000"
-              }, 
-              "account_number": "3100.000"
-          }, 
-          "account_number": "3000.000", 
-          "root_type": "Equity"
-      }, 
-      "Passiva": {
-          "Pasiva Lancar": {
-              "Biaya Yang Akan di Bayar": {
-                  "Biaya Yang Akan di Bayar": {
-                      "Biaya Yang Akan di Bayar": {
-                          "account_number": "2131.001"
-                      }, 
-                      "account_number": "2131.000"
-                  }, 
-                  "Biaya Yang Akan di Bayar - Freight": {
-                      "Biaya Yang Akan di Bayar - Freight": {
-                          "account_number": "2132.001", 
-                          "account_type": "Expenses Included In Valuation"
-                      }, 
-                      "account_number": "2132.000"
-                  }, 
-                  "account_number": "2130.000"
-              }, 
-              "Hutang Dagang": {
-                  "Hutang Dagang Other Currency": {
-                      "Hutang Dagang Biaya Kirim Dalam Negeri": {
-                          "account_number": "2112.005", 
-                          "account_type": "Payable"
-                      }, 
-                      "Hutang Dagang Biaya Kirim Luar Negeri (SGD)": {
-                          "account_number": "2112.004", 
-                          "account_type": "Payable"
-                      }, 
-                      "Hutang Dagang Biaya Kirim Luar Negeri (USD)": {
-                          "account_number": "2112.003", 
-                          "account_type": "Payable"
-                      }, 
-                      "Hutang Dagang Luar Negeri (SGD)": {
-                          "account_number": "2112.002", 
-                          "account_type": "Payable"
-                      }, 
-                      "Hutang Dagang Luar Negeri (USD)": {
-                          "account_number": "2112.001", 
-                          "account_type": "Payable"
-                      }, 
-                      "account_number": "2112.000"
-                  }, 
-                  "Hutang Dagang Rupiah": {
-                      "HUtang Dagang Biaya Kirim Luar Negeri": {
-                          "account_number": "2111.004", 
-                          "account_type": "Payable"
-                      }, 
-                      "Hutang Dagang Biaya Kirim Dalam Negeri": {
-                          "account_number": "2111.003", 
-                          "account_type": "Payable"
-                      }, 
-                      "Hutang Dagang Dalam Negeri": {
-                          "account_number": "2111.001", 
-                          "account_type": "Payable"
-                      }, 
-                      "Hutang Dagang Luar Negeri": {
-                          "account_number": "2111.002", 
-                          "account_type": "Payable"
-                      }, 
-                      "account_number": "2111.000"
-                  }, 
-                  "Stock Diterima Tapi Tidak Ditagih": {
-                      "account_number": "2115.000", 
-                      "account_type": "Stock Received But Not Billed"
-                  }, 
-                  "account_number": "2110.000"
-              }, 
-              "Hutang Pajak": {
-                  "Hutang Pajak": {
-                      "account_number": "2141.000", 
-                      "account_type": "Payable"
-                  }, 
-                  "account_number": "2140.000"
-              }, 
-              "Pendapatan di Terima di Muka": {
-                  "Pendapatan di Terima di Muka": {
-                      "Dp Penjualan": {
-                          "account_number": "2121.001", 
-                          "account_type": "Bank"
-                      }, 
-                      "account_number": "2121.000"
-                  }, 
-                  "account_number": "2120.000"
-              }, 
-              "account_number": "2100.000"
-          }, 
-          "Passiva Tetap": {
-              "Hutang Lain Lain": {
-                  "Hutang Lain Lain": {
-                      "Hutang": {
-                          "account_number": "2241.001"
-                      }, 
-                      "account_number": "2241.000"
-                  }, 
-                  "account_number": "2240.000"
-              }, 
-              "Hutang Leasing Kendaraan": {
-                  "Hutang Leasing Kendaraan": {
-                      "Hutang Leasing Kendaraan": {
-                          "account_number": "2231.001"
-                      }, 
-                      "account_number": "2231.000"
-                  }, 
-                  "account_number": "2230.000"
-              }, 
-              "Hutang Pada Bank": {
-                  "Hutang Bank": {
-                      "Hutang": {
-                          "account_number": "2221.001"
-                      }, 
-                      "account_number": "2221.000"
-                  }, 
-                  "account_number": "2220.000"
-              }, 
-              "Hutang Pada Pihak ke 3": {
-                  "Hutang Bunga Pinjaman Pihak Ke 3 Tidak Rutin": {
-                      "Hutang Bunga": {
-                          "account_number": "2213.001"
-                      }, 
-                      "account_number": "2213.000"
-                  }, 
-                  "Pinjaman Pihak ke 3 Rutin": {
-                      "Hutang": {
-                          "account_number": "2211.001"
-                      }, 
-                      "account_number": "2211.000"
-                  }, 
-                  "Pinjaman Pihak ke 3 Tidak Rutin": {
-                      "Hutang": {
-                          "account_number": "2212.001"
-                      }, 
-                      "account_number": "2212.000"
-                  }, 
-                  "account_number": "2210.000"
-              }, 
-              "account_number": "2200.000"
-          }, 
-          "account_number": "2000.000", 
-          "root_type": "Liability"
-      }, 
-      "Penjualan": {
-          "Harga Pokok Pembelian": {
-              "HPP Pembelian": {
-                  "account_number": "4210.000", 
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "account_number": "4200.000"
-          }, 
-          "Pendapatan Lain lain": {
-              "Pendapatan Bunga Bank": {
-                  "account_number": "4410.000"
-              }, 
-              "Pendapatan Bunga Dari Pihak Ke 3": {
-                  "account_number": "4420.000"
-              }, 
-              "Pendapatan Keuntungan Penjualan Aktiva": {
-                  "account_number": "4430.000"
-              }, 
-              "Pendapatan Komisi": {
-                  "account_number": "4440.000"
-              }, 
-              "Pendapatan Lain lain": {
-                  "account_number": "4480.000"
-              }, 
-              "Pendapatan Penjualan Barang BS": {
-                  "account_number": "4470.000"
-              }, 
-              "Pendapatan Sewa Gudang": {
-                  "account_number": "4450.000"
-              }, 
-              "Pendapatan Sewa Lain lain": {
-                  "account_number": "4460.000"
-              }, 
-              "account_number": "4400.000"
-          }, 
-          "Pendapatan Service/Jasa": {
-              "Pendapatan Service": {
-                  "account_number": "4310.000"
-              }, 
-              "account_number": "4300.000"
-          }, 
-          "Penjualan Barang Dagangan": {
-              "Penjualan": {
-                  "account_number": "4110.000"
-              }, 
-              "Potongan Penjualan": {
-                  "account_number": "4130.000"
-              }, 
-              "Retur Penjualan": {
-                  "account_number": "4120.000"
-              }, 
-              "account_number": "4100.000"
-          }, 
-          "account_number": "4000.000", 
-          "root_type": "Income"
-      }
+        "Modal di Setor": {
+          "accountNumber": "3110.000"
+        },
+        "Prive P.Saham": {
+          "accountNumber": "3120.000"
+        },
+        "Saldo pembukaan Equity": {
+          "accountNumber": "3130.000"
+        },
+        "accountNumber": "3100.000"
+      },
+      "accountNumber": "3000.000",
+      "rootType": "Equity"
+    },
+    "Passiva": {
+      "Pasiva Lancar": {
+        "Biaya Yang Akan di Bayar": {
+          "Biaya Yang Akan di Bayar": {
+            "Biaya Yang Akan di Bayar": {
+              "accountNumber": "2131.001"
+            },
+            "accountNumber": "2131.000"
+          },
+          "Biaya Yang Akan di Bayar - Freight": {
+            "Biaya Yang Akan di Bayar - Freight": {
+              "accountNumber": "2132.001",
+              "accountType": "Expenses Included In Valuation"
+            },
+            "accountNumber": "2132.000"
+          },
+          "accountNumber": "2130.000"
+        },
+        "Hutang Dagang": {
+          "Hutang Dagang Other Currency": {
+            "Hutang Dagang Biaya Kirim Dalam Negeri": {
+              "accountNumber": "2112.005",
+              "accountType": "Payable"
+            },
+            "Hutang Dagang Biaya Kirim Luar Negeri (SGD)": {
+              "accountNumber": "2112.004",
+              "accountType": "Payable"
+            },
+            "Hutang Dagang Biaya Kirim Luar Negeri (USD)": {
+              "accountNumber": "2112.003",
+              "accountType": "Payable"
+            },
+            "Hutang Dagang Luar Negeri (SGD)": {
+              "accountNumber": "2112.002",
+              "accountType": "Payable"
+            },
+            "Hutang Dagang Luar Negeri (USD)": {
+              "accountNumber": "2112.001",
+              "accountType": "Payable"
+            },
+            "accountNumber": "2112.000"
+          },
+          "Hutang Dagang Rupiah": {
+            "HUtang Dagang Biaya Kirim Luar Negeri": {
+              "accountNumber": "2111.004",
+              "accountType": "Payable"
+            },
+            "Hutang Dagang Biaya Kirim Dalam Negeri": {
+              "accountNumber": "2111.003",
+              "accountType": "Payable"
+            },
+            "Hutang Dagang Dalam Negeri": {
+              "accountNumber": "2111.001",
+              "accountType": "Payable"
+            },
+            "Hutang Dagang Luar Negeri": {
+              "accountNumber": "2111.002",
+              "accountType": "Payable"
+            },
+            "accountNumber": "2111.000"
+          },
+          "Stock Diterima Tapi Tidak Ditagih": {
+            "accountNumber": "2115.000",
+            "accountType": "Stock Received But Not Billed"
+          },
+          "accountNumber": "2110.000"
+        },
+        "Hutang Pajak": {
+          "Hutang Pajak": {
+            "accountNumber": "2141.000",
+            "accountType": "Payable"
+          },
+          "accountNumber": "2140.000"
+        },
+        "Pendapatan di Terima di Muka": {
+          "Pendapatan di Terima di Muka": {
+            "Dp Penjualan": {
+              "accountNumber": "2121.001",
+              "accountType": "Bank"
+            },
+            "accountNumber": "2121.000"
+          },
+          "accountNumber": "2120.000"
+        },
+        "accountNumber": "2100.000"
+      },
+      "Passiva Tetap": {
+        "Hutang Lain Lain": {
+          "Hutang Lain Lain": {
+            "Hutang": {
+              "accountNumber": "2241.001"
+            },
+            "accountNumber": "2241.000"
+          },
+          "accountNumber": "2240.000"
+        },
+        "Hutang Leasing Kendaraan": {
+          "Hutang Leasing Kendaraan": {
+            "Hutang Leasing Kendaraan": {
+              "accountNumber": "2231.001"
+            },
+            "accountNumber": "2231.000"
+          },
+          "accountNumber": "2230.000"
+        },
+        "Hutang Pada Bank": {
+          "Hutang Bank": {
+            "Hutang": {
+              "accountNumber": "2221.001"
+            },
+            "accountNumber": "2221.000"
+          },
+          "accountNumber": "2220.000"
+        },
+        "Hutang Pada Pihak ke 3": {
+          "Hutang Bunga Pinjaman Pihak Ke 3 Tidak Rutin": {
+            "Hutang Bunga": {
+              "accountNumber": "2213.001"
+            },
+            "accountNumber": "2213.000"
+          },
+          "Pinjaman Pihak ke 3 Rutin": {
+            "Hutang": {
+              "accountNumber": "2211.001"
+            },
+            "accountNumber": "2211.000"
+          },
+          "Pinjaman Pihak ke 3 Tidak Rutin": {
+            "Hutang": {
+              "accountNumber": "2212.001"
+            },
+            "accountNumber": "2212.000"
+          },
+          "accountNumber": "2210.000"
+        },
+        "accountNumber": "2200.000"
+      },
+      "accountNumber": "2000.000",
+      "rootType": "Liability"
+    },
+    "Penjualan": {
+      "Harga Pokok Pembelian": {
+        "HPP Pembelian": {
+          "accountNumber": "4210.000",
+          "accountType": "Cost of Goods Sold"
+        },
+        "accountNumber": "4200.000"
+      },
+      "Pendapatan Lain lain": {
+        "Pendapatan Bunga Bank": {
+          "accountNumber": "4410.000"
+        },
+        "Pendapatan Bunga Dari Pihak Ke 3": {
+          "accountNumber": "4420.000"
+        },
+        "Pendapatan Keuntungan Penjualan Aktiva": {
+          "accountNumber": "4430.000"
+        },
+        "Pendapatan Komisi": {
+          "accountNumber": "4440.000"
+        },
+        "Pendapatan Lain lain": {
+          "accountNumber": "4480.000"
+        },
+        "Pendapatan Penjualan Barang BS": {
+          "accountNumber": "4470.000"
+        },
+        "Pendapatan Sewa Gudang": {
+          "accountNumber": "4450.000"
+        },
+        "Pendapatan Sewa Lain lain": {
+          "accountNumber": "4460.000"
+        },
+        "accountNumber": "4400.000"
+      },
+      "Pendapatan Service/Jasa": {
+        "Pendapatan Service": {
+          "accountNumber": "4310.000"
+        },
+        "accountNumber": "4300.000"
+      },
+      "Penjualan Barang Dagangan": {
+        "Penjualan": {
+          "accountNumber": "4110.000"
+        },
+        "Potongan Penjualan": {
+          "accountNumber": "4130.000"
+        },
+        "Retur Penjualan": {
+          "accountNumber": "4120.000"
+        },
+        "accountNumber": "4100.000"
+      },
+      "accountNumber": "4000.000",
+      "rootType": "Income"
+    }
   }
 }

--- a/fixtures/verified/in.json
+++ b/fixtures/verified/in.json
@@ -1,176 +1,176 @@
 {
-    "country_code": "in",
-    "name": "India - Chart of Accounts",
-    "tree": {
-        "Application of Funds (Assets)": {
-            "Current Assets": {
-                "Accounts Receivable": {
-                    "Debtors": {
-                        "is_group": 0,
-                        "account_type": "Receivable"
-                    }
-                },
-                "Bank Accounts": {
-                    "account_type": "Bank",
-                    "is_group": 1
-                },
-                "Cash In Hand": {
-                    "Cash": {
-                        "account_type": "Cash"
-                    },
-                    "account_type": "Cash"
-                },
-                "Loans and Advances (Assets)": {
-                    "is_group": 1
-                },
-                "Securities and Deposits": {
-                    "Earnest Money": {}
-                },
-                "Stock Assets": {
-                    "Stock In Hand": {
-                        "account_type": "Stock"
-                    },
-                    "account_type": "Stock"
-                },
-                "Tax Assets": {
-                    "is_group": 1
-                }
-            },
-            "Fixed Assets": {
-                "Capital Equipments": {
-                    "account_type": "Fixed Asset"
-                },
-                "Electronic Equipments": {
-                    "account_type": "Fixed Asset"
-                },
-                "Furnitures and Fixtures": {
-                    "account_type": "Fixed Asset"
-                },
-                "Office Equipments": {
-                    "account_type": "Fixed Asset"
-                },
-                "Plants and Machineries": {
-                    "account_type": "Fixed Asset"
-                },
-                "Buildings": {
-                    "account_type": "Fixed Asset"
-                },
-                "Accumulated Depreciations": {
-                    "account_type": "Accumulated Depreciation"
-                }
-            },
-            "Investments": {
-                "is_group": 1
-            },
-            "Temporary Accounts": {
-                "Temporary Opening": {
-                    "account_type": "Temporary"
-                }
-            },
-            "root_type": "Asset"
+  "countryCode": "in",
+  "name": "India - Chart of Accounts",
+  "tree": {
+    "Application of Funds (Assets)": {
+      "Current Assets": {
+        "Accounts Receivable": {
+          "Debtors": {
+            "isGroup": 0,
+            "accountType": "Receivable"
+          }
         },
-        "Expenses": {
-            "Direct Expenses": {
-                "Stock Expenses": {
-                    "Cost of Goods Sold": {
-                        "account_type": "Cost of Goods Sold"
-                    },
-                    "Expenses Included In Valuation": {
-                        "account_type": "Expenses Included In Valuation"
-                    },
-                    "Stock Adjustment": {
-                        "account_type": "Stock Adjustment"
-                    }
-                }
-            },
-            "Indirect Expenses": {
-                "Administrative Expenses": {},
-                "Commission on Sales": {},
-                "Depreciation": {
-                    "account_type": "Depreciation"
-                },
-                "Entertainment Expenses": {},
-                "Freight and Forwarding Charges": {
-                    "account_type": "Chargeable"
-                },
-                "Legal Expenses": {},
-                "Marketing Expenses": {},
-                "Miscellaneous Expenses": {},
-                "Office Maintenance Expenses": {},
-                "Office Rent": {},
-                "Postal Expenses": {},
-                "Print and Stationary": {},
-                "Rounded Off": {
-                    "account_type": "Round Off"
-                },
-                "Salary": {},
-                "Sales Expenses": {},
-                "Telephone Expenses": {},
-                "Travel Expenses": {},
-                "Utility Expenses": {},
-                "Write Off": {},
-                "Exchange Gain/Loss": {},
-                "Gain/Loss on Asset Disposal": {}
-            },
-            "root_type": "Expense"
+        "Bank Accounts": {
+          "accountType": "Bank",
+          "isGroup": 1
         },
-        "Income": {
-            "Direct Income": {
-                "Sales": {
-                    "account_type": "Income Account"
-                },
-                "Service": {
-                    "account_type": "Income Account"
-                },
-                "account_type": "Income Account"
-            },
-            "Indirect Income": {
-                "account_type": "Income Account",
-                "is_group": 1
-            },
-            "root_type": "Income"
+        "Cash In Hand": {
+          "Cash": {
+            "accountType": "Cash"
+          },
+          "accountType": "Cash"
         },
-        "Source of Funds (Liabilities)": {
-            "Capital Account": {
-                "Reserves and Surplus": {},
-                "Shareholders Funds": {}
-            },
-            "Current Liabilities": {
-                "Accounts Payable": {
-                    "Creditors": {
-                        "account_type": "Payable"
-                    },
-                    "Payroll Payable": {}
-                },
-                "Stock Liabilities": {
-                    "Stock Received But Not Billed": {
-                        "account_type": "Stock Received But Not Billed"
-                    }
-                },
-                "Duties and Taxes": {
-                    "TDS": {
-                        "account_type": "Tax"
-                    },
-                    "IGST": {
-                        "accountType": "Tax"
-                    },
-                    "CGST": {
-                        "accountType": "Tax"
-                    },
-                    "SGST": {
-                        "accountType": "Tax"
-                    },
-                    "Exempt": {
-                        "accountType": "Tax"
-                    }
-                },
-                "Loans (Liabilities)": {
-                    "Secured Loans": {},
-                    "Unsecured Loans": {},
-                    "Bank Overdraft Account": {}
-                }
-            },
-            "root_type": "Liability"
+        "Loans and Advances (Assets)": {
+          "isGroup": 1
+        },
+        "Securities and Deposits": {
+          "Earnest Money": {}
+        },
+        "Stock Assets": {
+          "Stock In Hand": {
+            "accountType": "Stock"
+          },
+          "accountType": "Stock"
+        },
+        "Tax Assets": {
+          "isGroup": 1
         }
+      },
+      "Fixed Assets": {
+        "Capital Equipments": {
+          "accountType": "Fixed Asset"
+        },
+        "Electronic Equipments": {
+          "accountType": "Fixed Asset"
+        },
+        "Furnitures and Fixtures": {
+          "accountType": "Fixed Asset"
+        },
+        "Office Equipments": {
+          "accountType": "Fixed Asset"
+        },
+        "Plants and Machineries": {
+          "accountType": "Fixed Asset"
+        },
+        "Buildings": {
+          "accountType": "Fixed Asset"
+        },
+        "Accumulated Depreciations": {
+          "accountType": "Accumulated Depreciation"
+        }
+      },
+      "Investments": {
+        "isGroup": 1
+      },
+      "Temporary Accounts": {
+        "Temporary Opening": {
+          "accountType": "Temporary"
+        }
+      },
+      "rootType": "Asset"
+    },
+    "Expenses": {
+      "Direct Expenses": {
+        "Stock Expenses": {
+          "Cost of Goods Sold": {
+            "accountType": "Cost of Goods Sold"
+          },
+          "Expenses Included In Valuation": {
+            "accountType": "Expenses Included In Valuation"
+          },
+          "Stock Adjustment": {
+            "accountType": "Stock Adjustment"
+          }
+        }
+      },
+      "Indirect Expenses": {
+        "Administrative Expenses": {},
+        "Commission on Sales": {},
+        "Depreciation": {
+          "accountType": "Depreciation"
+        },
+        "Entertainment Expenses": {},
+        "Freight and Forwarding Charges": {
+          "accountType": "Chargeable"
+        },
+        "Legal Expenses": {},
+        "Marketing Expenses": {},
+        "Miscellaneous Expenses": {},
+        "Office Maintenance Expenses": {},
+        "Office Rent": {},
+        "Postal Expenses": {},
+        "Print and Stationary": {},
+        "Rounded Off": {
+          "accountType": "Round Off"
+        },
+        "Salary": {},
+        "Sales Expenses": {},
+        "Telephone Expenses": {},
+        "Travel Expenses": {},
+        "Utility Expenses": {},
+        "Write Off": {},
+        "Exchange Gain/Loss": {},
+        "Gain/Loss on Asset Disposal": {}
+      },
+      "rootType": "Expense"
+    },
+    "Income": {
+      "Direct Income": {
+        "Sales": {
+          "accountType": "Income Account"
+        },
+        "Service": {
+          "accountType": "Income Account"
+        },
+        "accountType": "Income Account"
+      },
+      "Indirect Income": {
+        "accountType": "Income Account",
+        "isGroup": 1
+      },
+      "rootType": "Income"
+    },
+    "Source of Funds (Liabilities)": {
+      "Capital Account": {
+        "Reserves and Surplus": {},
+        "Shareholders Funds": {}
+      },
+      "Current Liabilities": {
+        "Accounts Payable": {
+          "Creditors": {
+            "accountType": "Payable"
+          },
+          "Payroll Payable": {}
+        },
+        "Stock Liabilities": {
+          "Stock Received But Not Billed": {
+            "accountType": "Stock Received But Not Billed"
+          }
+        },
+        "Duties and Taxes": {
+          "TDS": {
+            "accountType": "Tax"
+          },
+          "IGST": {
+            "accountType": "Tax"
+          },
+          "CGST": {
+            "accountType": "Tax"
+          },
+          "SGST": {
+            "accountType": "Tax"
+          },
+          "Exempt": {
+            "accountType": "Tax"
+          }
+        },
+        "Loans (Liabilities)": {
+          "Secured Loans": {},
+          "Unsecured Loans": {},
+          "Bank Overdraft Account": {}
+        }
+      },
+      "rootType": "Liability"
     }
+  }
 }

--- a/fixtures/verified/mx.json
+++ b/fixtures/verified/mx.json
@@ -1,602 +1,602 @@
 {
-  "country_code": "mx", 
-  "name": "Mexico - Plan de Cuentas", 
+  "countryCode": "mx",
+  "name": "Mexico - Plan de Cuentas",
   "tree": {
-      "ACTIVO": {
-          "ACTIVO CIRCULANTE": {
-              "DOCUMENTOS Y CUENTAS  POR COBRAR": {
-                  "COMPA\u00d1IAS AFILIADAS Y RELACIONADAS 1": {}, 
-                  "CUENTAS POR COBRAR ACCIONISTAS": {
-                      "CUENTAS POR COBRAR SOCIOS 1": {
-                          "account_type": "Receivable"
-                      }
-                  }, 
-                  "CUENTAS POR COBRAR EMPLEADOS": {
-                      "ANTICIPO DE NOMINA": {}, 
-                      "CUENTAS POR COBRAR EMPLEADOS 1": {
-                          "account_type": "Receivable"
-                      }, 
-                      "CUENTAS POR COBRAR SOCIOS": {
-                          "account_type": "Receivable"
-                      }, 
-                      "PRESTAMOS PERSONALES": {}, 
-                      "SEGURO DE VEHICULOS": {}, 
-                      "UTILIDADES 1": {}, 
-                      "VACACIONES 1": {}, 
-                      "VIATICOS VENDEDORES": {}
-                  }, 
-                  "CUENTAS POR COBRAR EXTERIOR": {}, 
-                  "CUENTAS POR COBRAR NACIONALES": {
-                      "COBRO ANTICIPO CLIENTES": {}, 
-                      "CUENTAS POR COBRAR CLIENTES": {
-                          "account_type": "Receivable"
-                      }, 
-                      "CUENTAS POR COBRAR DETALLISTA": {
-                          "account_type": "Receivable"
-                      }, 
-                      "CUENTAS POR COBRAR MAYORISTA": {
-                          "account_type": "Receivable"
-                      }
-                  }, 
-                  "EFECTOS POR COBRAR": {
-                      "EFECTOS POR COBRAR NACIONALES": {
-                          "account_type": "Receivable"
-                      }, 
-                      "account_type": "Receivable"
-                  }, 
-                  "INTERESES POR COBRAR": {}, 
-                  "OTRAS CUENTAS POR COBRAR 1": {
-                      "ADELANTO A PROVEEDORES": {}, 
-                      "CHEQUES DEVUELTOS": {}, 
-                      "DEPOSITOS VARIOS": {}, 
-                      "DEUDORES DIVERSOS": {
-                          "account_type": "Receivable"
-                      }, 
-                      "ENTES GUBERNAMENTALES": {}, 
-                      "RECLAMO AL BANCO": {}, 
-                      "RECLAMO AL SEGURO": {}, 
-                      "TRANSFERENCIAS BANCARIAS": {}
-                  }, 
-                  "PROVINCION INCOBRABLES NACIONAL": {
-                      "PROVINCION INCOBRABLES EXTERIOR": {}, 
-                      "PROVISION INCOBRALES NACIONALES": {}
-                  }
-              }, 
-              "EFECTIVO Y VALORES NEGOCIABLES": {
-                  "BANCOS E INSTITUCIONES FINANCIERAS EXTERIOR": {
-                      "BANCO EXTERIOR X": {}
-                  }, 
-                  "BANCOS E INTITUCIONES FINANCIERAS": {
-                      "BANCO X MXN": {}, 
-                      "BANCO X USD": {}, 
-                      "account_type": "Bank"
-                  }, 
-                  "CAJAS": {
-                      "CAJA CHICA": {
-                          "account_type": "Cash"
-                      }, 
-                      "CAJA PRINCIPAL": {
-                          "account_type": "Cash"
-                      }, 
-                      "FONDO A DEPOSITAR": {}, 
-                      "account_type": "Cash"
-                  }, 
-                  "INVERSIONES A CORTO PLAZO": {
-                      "INVERSIONES EN BONOS M.E.": {}, 
-                      "INVERSIONES EN BONOS M.N. 1": {}, 
-                      "INVERSIONES TEMPORALES": {}, 
-                      "PAPELES COMERCIALES": {}
-                  }
-              }, 
-              "GASTOS OPERACIONALES": {
-                  "GASTOS PREPAGADOS OPERATIVOS": {
-                      "ALQUILERES 1": {}, 
-                      "PUBLICIDAD": {}, 
-                      "SEGURO PREPAGADOS": {}
-                  }
-              }, 
-              "IMPUESTOS PAGADOS POR ANTICIPADOS": {
-                  "IMPUESTOS": {
-                      "IETU PAGADO": {}, 
-                      "IMPUESTO MUNICIPAL PAGADO EN EXCESO": {}, 
-                      "ISR  DECLARACION ESTIMADAS": {}, 
-                      "ISR  RETENIDO": {}, 
-                      "ISR PAGADO": {}, 
-                      "IVA . CREDITO FISCAL IMPORTACION": {}, 
-                      "IVA ACREDITABLE o PAGADO A PROVEEDORES": {}, 
-                      "IVA EFECTIVAMENTE PAGADO": {}, 
-                      "PATENTE  MUNICIPAL ESTIMADA": {}
-                  }
-              }, 
-              "INVENTARIOS": {
-                  "account_type": "Stock", 
-                  "is_group": 1
-              }
-          }, 
-          "ACTIVO LARGO PLAZO": {
-              "ACTIVO FIJO NETO": {
-                  "ACTIVO FIJO": {
-                      "INMUEBLES COSTO ORIGINAL": {
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "LICENCIA Y SOFTWARE COSTO ORIGINAL": {}, 
-                      "MAQUINARIAS Y EQUIPOS COSTO ORIGINAL": {
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "MUEBLES Y ENSERES COSTO ORIGINAL": {
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "TERRENO COSTO ORIGINAL": {}, 
-                      "VEHICULOS COSTO ORIGINAL": {
-                          "account_type": "Fixed Asset"
-                      }, 
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "DEPRECIACION Y AMORTIZACION ACUMULADAS": {
-                      "INMUEBLES COSTO ORIGINAL 1": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "LICENCIA Y SOFTWARE COSTO ORIGINAL 1": {}, 
-                      "MAQUINARIAS Y EQUIPOS COSTO ORIGINAL 1": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "MEJORAS A PROPIEDAD COSTO ORIGINAL": {}, 
-                      "MUEBLES Y ENSERES COSTO ORIGINAL 1": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "TERRENOS COSTO ORIGINAL": {}, 
-                      "VEHICULOS COSTO ORIGINAL 1": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "account_type": "Accumulated Depreciation"
-                  }
-              }, 
-              "CARGOS DIFERIDOS": {
-                  "CARGOS DIFERIDOS 1": {
-                      "GASTOS DE CONSTITUCION": {}, 
-                      "MARCA DE FABRICA": {}, 
-                      "OTRAS CUENTAS POR COBRAR": {
-                          "account_type": "Receivable"
-                      }
-                  }
-              }, 
-              "IMPUESTOS DIFERIDOS": {
-                  "IMPUESTOS DIFERIDOS ISR ": {
-                      "IMPUESTOS DIFERIDOS ISR  1": {}
-                  }
-              }, 
-              "INVERSIONES LARGO PLAZO": {
-                  "TITULOS DE VALORES": {
-                      "BONOS TITULOS": {}, 
-                      "INVERSIONES EN BONOS M.N.": {}, 
-                      "INVERSIONES PERMANENTES": {}
-                  }
-              }, 
-              "OTROS ACTIVOS": {
-                  "OTROS ACTIVOS 1": {
-                      "DEPOSITOS GARANTIA ARRENDAMIENTO LOCAL": {}, 
-                      "DEPOSITOS GARANTIA BANCOS": {}, 
-                      "DEPOSITOS GARANTIA PROVEEDORES": {}
-                  }
-              }
-          }, 
-          "root_type": "Asset"
-      }, 
-      "CAPITAL": {
-          "CAPITAL SOCIAL": {
-              "ACCIONES EN TESORERIA": {
-                  "ACCIONES EN TESORERIA 1": {
-                      "ACCIONES EN TESORERIA 2": {}, 
-                      "ACTUALIZACION DE VALOR": {}
-                  }
-              }, 
-              "CAPITAL SOCIAL PAGADO": {
-                  "CAPITAL SOCIAL PAGADO 1": {
-                      "ACTUALIZACION DEL VALOR 1": {}, 
-                      "CAPITAL SOCIAL 1": {}
-                  }
-              }
-          }, 
-          "GANANCIAS Y PERDIDAS": {
-              "GANACIAS Y PERDIDAS": {
-                  "GANACIAS Y PERDIDAS 1": {}
-              }
-          }, 
-          "RESERVA DE CAPITAL": {
-              "OTRAS RESERVAS": {
-                  "OTRAS RESERVAS 1": {
-                      "ACTUALIZACION DEL VALOR": {}, 
-                      "VALOR ORIGINAL": {}
-                  }
-              }, 
-              "RESERVA LEGAL": {
-                  "RESERVA LEGAL 1": {
-                      "RESERVA P/FUTURO AUMENTO DE CAPITAL": {}, 
-                      "VALOR ORIGINAL RESERVA LEGAL": {}
-                  }
-              }
-          }, 
-          "SUPERAVIT": {
-              "RESULT.POR TENDENCIA DE ACTIVO NO MONETARIOS": {
-                  "RESULT.POR TENDENCIA DE ACTIVO NO MONETARIOS 1": {}
-              }, 
-              "SUPERAVIT GANADO": {
-                  "RESULTADO POR EXPOS. A LA INFLACION": {
-                      "ACTUALIZACION DEL PATRIMONIO": {}, 
-                      "EXCLUSIONES FISCALES": {}, 
-                      "REAJUSTE POR INFLACION": {}
-                  }, 
-                  "SUPERAVIT OPERATIVO": {
-                      "UTILIDADES DEL EJERCICIO": {}, 
-                      "UTILIDADES NO DISTRIBUIDAS": {}
-                  }
-              }
-          }, 
-          "root_type": "Equity"
-      }, 
-      "COSTO": {
-          " Gastos incluidos en la valoraci\u00f3n": {
-              "account_type": "Expenses Included In Valuation"
-          }, 
-          "COSTO DE VENTAS": {
-              "account_type": "Cost of Goods Sold"
-          }, 
-          "root_type": "Expense"
-      }, 
-      "CUENTAS DE ORDEN": {
-          "CUENTAS DE ORDEN 1": {
-              "CUENTAS DE ORDEN DEUDORAS": {
-                  "CUENTAS DE ORDEN DEUDORAS 1": {
-                      "CARTAS DE CREDITOS": {}, 
-                      "MERCANCIAS COMPRADAS EN TRANSITO": {}, 
-                      "MERCANCIAS EN CONSIGNACION": {}
-                  }
-              }
-          }, 
-          "CUENTAS DE ORDEN ACREEDORAS": {
-              "CUENTAS DE ORDEN ACREEDORAS 1": {
-                  "CUENTAS DE ORDEN ACREEDORAS 2": {
-                      "MERCANCIA EN CONSIGNACION P. COMPRA": {}, 
-                      "MERCANCIA VENDIDAS EN TRANSITO": {}
-                  }
-              }
-          }, 
-          "root_type": "Asset"
-      }, 
-      "GASTOS": {
-          "GASTOS OPERATIVOS": {
-              "DEPRECIACION Y AMORTIZACION": {
-                  "AMORTIZACION": {
-                      "SEGUROS": {}
-                  }, 
-                  "DEPRECIACION": {
-                      "INMUEBLES": {}, 
-                      "LICENCIA Y SOFTWARE": {}, 
-                      "MAQUINARIAS Y EQUIPOS": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "MEJORAS A PROPIEDAD": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "MUEBLES Y ENSERES": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "VEHICULOS": {
-                          "account_type": "Depreciation"
-                      }, 
-                      "account_type": "Depreciation"
-                  }
-              }, 
-              "GASTOS COMERCIALIZACION": {
-                  "GASTOS DE DISTRIBUCION": {
-                      "ACTIVIDADES REGIONALES": {}, 
-                      "CUENTAS INCOBRABLES NACIONALES": {}, 
-                      "DISTRIBUCION Y REPARTO LOCALES": {}, 
-                      "EVENTOS ESPECIALES": {}, 
-                      "MATERIALES PROMOCIONALES": {}, 
-                      "MEDIOS": {}, 
-                      "PATENTE INDUSTRIA Y COMERCIO 1": {}, 
-                      "PRODUCCION MATERIAL P.O.P.": {}, 
-                      "PROMOCIONES": {}, 
-                      "PUBLICIDAD 1": {}, 
-                      "TRANSPORTE Y FLETES": {}
-                  }
-              }, 
-              "GASTOS DE PERSONAL": {
-                  "GASTOS PERSONAL": {
-                      "BENEFICIOS ADIESTRAMIENTOS-CURSOS": {}, 
-                      "BENEFICIOS AYUDAS ESCOLARES": {}, 
-                      "BENEFICIOS BECAS": {}, 
-                      "BENEFICIOS COMEDOR": {}, 
-                      "BENEFICIOS SERVICIOS MEDICOS": {}, 
-                      "BENEFICIOS UNIFORMES": {}, 
-                      "BONIFICACION UNICA ESPECIAL 1": {}, 
-                      "BONO VACACIONAL": {}, 
-                      "COMISION AL PERSONAL": {}, 
-                      "CONTRIBUCIONES": {}, 
-                      "GASTOS PERSONAL CONTRATADO": {}, 
-                      "GASTOS PERSONAL TRANSFERIDOSR": {}, 
-                      "HONORARIOS POR PARTIPACION JUNTA DIRECTIVA": {}, 
-                      "HORAS EXTRAORDINARIAS": {}, 
-                      "HORAS EXTRAS": {}, 
-                      "INTERESES S/PRESTACIONES SOCIALES 2": {}, 
-                      "PRESTACIONES SOCIALES 1": {}, 
-                      "PRIMA POR RENDIMIENTO": {}, 
-                      "PROGRAMA DE ALIMENTACION EMPLEADOS": {}, 
-                      "SUELDOS DIRECTIVOS": {}, 
-                      "SUELDOS EMPLEADOS": {}, 
-                      "TRANSPORTE Y ALIMENTACION": {}, 
-                      "UTILIDADES 2": {}, 
-                      "VACACIONES 2": {}, 
-                      "VIATICOS Y GASTOS DE REPRESENTACION": {}
-                  }
-              }, 
-              "GASTOS GENERALES": {
-                  "GASTOS GENERALES 1": {
-                      "AGUA POTABLE Y REFRIGERIO": {}, 
-                      "AJUSTE DE INVENTARIOS DONADOS": {
-                          "account_type": "Stock Adjustment"
-                      }, 
-                      "AJUSTE DE INVENTARIOS OBSOLETOS": {
-                          "account_type": "Stock Adjustment"
-                      }, 
-                      "ARRENDAMIENTO": {}, 
-                      "ARTICULOS DE OFICINA": {}, 
-                      "ASEO URBANO": {}, 
-                      "ASEO Y LIMPIEZA": {}, 
-                      "ASIMILABLES A SALARIOS": {}, 
-                      "AVERIAS-PRODUCTOS": {}, 
-                      "BONIFICACION UNICA ESPECIAL": {}, 
-                      "COMBUSTIBLES": {}, 
-                      "COMIDAS, VIAJES Y TRASLADOS": {}, 
-                      "CONDOMINIOS 1": {}, 
-                      "CONVENSION  DE COMERCIALIZACION": {}, 
-                      "DERECHO DE FRENTE": {}, 
-                      "ENERGIA ELECTRICA": {}, 
-                      "EQUIPOS Y EVENTOS DEPORTIVOS": {}, 
-                      "ESTACIONAMINETO": {}, 
-                      "FLETES Y TRANSPORTES": {}, 
-                      "GASTOS DE ISR ": {}, 
-                      "GASTOS DE REPRESENTACION": {}, 
-                      "GASTOS DE SISTEMAS": {}, 
-                      "HONORARIOS PROFESIONALES": {}, 
-                      "HOSPEDAJE": {}, 
-                      "MANTENIMIENTO DE VEHICULOS": {}, 
-                      "MANTENIMIENTOS": {}, 
-                      "OTROS GASTOS": {}, 
-                      "PALERIA Y FOTOCOPIADO": {}, 
-                      "PARTIDAS NO DEDUCIBLES": {}, 
-                      "PASAJE EXTERIOR NO DEDUCIBLE": {}, 
-                      "PASAJES LOCALES Y EXT.DEDUCIBLES": {}, 
-                      "REMANENTES DISTRIBUIBLES": {}, 
-                      "REPARACIONES": {}, 
-                      "REPAROS": {}, 
-                      "SEGUROS 1": {}, 
-                      "SERVICIOS CONTRATADOS A TERCEROS": {}, 
-                      "SERVICIOS DE PUBLICIDAD": {}, 
-                      "SERVICIOS PUBLICOS": {}, 
-                      "SUMINISTROS DE EQUIPOS DE OFICINA": {}, 
-                      "TELEFONOS Y TELECOMUNICACIONES": {}, 
-                      "TRAMITES DE SOLVENCIAS": {}, 
-                      "TRAMITES LEGALES": {}, 
-                      "UTILES DE LIMPIEZA": {}, 
-                      "VIATICOS DEDUCIBLES": {}, 
-                      "VIATICOS NO DEDUCIBLES": {}
-                  }
-              }
-          }, 
-          "root_type": "Expense"
-      }, 
-      "INGRESOS": {
-          "INGRESOS OPERACIONALES": {
-              "INGRESOS OPERACIONALES 1": {
-                  "DESCUENTOS Y DEVOLUCION EN VENTAS": {
-                      "DESCUENTOS EN VENTAS": {}, 
-                      "DEVOLUCIONES EN VENTAS": {}
-                  }, 
-                  "INGRESOS POR SERVICIOS": {
-                      "INGRESOS POR SERVICIOS 1": {}
-                  }, 
-                  "VENTAS": {
-                      "VENTAS EXPORTACION": {}, 
-                      "VENTAS INMUEBLES": {}, 
-                      "VENTAS NACIONALES": {}, 
-                      "VENTAS NACIONALES AL DETAL": {}
-                  }
-              }
-          }, 
-          "root_type": "Income"
-      }, 
-      "OTROS INGRESOS (EGRESOS)": {
-          "EGRESOS": {
-              "GASTOS FINANCIEROS": {
-                  "EGRESOS NO GRAVABLES": {
-                      "IMPUESTOS A LAS TRANSACIONES FINANCIERAS": {}
-                  }, 
-                  "GASTOS FINANCIEROS 1": {
-                      "COMISIONES TICKET DE ALIMENTACION": {}, 
-                      "COMISIONES Y GASTOS BANCARIOS": {}, 
-                      "INTERESES BANCOS NACIONALES": {}, 
-                      "INTERESES POR FINANCIAMIENTOS": {}, 
-                      "OTROS EGRESOS": {}
-                  }, 
-                  "OTROS EGRESOS 1": {
-                      "AJUSTE DE A\u00d1OS ANTERIORES": {}, 
-                      "FLUCTUACION CAMBIARIA NO REALIZADAS": {}, 
-                      "INTERESES S/PRESTACIONES SOCIALES 1": {}, 
-                      "PERDIDA POR ROBO DE INVENTARIO": {}, 
-                      "PERDIDAS EN DIFERENCIAL CAMBIARIO": {}, 
-                      "PERDIDAS EN INVERSIONES DE BONOS P.": {}, 
-                      "PERDIDAS EN VENTAS ACTIVOS FIJOS": {}, 
-                      "PERDIDAS EN VENTAS DE INVERSIONES": {}
-                  }
-              }
-          }, 
-          "OTROS INGRESOS": {
-              "OTROS INGRESOS 1": {
-                  "INGRESOS FINANCIEROS": {
-                      "INTERESES DE BANCOS EXTRANJEROS": {}, 
-                      "INTERESES DE BANCOS NACIONALES": {}, 
-                      "OTROS INGRESOS FINANCIEROS": {}
-                  }, 
-                  "OTROS INGRESOS 2": {
-                      "GANANCIAS EN DIFERENCIAL CAMBIARIO": {}, 
-                      "GANANCIAS EN VENTAS DE ACTIVOS FIJOS": {}, 
-                      "GANANCIAS EN VENTAS DE INVERSIONES": {}, 
-                      "INTERESES VARIOS": {}, 
-                      "OTROS INGRESOS 3": {}
-                  }
-              }
-          }, 
-          "root_type": "Income"
-      }, 
-      "PASIVO": {
-          " Stock recibidas, pero no facturada": {
-              "account_type": "Stock Received But Not Billed"
-          }, 
-          "OTROS PASIVOS A CORTO PLAZO": {
-              "OTROS PASIVOS A CORTO PLAZO 1": {
-                  "IMPUESTOS POR PAGAR": {
-                      "1% DE RET CEDULAR ARRENDAMIETOS (GUANAJUATO)": {}, 
-                      "10% ISR RETENIDO ARRENDAMIENTO": {}, 
-                      "10% ISR RETENIDO HONORARIOS": {}, 
-                      "10.67%  IVA RETENIDO ARRENDAMIENTO": {}, 
-                      "10.67%  IVA RETENIDO HONORARIOS": {}, 
-                      "4% IVA RETENIDO FLETES": {}, 
-                      "ISR RETENIDO ASIMILABLES": {}, 
-                      "ISR RETENIDO SALARIOS": {}, 
-                      "PASIVOS A  CORTO PLAZO": {}
-                  }, 
-                  "IVA TRASLADADO": {
-                      "IVA POR TRASLADAR o COBRADO": {}
-                  }
-              }
-          }, 
-          "PASIVO A CORTO PLAZO": {
-              "ACUMULACIONES LABORALES": {
-                  "APORTES EMPLEADOS": {
-                      "APORTES EMPLEADOS 1": {}, 
-                      "FONDO DE AHORRO": {}, 
-                      "FONDO FIDEICOMISO": {}
-                  }
-              }, 
-              "DIVIDENDO POR PAGAR": {
-                  "DIVIDENDO POR PAGAR 1": {
-                      "DIVDENDO POR COBRAR NO COBRADOS": {}, 
-                      "DIVIDENDO POR PAGAR VIGENTES": {}
-                  }
-              }, 
-              "DOCUMENTOS Y CUENTAS POR PAGAR": {
-                  "COMPA\u00d1IAS AFILIADAS Y RELACIONADAS": {}, 
-                  "CUENTAS POR PAGAR ACCIONISTAS": {
-                      "CUENTAS POR PAGAR SOCIOS": {
-                          "account_type": "Payable"
-                      }, 
-                      "account_type": "Payable"
-                  }, 
-                  "PROVEEDORES EXTRANJEROS": {}, 
-                  "PROVEEDORES OCASIONALES": {
-                      "CUENTAS POR PAGAR PROVEEDORES": {
-                          "account_type": "Payable"
-                      }, 
-                      "OTRAS CUENTAS POR PAGAR": {
-                          "account_type": "Payable"
-                      }, 
-                      "TARJETA DE CREDITO X": {
-                          "account_type": "Payable"
-                      }, 
-                      "account_type": "Payable"
-                  }, 
-                  "account_type": "Payable"
-              }, 
-              "GASTOS ACUMULADOS Y RETENCIONES POR PAGAR": {
-                  "CONTRIBUCIONES PATRONAL": {
-                      "APORTE EMPRESA": {}
-                  }, 
-                  "OTRAS ACUMULACIONES": {
-                      "ADELANTO DE CLIENTES": {}, 
-                      "ALQUILERES": {}, 
-                      "BONIFICACION ACCIDENTAL UNICA": {}, 
-                      "COMISIONES": {}, 
-                      "CONDOMINIOS": {}, 
-                      "CONVESION DE COMERCIALIZACION": {}, 
-                      "IMPUESTOS MUNICIPALES POR PAGAR": {
-                          "account_type": "Payable"
-                      }, 
-                      "IMPUESTOS POR PAGAR 1": {
-                          "account_type": "Tax"
-                      }, 
-                      "INTERESES S/PRESTACIONES SOCIALES": {}, 
-                      "NOMINA POR PAGAR": {
-                          "account_type": "Payable"
-                      }, 
-                      "PATENTE INDUSTRIA Y COMERCIO": {}, 
-                      "POLIZA DE SEGURO POR PAGAR": {
-                          "account_type": "Payable"
-                      }, 
-                      "PRESTACIONES SOCIALES": {}, 
-                      "PRIMA POR EFECIENCIA": {}, 
-                      "PROGRAMA DE ALIMENTACION": {}, 
-                      "PUBLICIDAD Y PROPAGANDA": {}, 
-                      "TARJETA CORPORATIVA": {}, 
-                      "UTILIDADES": {}, 
-                      "VACACIONES": {}
-                  }, 
-                  "RETENCIONES E IMPUESTOS POR PAGAR": {
-                      "IVA  DEBITO FISCAL": {}, 
-                      "RETENCIONES ISR  EMPLEADOS": {}, 
-                      "RETENCIONES ISR  PROVEEDORES": {}
-                  }, 
-                  "RETENCIONES VARIAS": {
-                      "EMBARGO DE SUELDO": {}, 
-                      "PRESTAMOS SOBRE FIDEICOMISO": {}, 
-                      "SINDICATOS": {}
-                  }
-              }, 
-              "IMPUESTOS SOBRE LA RENTA POR PAGAR": {
-                  "ISR  ACUMULADOS GASTOS": {
-                      "DECLARACION ESTIMADAS": {}, 
-                      "ISR  ACUMULADOS GASTOS 1": {}, 
-                      "RAR AJUSTE INICIAL POR INFLACION": {}
-                  }
-              }, 
-              "PASIVOS FINACIEROS A CORTO PLAZO": {
-                  "PASIVOS FINANCIEROS A CORTO PLAZO": {
-                      "BANCO X": {}
-                  }
-              }, 
-              "RESERVAS": {
-                  "RESERVAS 1": {
-                      "RESERVAS FINANCIERAS": {}, 
-                      "RESERVAS FISCALES": {}, 
-                      "RESERVAS OPERATIVAS": {}
-                  }
-              }
-          }, 
-          "PASIVO A LARGO PLAZO": {
-              "ACUMULACIONES PARA INDEMNIZ. LABORALES": {
-                  "ACUMULACIONES PARA INDEMNIZ.LABORALES": {
-                      "INDEMNIZACIONES DOBLES": {}, 
-                      "INDEMNIZACIONES SENCILLAS": {}
-                  }
-              }, 
-              "OTROS PASIVOS A LARGO PLAZO": {
-                  "OTROS PASIVOS A LARGO PLAZO 1": {
-                      "OTROS PASIVOS A LARGO PLAZO 2": {}
-                  }
-              }, 
-              "PASIVOS FINANCIEROS A LARGO PLAZO": {
-                  "PASIVOS FINANCIEROS A LARGO PLAZO 1": {
-                      "PASIVOS FINANCIEROS A LARGO PLAZO 2": {}
-                  }
-              }, 
-              "PASIVOS INTERCOMPA\u00d1IAS": {
-                  "PASIVOS INTERCOMPA\u00d1IAS 1": {
-                      "PASIVOS INTERCOMPA\u00d1IAS 2": {}
-                  }
-              }
-          }, 
-          "root_type": "Liability"
-      }
+    "ACTIVO": {
+      "ACTIVO CIRCULANTE": {
+        "DOCUMENTOS Y CUENTAS  POR COBRAR": {
+          "COMPA\u00d1IAS AFILIADAS Y RELACIONADAS 1": {},
+          "CUENTAS POR COBRAR ACCIONISTAS": {
+            "CUENTAS POR COBRAR SOCIOS 1": {
+              "accountType": "Receivable"
+            }
+          },
+          "CUENTAS POR COBRAR EMPLEADOS": {
+            "ANTICIPO DE NOMINA": {},
+            "CUENTAS POR COBRAR EMPLEADOS 1": {
+              "accountType": "Receivable"
+            },
+            "CUENTAS POR COBRAR SOCIOS": {
+              "accountType": "Receivable"
+            },
+            "PRESTAMOS PERSONALES": {},
+            "SEGURO DE VEHICULOS": {},
+            "UTILIDADES 1": {},
+            "VACACIONES 1": {},
+            "VIATICOS VENDEDORES": {}
+          },
+          "CUENTAS POR COBRAR EXTERIOR": {},
+          "CUENTAS POR COBRAR NACIONALES": {
+            "COBRO ANTICIPO CLIENTES": {},
+            "CUENTAS POR COBRAR CLIENTES": {
+              "accountType": "Receivable"
+            },
+            "CUENTAS POR COBRAR DETALLISTA": {
+              "accountType": "Receivable"
+            },
+            "CUENTAS POR COBRAR MAYORISTA": {
+              "accountType": "Receivable"
+            }
+          },
+          "EFECTOS POR COBRAR": {
+            "EFECTOS POR COBRAR NACIONALES": {
+              "accountType": "Receivable"
+            },
+            "accountType": "Receivable"
+          },
+          "INTERESES POR COBRAR": {},
+          "OTRAS CUENTAS POR COBRAR 1": {
+            "ADELANTO A PROVEEDORES": {},
+            "CHEQUES DEVUELTOS": {},
+            "DEPOSITOS VARIOS": {},
+            "DEUDORES DIVERSOS": {
+              "accountType": "Receivable"
+            },
+            "ENTES GUBERNAMENTALES": {},
+            "RECLAMO AL BANCO": {},
+            "RECLAMO AL SEGURO": {},
+            "TRANSFERENCIAS BANCARIAS": {}
+          },
+          "PROVINCION INCOBRABLES NACIONAL": {
+            "PROVINCION INCOBRABLES EXTERIOR": {},
+            "PROVISION INCOBRALES NACIONALES": {}
+          }
+        },
+        "EFECTIVO Y VALORES NEGOCIABLES": {
+          "BANCOS E INSTITUCIONES FINANCIERAS EXTERIOR": {
+            "BANCO EXTERIOR X": {}
+          },
+          "BANCOS E INTITUCIONES FINANCIERAS": {
+            "BANCO X MXN": {},
+            "BANCO X USD": {},
+            "accountType": "Bank"
+          },
+          "CAJAS": {
+            "CAJA CHICA": {
+              "accountType": "Cash"
+            },
+            "CAJA PRINCIPAL": {
+              "accountType": "Cash"
+            },
+            "FONDO A DEPOSITAR": {},
+            "accountType": "Cash"
+          },
+          "INVERSIONES A CORTO PLAZO": {
+            "INVERSIONES EN BONOS M.E.": {},
+            "INVERSIONES EN BONOS M.N. 1": {},
+            "INVERSIONES TEMPORALES": {},
+            "PAPELES COMERCIALES": {}
+          }
+        },
+        "GASTOS OPERACIONALES": {
+          "GASTOS PREPAGADOS OPERATIVOS": {
+            "ALQUILERES 1": {},
+            "PUBLICIDAD": {},
+            "SEGURO PREPAGADOS": {}
+          }
+        },
+        "IMPUESTOS PAGADOS POR ANTICIPADOS": {
+          "IMPUESTOS": {
+            "IETU PAGADO": {},
+            "IMPUESTO MUNICIPAL PAGADO EN EXCESO": {},
+            "ISR  DECLARACION ESTIMADAS": {},
+            "ISR  RETENIDO": {},
+            "ISR PAGADO": {},
+            "IVA . CREDITO FISCAL IMPORTACION": {},
+            "IVA ACREDITABLE o PAGADO A PROVEEDORES": {},
+            "IVA EFECTIVAMENTE PAGADO": {},
+            "PATENTE  MUNICIPAL ESTIMADA": {}
+          }
+        },
+        "INVENTARIOS": {
+          "accountType": "Stock",
+          "isGroup": 1
+        }
+      },
+      "ACTIVO LARGO PLAZO": {
+        "ACTIVO FIJO NETO": {
+          "ACTIVO FIJO": {
+            "INMUEBLES COSTO ORIGINAL": {
+              "accountType": "Fixed Asset"
+            },
+            "LICENCIA Y SOFTWARE COSTO ORIGINAL": {},
+            "MAQUINARIAS Y EQUIPOS COSTO ORIGINAL": {
+              "accountType": "Fixed Asset"
+            },
+            "MUEBLES Y ENSERES COSTO ORIGINAL": {
+              "accountType": "Fixed Asset"
+            },
+            "TERRENO COSTO ORIGINAL": {},
+            "VEHICULOS COSTO ORIGINAL": {
+              "accountType": "Fixed Asset"
+            },
+            "accountType": "Fixed Asset"
+          },
+          "DEPRECIACION Y AMORTIZACION ACUMULADAS": {
+            "INMUEBLES COSTO ORIGINAL 1": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "LICENCIA Y SOFTWARE COSTO ORIGINAL 1": {},
+            "MAQUINARIAS Y EQUIPOS COSTO ORIGINAL 1": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "MEJORAS A PROPIEDAD COSTO ORIGINAL": {},
+            "MUEBLES Y ENSERES COSTO ORIGINAL 1": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "TERRENOS COSTO ORIGINAL": {},
+            "VEHICULOS COSTO ORIGINAL 1": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "accountType": "Accumulated Depreciation"
+          }
+        },
+        "CARGOS DIFERIDOS": {
+          "CARGOS DIFERIDOS 1": {
+            "GASTOS DE CONSTITUCION": {},
+            "MARCA DE FABRICA": {},
+            "OTRAS CUENTAS POR COBRAR": {
+              "accountType": "Receivable"
+            }
+          }
+        },
+        "IMPUESTOS DIFERIDOS": {
+          "IMPUESTOS DIFERIDOS ISR ": {
+            "IMPUESTOS DIFERIDOS ISR  1": {}
+          }
+        },
+        "INVERSIONES LARGO PLAZO": {
+          "TITULOS DE VALORES": {
+            "BONOS TITULOS": {},
+            "INVERSIONES EN BONOS M.N.": {},
+            "INVERSIONES PERMANENTES": {}
+          }
+        },
+        "OTROS ACTIVOS": {
+          "OTROS ACTIVOS 1": {
+            "DEPOSITOS GARANTIA ARRENDAMIENTO LOCAL": {},
+            "DEPOSITOS GARANTIA BANCOS": {},
+            "DEPOSITOS GARANTIA PROVEEDORES": {}
+          }
+        }
+      },
+      "rootType": "Asset"
+    },
+    "CAPITAL": {
+      "CAPITAL SOCIAL": {
+        "ACCIONES EN TESORERIA": {
+          "ACCIONES EN TESORERIA 1": {
+            "ACCIONES EN TESORERIA 2": {},
+            "ACTUALIZACION DE VALOR": {}
+          }
+        },
+        "CAPITAL SOCIAL PAGADO": {
+          "CAPITAL SOCIAL PAGADO 1": {
+            "ACTUALIZACION DEL VALOR 1": {},
+            "CAPITAL SOCIAL 1": {}
+          }
+        }
+      },
+      "GANANCIAS Y PERDIDAS": {
+        "GANACIAS Y PERDIDAS": {
+          "GANACIAS Y PERDIDAS 1": {}
+        }
+      },
+      "RESERVA DE CAPITAL": {
+        "OTRAS RESERVAS": {
+          "OTRAS RESERVAS 1": {
+            "ACTUALIZACION DEL VALOR": {},
+            "VALOR ORIGINAL": {}
+          }
+        },
+        "RESERVA LEGAL": {
+          "RESERVA LEGAL 1": {
+            "RESERVA P/FUTURO AUMENTO DE CAPITAL": {},
+            "VALOR ORIGINAL RESERVA LEGAL": {}
+          }
+        }
+      },
+      "SUPERAVIT": {
+        "RESULT.POR TENDENCIA DE ACTIVO NO MONETARIOS": {
+          "RESULT.POR TENDENCIA DE ACTIVO NO MONETARIOS 1": {}
+        },
+        "SUPERAVIT GANADO": {
+          "RESULTADO POR EXPOS. A LA INFLACION": {
+            "ACTUALIZACION DEL PATRIMONIO": {},
+            "EXCLUSIONES FISCALES": {},
+            "REAJUSTE POR INFLACION": {}
+          },
+          "SUPERAVIT OPERATIVO": {
+            "UTILIDADES DEL EJERCICIO": {},
+            "UTILIDADES NO DISTRIBUIDAS": {}
+          }
+        }
+      },
+      "rootType": "Equity"
+    },
+    "COSTO": {
+      " Gastos incluidos en la valoraci\u00f3n": {
+        "accountType": "Expenses Included In Valuation"
+      },
+      "COSTO DE VENTAS": {
+        "accountType": "Cost of Goods Sold"
+      },
+      "rootType": "Expense"
+    },
+    "CUENTAS DE ORDEN": {
+      "CUENTAS DE ORDEN 1": {
+        "CUENTAS DE ORDEN DEUDORAS": {
+          "CUENTAS DE ORDEN DEUDORAS 1": {
+            "CARTAS DE CREDITOS": {},
+            "MERCANCIAS COMPRADAS EN TRANSITO": {},
+            "MERCANCIAS EN CONSIGNACION": {}
+          }
+        }
+      },
+      "CUENTAS DE ORDEN ACREEDORAS": {
+        "CUENTAS DE ORDEN ACREEDORAS 1": {
+          "CUENTAS DE ORDEN ACREEDORAS 2": {
+            "MERCANCIA EN CONSIGNACION P. COMPRA": {},
+            "MERCANCIA VENDIDAS EN TRANSITO": {}
+          }
+        }
+      },
+      "rootType": "Asset"
+    },
+    "GASTOS": {
+      "GASTOS OPERATIVOS": {
+        "DEPRECIACION Y AMORTIZACION": {
+          "AMORTIZACION": {
+            "SEGUROS": {}
+          },
+          "DEPRECIACION": {
+            "INMUEBLES": {},
+            "LICENCIA Y SOFTWARE": {},
+            "MAQUINARIAS Y EQUIPOS": {
+              "accountType": "Depreciation"
+            },
+            "MEJORAS A PROPIEDAD": {
+              "accountType": "Depreciation"
+            },
+            "MUEBLES Y ENSERES": {
+              "accountType": "Depreciation"
+            },
+            "VEHICULOS": {
+              "accountType": "Depreciation"
+            },
+            "accountType": "Depreciation"
+          }
+        },
+        "GASTOS COMERCIALIZACION": {
+          "GASTOS DE DISTRIBUCION": {
+            "ACTIVIDADES REGIONALES": {},
+            "CUENTAS INCOBRABLES NACIONALES": {},
+            "DISTRIBUCION Y REPARTO LOCALES": {},
+            "EVENTOS ESPECIALES": {},
+            "MATERIALES PROMOCIONALES": {},
+            "MEDIOS": {},
+            "PATENTE INDUSTRIA Y COMERCIO 1": {},
+            "PRODUCCION MATERIAL P.O.P.": {},
+            "PROMOCIONES": {},
+            "PUBLICIDAD 1": {},
+            "TRANSPORTE Y FLETES": {}
+          }
+        },
+        "GASTOS DE PERSONAL": {
+          "GASTOS PERSONAL": {
+            "BENEFICIOS ADIESTRAMIENTOS-CURSOS": {},
+            "BENEFICIOS AYUDAS ESCOLARES": {},
+            "BENEFICIOS BECAS": {},
+            "BENEFICIOS COMEDOR": {},
+            "BENEFICIOS SERVICIOS MEDICOS": {},
+            "BENEFICIOS UNIFORMES": {},
+            "BONIFICACION UNICA ESPECIAL 1": {},
+            "BONO VACACIONAL": {},
+            "COMISION AL PERSONAL": {},
+            "CONTRIBUCIONES": {},
+            "GASTOS PERSONAL CONTRATADO": {},
+            "GASTOS PERSONAL TRANSFERIDOSR": {},
+            "HONORARIOS POR PARTIPACION JUNTA DIRECTIVA": {},
+            "HORAS EXTRAORDINARIAS": {},
+            "HORAS EXTRAS": {},
+            "INTERESES S/PRESTACIONES SOCIALES 2": {},
+            "PRESTACIONES SOCIALES 1": {},
+            "PRIMA POR RENDIMIENTO": {},
+            "PROGRAMA DE ALIMENTACION EMPLEADOS": {},
+            "SUELDOS DIRECTIVOS": {},
+            "SUELDOS EMPLEADOS": {},
+            "TRANSPORTE Y ALIMENTACION": {},
+            "UTILIDADES 2": {},
+            "VACACIONES 2": {},
+            "VIATICOS Y GASTOS DE REPRESENTACION": {}
+          }
+        },
+        "GASTOS GENERALES": {
+          "GASTOS GENERALES 1": {
+            "AGUA POTABLE Y REFRIGERIO": {},
+            "AJUSTE DE INVENTARIOS DONADOS": {
+              "accountType": "Stock Adjustment"
+            },
+            "AJUSTE DE INVENTARIOS OBSOLETOS": {
+              "accountType": "Stock Adjustment"
+            },
+            "ARRENDAMIENTO": {},
+            "ARTICULOS DE OFICINA": {},
+            "ASEO URBANO": {},
+            "ASEO Y LIMPIEZA": {},
+            "ASIMILABLES A SALARIOS": {},
+            "AVERIAS-PRODUCTOS": {},
+            "BONIFICACION UNICA ESPECIAL": {},
+            "COMBUSTIBLES": {},
+            "COMIDAS, VIAJES Y TRASLADOS": {},
+            "CONDOMINIOS 1": {},
+            "CONVENSION  DE COMERCIALIZACION": {},
+            "DERECHO DE FRENTE": {},
+            "ENERGIA ELECTRICA": {},
+            "EQUIPOS Y EVENTOS DEPORTIVOS": {},
+            "ESTACIONAMINETO": {},
+            "FLETES Y TRANSPORTES": {},
+            "GASTOS DE ISR ": {},
+            "GASTOS DE REPRESENTACION": {},
+            "GASTOS DE SISTEMAS": {},
+            "HONORARIOS PROFESIONALES": {},
+            "HOSPEDAJE": {},
+            "MANTENIMIENTO DE VEHICULOS": {},
+            "MANTENIMIENTOS": {},
+            "OTROS GASTOS": {},
+            "PALERIA Y FOTOCOPIADO": {},
+            "PARTIDAS NO DEDUCIBLES": {},
+            "PASAJE EXTERIOR NO DEDUCIBLE": {},
+            "PASAJES LOCALES Y EXT.DEDUCIBLES": {},
+            "REMANENTES DISTRIBUIBLES": {},
+            "REPARACIONES": {},
+            "REPAROS": {},
+            "SEGUROS 1": {},
+            "SERVICIOS CONTRATADOS A TERCEROS": {},
+            "SERVICIOS DE PUBLICIDAD": {},
+            "SERVICIOS PUBLICOS": {},
+            "SUMINISTROS DE EQUIPOS DE OFICINA": {},
+            "TELEFONOS Y TELECOMUNICACIONES": {},
+            "TRAMITES DE SOLVENCIAS": {},
+            "TRAMITES LEGALES": {},
+            "UTILES DE LIMPIEZA": {},
+            "VIATICOS DEDUCIBLES": {},
+            "VIATICOS NO DEDUCIBLES": {}
+          }
+        }
+      },
+      "rootType": "Expense"
+    },
+    "INGRESOS": {
+      "INGRESOS OPERACIONALES": {
+        "INGRESOS OPERACIONALES 1": {
+          "DESCUENTOS Y DEVOLUCION EN VENTAS": {
+            "DESCUENTOS EN VENTAS": {},
+            "DEVOLUCIONES EN VENTAS": {}
+          },
+          "INGRESOS POR SERVICIOS": {
+            "INGRESOS POR SERVICIOS 1": {}
+          },
+          "VENTAS": {
+            "VENTAS EXPORTACION": {},
+            "VENTAS INMUEBLES": {},
+            "VENTAS NACIONALES": {},
+            "VENTAS NACIONALES AL DETAL": {}
+          }
+        }
+      },
+      "rootType": "Income"
+    },
+    "OTROS INGRESOS (EGRESOS)": {
+      "EGRESOS": {
+        "GASTOS FINANCIEROS": {
+          "EGRESOS NO GRAVABLES": {
+            "IMPUESTOS A LAS TRANSACIONES FINANCIERAS": {}
+          },
+          "GASTOS FINANCIEROS 1": {
+            "COMISIONES TICKET DE ALIMENTACION": {},
+            "COMISIONES Y GASTOS BANCARIOS": {},
+            "INTERESES BANCOS NACIONALES": {},
+            "INTERESES POR FINANCIAMIENTOS": {},
+            "OTROS EGRESOS": {}
+          },
+          "OTROS EGRESOS 1": {
+            "AJUSTE DE A\u00d1OS ANTERIORES": {},
+            "FLUCTUACION CAMBIARIA NO REALIZADAS": {},
+            "INTERESES S/PRESTACIONES SOCIALES 1": {},
+            "PERDIDA POR ROBO DE INVENTARIO": {},
+            "PERDIDAS EN DIFERENCIAL CAMBIARIO": {},
+            "PERDIDAS EN INVERSIONES DE BONOS P.": {},
+            "PERDIDAS EN VENTAS ACTIVOS FIJOS": {},
+            "PERDIDAS EN VENTAS DE INVERSIONES": {}
+          }
+        }
+      },
+      "OTROS INGRESOS": {
+        "OTROS INGRESOS 1": {
+          "INGRESOS FINANCIEROS": {
+            "INTERESES DE BANCOS EXTRANJEROS": {},
+            "INTERESES DE BANCOS NACIONALES": {},
+            "OTROS INGRESOS FINANCIEROS": {}
+          },
+          "OTROS INGRESOS 2": {
+            "GANANCIAS EN DIFERENCIAL CAMBIARIO": {},
+            "GANANCIAS EN VENTAS DE ACTIVOS FIJOS": {},
+            "GANANCIAS EN VENTAS DE INVERSIONES": {},
+            "INTERESES VARIOS": {},
+            "OTROS INGRESOS 3": {}
+          }
+        }
+      },
+      "rootType": "Income"
+    },
+    "PASIVO": {
+      " Stock recibidas, pero no facturada": {
+        "accountType": "Stock Received But Not Billed"
+      },
+      "OTROS PASIVOS A CORTO PLAZO": {
+        "OTROS PASIVOS A CORTO PLAZO 1": {
+          "IMPUESTOS POR PAGAR": {
+            "1% DE RET CEDULAR ARRENDAMIETOS (GUANAJUATO)": {},
+            "10% ISR RETENIDO ARRENDAMIENTO": {},
+            "10% ISR RETENIDO HONORARIOS": {},
+            "10.67%  IVA RETENIDO ARRENDAMIENTO": {},
+            "10.67%  IVA RETENIDO HONORARIOS": {},
+            "4% IVA RETENIDO FLETES": {},
+            "ISR RETENIDO ASIMILABLES": {},
+            "ISR RETENIDO SALARIOS": {},
+            "PASIVOS A  CORTO PLAZO": {}
+          },
+          "IVA TRASLADADO": {
+            "IVA POR TRASLADAR o COBRADO": {}
+          }
+        }
+      },
+      "PASIVO A CORTO PLAZO": {
+        "ACUMULACIONES LABORALES": {
+          "APORTES EMPLEADOS": {
+            "APORTES EMPLEADOS 1": {},
+            "FONDO DE AHORRO": {},
+            "FONDO FIDEICOMISO": {}
+          }
+        },
+        "DIVIDENDO POR PAGAR": {
+          "DIVIDENDO POR PAGAR 1": {
+            "DIVDENDO POR COBRAR NO COBRADOS": {},
+            "DIVIDENDO POR PAGAR VIGENTES": {}
+          }
+        },
+        "DOCUMENTOS Y CUENTAS POR PAGAR": {
+          "COMPA\u00d1IAS AFILIADAS Y RELACIONADAS": {},
+          "CUENTAS POR PAGAR ACCIONISTAS": {
+            "CUENTAS POR PAGAR SOCIOS": {
+              "accountType": "Payable"
+            },
+            "accountType": "Payable"
+          },
+          "PROVEEDORES EXTRANJEROS": {},
+          "PROVEEDORES OCASIONALES": {
+            "CUENTAS POR PAGAR PROVEEDORES": {
+              "accountType": "Payable"
+            },
+            "OTRAS CUENTAS POR PAGAR": {
+              "accountType": "Payable"
+            },
+            "TARJETA DE CREDITO X": {
+              "accountType": "Payable"
+            },
+            "accountType": "Payable"
+          },
+          "accountType": "Payable"
+        },
+        "GASTOS ACUMULADOS Y RETENCIONES POR PAGAR": {
+          "CONTRIBUCIONES PATRONAL": {
+            "APORTE EMPRESA": {}
+          },
+          "OTRAS ACUMULACIONES": {
+            "ADELANTO DE CLIENTES": {},
+            "ALQUILERES": {},
+            "BONIFICACION ACCIDENTAL UNICA": {},
+            "COMISIONES": {},
+            "CONDOMINIOS": {},
+            "CONVESION DE COMERCIALIZACION": {},
+            "IMPUESTOS MUNICIPALES POR PAGAR": {
+              "accountType": "Payable"
+            },
+            "IMPUESTOS POR PAGAR 1": {
+              "accountType": "Tax"
+            },
+            "INTERESES S/PRESTACIONES SOCIALES": {},
+            "NOMINA POR PAGAR": {
+              "accountType": "Payable"
+            },
+            "PATENTE INDUSTRIA Y COMERCIO": {},
+            "POLIZA DE SEGURO POR PAGAR": {
+              "accountType": "Payable"
+            },
+            "PRESTACIONES SOCIALES": {},
+            "PRIMA POR EFECIENCIA": {},
+            "PROGRAMA DE ALIMENTACION": {},
+            "PUBLICIDAD Y PROPAGANDA": {},
+            "TARJETA CORPORATIVA": {},
+            "UTILIDADES": {},
+            "VACACIONES": {}
+          },
+          "RETENCIONES E IMPUESTOS POR PAGAR": {
+            "IVA  DEBITO FISCAL": {},
+            "RETENCIONES ISR  EMPLEADOS": {},
+            "RETENCIONES ISR  PROVEEDORES": {}
+          },
+          "RETENCIONES VARIAS": {
+            "EMBARGO DE SUELDO": {},
+            "PRESTAMOS SOBRE FIDEICOMISO": {},
+            "SINDICATOS": {}
+          }
+        },
+        "IMPUESTOS SOBRE LA RENTA POR PAGAR": {
+          "ISR  ACUMULADOS GASTOS": {
+            "DECLARACION ESTIMADAS": {},
+            "ISR  ACUMULADOS GASTOS 1": {},
+            "RAR AJUSTE INICIAL POR INFLACION": {}
+          }
+        },
+        "PASIVOS FINACIEROS A CORTO PLAZO": {
+          "PASIVOS FINANCIEROS A CORTO PLAZO": {
+            "BANCO X": {}
+          }
+        },
+        "RESERVAS": {
+          "RESERVAS 1": {
+            "RESERVAS FINANCIERAS": {},
+            "RESERVAS FISCALES": {},
+            "RESERVAS OPERATIVAS": {}
+          }
+        }
+      },
+      "PASIVO A LARGO PLAZO": {
+        "ACUMULACIONES PARA INDEMNIZ. LABORALES": {
+          "ACUMULACIONES PARA INDEMNIZ.LABORALES": {
+            "INDEMNIZACIONES DOBLES": {},
+            "INDEMNIZACIONES SENCILLAS": {}
+          }
+        },
+        "OTROS PASIVOS A LARGO PLAZO": {
+          "OTROS PASIVOS A LARGO PLAZO 1": {
+            "OTROS PASIVOS A LARGO PLAZO 2": {}
+          }
+        },
+        "PASIVOS FINANCIEROS A LARGO PLAZO": {
+          "PASIVOS FINANCIEROS A LARGO PLAZO 1": {
+            "PASIVOS FINANCIEROS A LARGO PLAZO 2": {}
+          }
+        },
+        "PASIVOS INTERCOMPA\u00d1IAS": {
+          "PASIVOS INTERCOMPA\u00d1IAS 1": {
+            "PASIVOS INTERCOMPA\u00d1IAS 2": {}
+          }
+        }
+      },
+      "rootType": "Liability"
+    }
   }
 }

--- a/fixtures/verified/ni.json
+++ b/fixtures/verified/ni.json
@@ -1,494 +1,494 @@
 {
-  "country_code": "ni", 
-  "name": "Nicaragua - Catalogo de Cuentas", 
+  "countryCode": "ni",
+  "name": "Nicaragua - Catalogo de Cuentas",
   "tree": {
-      "Activo": {
-          "Activo Corriente": {
-              "Activos Financieros Realizables a Corto Plazo": {
-                  "Bonos y Acciones Disponibles para la Venta": {}, 
-                  "Certificados Bancarios": {}, 
-                  "Inversiones a Corto Plazo": {}, 
-                  "Otros Valores Negociables a Corto Plazo": {}
-              }, 
-              "Cuentas y Documentos por Cobrar a Clientes": {
-                  "Cuentas por Cobrar Moneda Extrangera": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Cuentas por Cobrar Moneda Nacional": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Cuentas por Cobrar por Exportaciones": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Documentos por Cobrar Moneda Extrangera": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Documentos por Cobrar Moneda Nacional": {
-                      "account_type": "Receivable"
-                  }, 
-                  "Estimacion para Cuentas Incobrables": {}
-              }, 
-              "Efectivo en Caja y Bancos": {
-                  "Caja": {
-                      "Caja Chica Moneda Extrangera": {
-                          "account_type": "Cash"
-                      }, 
-                      "Caja Chica Moneda Nacional": {
-                          "account_type": "Cash"
-                      }, 
-                      "Caja General Moneda Extrangera": {
-                          "account_type": "Cash"
-                      }, 
-                      "Caja General Moneda Nacional": {
-                          "account_type": "Cash"
-                      }, 
-                      "Fondos por Depositar": {
-                          "account_type": "Cash"
-                      }
-                  }, 
-                  "Cuentas Bancarias": {
-                      "Cuenta Corriente Moneda Extrangera": {
-                          "account_type": "Bank"
-                      }, 
-                      "Cuenta Corriente Moneda Nacional": {
-                          "account_type": "Bank"
-                      }, 
-                      "account_type": "Bank"
-                  }, 
-                  "Otros Equivalentes a Efectivo": {
-                      "account_type": "Cash", 
-                      "is_group": 1
-                  }
-              }, 
-              "Impuestos Acreditables": {
-                  "Anticipos de IR o Pago Minimo Definitivo": {}, 
-                  "Impuesto a Valor Agregado Acreditable": {
-                      "Acreditacion Proporcional": {}, 
-                      "IVA Acreditable por Compra de Bienes": {
-                          "account_type": "Tax"
-                      }, 
-                      "IVA Acreditable por Importaciones": {
-                          "account_type": "Tax"
-                      }, 
-                      "IVA Acreditable por Prestacion de Servicios y Uso y Goce de Bienes": {
-                          "account_type": "Tax"
-                      }
-                  }, 
-                  "Retenciones Definitivas Sobre Rentas o Ganancias de Capital": {}, 
-                  "Retenciones a Cuenta de IMI Acreditables": {}, 
-                  "Retenciones a Cuenta de IR Acreditables": {
-                      "Retencion Operaciones Targeta Debito/Credito 1.5%": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion por V/Bienes o P/Servicios 2%": {
-                          "account_type": "Tax"
-                      }
-                  }
-              }, 
-              "Inventarios": {
-                  "Ajuste de Inventarios": {
-                      "account_type": "Stock Adjustment"
-                  }, 
-                  "Todos los Almacenes": {
-                      "account_type": "Stock", 
-                      "is_group": 1
-                  }, 
-                  "account_type": "Stock"
-              }, 
-              "Otras Cuentas por Cobrar": {
-                  "account_type": "Receivable", 
-                  "is_group": 1
-              }
-          }, 
-          "Activo no Corriente": {
-              "Activo por Impuestos Diferidos": {
-                  "is_group": 1
-              }, 
-              "Activos Intangibles": {
-                  "Amortizacion de Activos Intangibles": {
-                      "is_group": 1
-                  }, 
-                  "Concesiones": {
-                      "is_group": 1
-                  }, 
-                  "Derechos de Autor": {
-                      "is_group": 1
-                  }, 
-                  "Deterioro de Valor de Activos Intangibles": {}, 
-                  "Gastos de investigacion": {
-                      "is_group": 1
-                  }, 
-                  "Licencias": {
-                      "is_group": 1
-                  }, 
-                  "Marcas Registradas": {
-                      "is_group": 1
-                  }, 
-                  "Patentes": {
-                      "is_group": 1
-                  }
-              }, 
-              "Amortizables": {
-                  "Amortizacion de Activos Amortizables": {}, 
-                  "Deterioro de Valaor de Activos Amortizables": {}, 
-                  "Gastos Pre Operativos": {
-                      "account_type": "Expenses Included In Valuation"
-                  }, 
-                  "Gastos de Consitucion": {
-                      "account_type": "Expenses Included In Valuation"
-                  }, 
-                  "Mejoras en Bienes Arrendados": {
-                      "is_group": 1
-                  }
-              }, 
-              "Bienes en Arrendamiento Financiero": {
-                  "Equipos y Maquinaria en Arrendamiento": {}, 
-                  "Locales y Edificios en Arrendamiento": {}
-              }, 
-              "Cuentas por Cobrar a Largo Plazo": {
-                  "Creditos a Largo Plazo": {
-                      "is_group": 1
-                  }
-              }, 
-              "Inversiones Permanentes": {
-                  "Inversiones Permanentes 1": {
-                      "account_type": "Fixed Asset", 
-                      "is_group": 1
-                  }, 
-                  "Negocios Conjuntos": {
-                      "account_type": "Fixed Asset", 
-                      "is_group": 1
-                  }
-              }, 
-              "Inversiones a Largo Plazo": {
-                  "Depositos Bancarios a Plazo": {
-                      "is_group": 1
-                  }, 
-                  "Intereses percibidos por adelantado": {
-                      "is_group": 1
-                  }, 
-                  "Titulos y Acciones": {
-                      "is_group": 1
-                  }
-              }, 
-              "Propiedad Planta y Equipo": {
-                  "Almacenes": {}, 
-                  "Depresiacion Acumulada": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Edificios": {}, 
-                  "Equipo de Computo": {}, 
-                  "Maquinaria Industrial": {}, 
-                  "Mobiliario y Equipo de Oficinas": {}, 
-                  "Otra Bienes Mobiliarios": {
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "Otros Activos Inmobiliarios": {}, 
-                  "Parque Vehicular": {}, 
-                  "Terrenos": {}, 
-                  "account_type": "Fixed Asset"
-              }
-          }, 
-          "root_type": "Asset"
-      }, 
-      "Capital y Patrimonio": {
-          "Aporte de Socios": {
-              "Capital": {
-                  "Capital Social Pagado": {
-                      "account_type": "Equity"
-                  }, 
-                  "Capital Social no Pagado": {
-                      "account_type": "Equity"
-                  }
-              }
-          }, 
-          "Donaciones": {
-              "is_group": 1
-          }, 
-          "Ganancias Acumuladas": {
-              "Reservas": {
-                  "Reservas Legales": {
-                      "account_type": "Equity"
-                  }, 
-                  "Reservas Voluntarias": {
-                      "account_type": "Equity"
-                  }
-              }, 
-              "Resultados": {
-                  "Ajustes a Periodos Anteriores": {
-                      "account_type": "Equity"
-                  }, 
-                  "Resultado del ejercicio": {
-                      "account_type": "Equity"
-                  }, 
-                  "Resultados Acumulados": {
-                      "account_type": "Equity"
-                  }
-              }
-          }, 
-          "root_type": "Equity"
-      }, 
-      "Costos y Gastos": {
-          "Costo de Venta": {
-              "Costo de Bienes": {
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "Costo de Produccion": {
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "Costo de Servicios": {
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "account_type": "Cost of Goods Sold"
-          }, 
-          "Costos y Gastos No Deducibles": {}, 
-          "Gastopor Depreciacion": {
-              "account_type": "Depreciation"
-          }, 
-          "Gastos de Administracion": {
-              "Alquileres": {}, 
-              "Amortizaciones": {}, 
-              "Ayuda a Empleados": {}, 
-              "Capacitacion al Personal": {}, 
-              "Combustible": {}, 
-              "Cuentas Incobrables": {}, 
-              "Donaciones 1": {}, 
-              "Fletes y Correos": {}, 
-              "Gastos Varios": {}, 
-              "IVA Proporcional no Acreditado": {}, 
-              "Impuesto Municipal": {}, 
-              "Inatec": {}, 
-              "Indemnizacion": {}, 
-              "Mantenimiento y Reparaciones": {}, 
-              "Matricula": {}, 
-              "Papeleria": {}, 
-              "Recoleccion de Basura": {}, 
-              "Representacion": {}, 
-              "Seguros": {}, 
-              "Servicios Basicos": {
-                  "Agua Potable": {}, 
-                  "Celular": {}, 
-                  "Costos por Servicios WEB": {}, 
-                  "Energia Electrica": {}, 
-                  "Internet": {}, 
-                  "Telefono Fijo": {}
-              }, 
-              "Uniformes": {}, 
-              "Vigilancia": {}
-          }, 
-          "Gastos de Ventas": {
-              "Fletes": {}, 
-              "Mercadeo": {}, 
-              "Muestras Gratis": {}, 
-              "Promociones": {}, 
-              "Publicidad": {}, 
-              "Regalosa Clientes": {}
-          }, 
-          "Gastos por Salarios y Otras Compensaciones": {}, 
-          "Gastos por Servicios Profesionales y Tecnicos": {}, 
-          "Impuesto por Rentas y Ganancias de Capital": {}, 
-          "Impuesto sobre la Rentade Activividades Economicas": {}, 
-          "Otros Gastos": {
-              "Certificacion de Cheques y Chequeras": {}, 
-              "Perdida Cambiario": {}, 
-              "P\u00e9rdida en Venta de Activo Fijo": {
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "Siniestros": {}
-          }, 
-          "root_type": "Expense"
-      }, 
-      "Ingresos": {
-          "Ingresos no Grabables": {
-              "Ingreso por Rentas y Ganacias de Capital sujetas a Retencion Definitiva": {}, 
-              "Interes Bancarios": {}, 
-              "Otros Ingresos no Grabables": {}
-          }, 
-          "Otros Ingresos Grabables": {
-              "Ganacia Cambiaria": {}, 
-              "Otros Ingresos Grabables 1": {}, 
-              "Sobrante en Arqueo de Caja": {}
-          }, 
-          "Ventas": {
-              "Venta de Bienes o Prestacion de Servicios Exentos": {}, 
-              "Venta de Bienes o Prestacion de Servicios Exonerados": {}, 
-              "Venta de Bienes o Prestacion de Servicios Grabados": {}, 
-              "Venta por Exportaciones": {}
-          }, 
-          "root_type": "Income"
-      }, 
-      "Pasivo": {
-          "Obligaciones por Arrendamiento Financiero a Largo Plazo": {
-              "is_group": 1
-          }, 
-          "Pasivo Corriente": {
-              "Anticipos de Clientes": {}, 
-              "Cuentas por Pagar Proveedores": {
-                  "Bienes Adquiridos no Pagados": {
-                      "account_type": "Stock Received But Not Billed"
-                  }, 
-                  "Cuentas por Pagar Moneda Extrangera": {
-                      "account_type": "Payable"
-                  }, 
-                  "Cuentas por Pagar Moneda Nacional": {
-                      "account_type": "Payable"
-                  }, 
-                  "Cuentas por Pagar por Importaciones": {
-                      "account_type": "Payable"
-                  }, 
-                  "Documentos por Pagar Moneda Extrangera": {
-                      "account_type": "Payable"
-                  }, 
-                  "Documentos por Pagar Moneda Nacional": {
-                      "account_type": "Payable"
-                  }
-              }, 
-              "Gastos por Pagar": {
-                  "Prestaciones Sociales": {
-                      "is_group": 1
-                  }, 
-                  "Salarios por Pagar": {}, 
-                  "Servicios Basicos 1": {
-                      "is_group": 1
-                  }
-              }, 
-              "Impuestos por Pagar": {
-                  "Impuesto al Valor Agregado por Pagar": {
-                      "account_type": "Tax"
-                  }, 
-                  "Impuesto sobre la Renta por Actividades Economicas": {
-                      "account_type": "Tax"
-                  }, 
-                  "Impuestos Municipales": {
-                      "Impuesto Municipal Sobre Ingresos": {
-                          "account_type": "Tax"
-                      }, 
-                      "Matricula Municipal": {
-                          "account_type": "Tax"
-                      }, 
-                      "Recoleccion Basura": {
-                          "account_type": "Tax"
-                      }
-                  }
-              }, 
-              "Otras Cuentas por Pagar": {
-                  "is_group": 1
-              }, 
-              "Pasivos Financieros a Corto Plazo": {
-                  "Otras Deudas Bancarias": {
-                      "is_group": 1
-                  }, 
-                  "Prestamos por Pagar a Corto Plazo": {
-                      "is_group": 1
-                  }, 
-                  "Sobregiros Bancarios": {
-                      "is_group": 1
-                  }
-              }, 
-              "Provisiones por Pagar": {
-                  "Pasivos Laborales": {
-                      "Aguinaldo por Pagar": {}, 
-                      "Indemnizacion Laboral": {}
-                  }, 
-                  "Reclamos por Pagar": {}, 
-                  "Responsabilidad frente a terceros": {}
-              }, 
-              "Retenciones por Pagar": {
-                  "Rentas de Actividades Economicas": {
-                      "Otras Retenciones 10%": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion 10% Servicios Profesionales": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion 2% por C/Bienes o P/Servicios": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion 3% compra Bienes Agropecuarios": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion 5% compra Madera en Rollo": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 1.5% Actividades Economicas No Residentes": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 10% Actividades Economicas No Residentes": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 15% Actividades Economicas No Residentes": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 3% Actividades Economicas No Residentes": {
-                          "account_type": "Tax"
-                      }
-                  }, 
-                  "Rentas del Trabajo": {
-                      "Retencion Definitiva 10% por Rentas del Trabajo - Indemnizacion Adicional": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 12.5% por Rentas del Trabajo - Dietas": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 15% por Rentas del Trabajo - No Residentes": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Rentas del Trabajo Tarifa Progresiva": {
-                          "account_type": "Tax"
-                      }
-                  }, 
-                  "Rentas y Ganancias de Capital": {
-                      "Retencion Definitiva 0.25% Transacciones Bursatiles": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 1% Transacciones Bursatiles": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 1.5% Transacciones Bursatiles": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 10% por Ganancia de Capital": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 2% Transacciones Bursatiles": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Definitiva 5% por Rentas de Capital": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Defintiva 10% por Rentas de Capital": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retencion Defintiva 15% por Rentas de Capital": {
-                          "account_type": "Tax"
-                      }, 
-                      "Retenciones Defintiva 5% Fondos de Inversion": {
-                          "account_type": "Tax"
-                      }
-                  }, 
-                  "Retencion 17% Operaciones con Paraisos Fiscales": {
-                      "account_type": "Tax"
-                  }
-              }
-          }, 
-          "Pasivo No Corriente": {
-              "Cuentas por Pagar a Largo Plaso": {
-                  "is_group": 1
-              }, 
-              "Otras Cuentas por Pagar a Largo Plazo": {
-                  "is_group": 1
-              }, 
-              "Otros Pasivos Financieros a Largo Plaso": {
-                  "is_group": 1
-              }, 
-              "Prestamos a Largo Plazo": {
-                  "is_group": 1
-              }
-          }, 
-          "Pasivo por Impuestos Diferidos": {
-              "is_group": 1
-          }, 
-          "root_type": "Liability"
-      }
+    "Activo": {
+      "Activo Corriente": {
+        "Activos Financieros Realizables a Corto Plazo": {
+          "Bonos y Acciones Disponibles para la Venta": {},
+          "Certificados Bancarios": {},
+          "Inversiones a Corto Plazo": {},
+          "Otros Valores Negociables a Corto Plazo": {}
+        },
+        "Cuentas y Documentos por Cobrar a Clientes": {
+          "Cuentas por Cobrar Moneda Extrangera": {
+            "accountType": "Receivable"
+          },
+          "Cuentas por Cobrar Moneda Nacional": {
+            "accountType": "Receivable"
+          },
+          "Cuentas por Cobrar por Exportaciones": {
+            "accountType": "Receivable"
+          },
+          "Documentos por Cobrar Moneda Extrangera": {
+            "accountType": "Receivable"
+          },
+          "Documentos por Cobrar Moneda Nacional": {
+            "accountType": "Receivable"
+          },
+          "Estimacion para Cuentas Incobrables": {}
+        },
+        "Efectivo en Caja y Bancos": {
+          "Caja": {
+            "Caja Chica Moneda Extrangera": {
+              "accountType": "Cash"
+            },
+            "Caja Chica Moneda Nacional": {
+              "accountType": "Cash"
+            },
+            "Caja General Moneda Extrangera": {
+              "accountType": "Cash"
+            },
+            "Caja General Moneda Nacional": {
+              "accountType": "Cash"
+            },
+            "Fondos por Depositar": {
+              "accountType": "Cash"
+            }
+          },
+          "Cuentas Bancarias": {
+            "Cuenta Corriente Moneda Extrangera": {
+              "accountType": "Bank"
+            },
+            "Cuenta Corriente Moneda Nacional": {
+              "accountType": "Bank"
+            },
+            "accountType": "Bank"
+          },
+          "Otros Equivalentes a Efectivo": {
+            "accountType": "Cash",
+            "isGroup": 1
+          }
+        },
+        "Impuestos Acreditables": {
+          "Anticipos de IR o Pago Minimo Definitivo": {},
+          "Impuesto a Valor Agregado Acreditable": {
+            "Acreditacion Proporcional": {},
+            "IVA Acreditable por Compra de Bienes": {
+              "accountType": "Tax"
+            },
+            "IVA Acreditable por Importaciones": {
+              "accountType": "Tax"
+            },
+            "IVA Acreditable por Prestacion de Servicios y Uso y Goce de Bienes": {
+              "accountType": "Tax"
+            }
+          },
+          "Retenciones Definitivas Sobre Rentas o Ganancias de Capital": {},
+          "Retenciones a Cuenta de IMI Acreditables": {},
+          "Retenciones a Cuenta de IR Acreditables": {
+            "Retencion Operaciones Targeta Debito/Credito 1.5%": {
+              "accountType": "Tax"
+            },
+            "Retencion por V/Bienes o P/Servicios 2%": {
+              "accountType": "Tax"
+            }
+          }
+        },
+        "Inventarios": {
+          "Ajuste de Inventarios": {
+            "accountType": "Stock Adjustment"
+          },
+          "Todos los Almacenes": {
+            "accountType": "Stock",
+            "isGroup": 1
+          },
+          "accountType": "Stock"
+        },
+        "Otras Cuentas por Cobrar": {
+          "accountType": "Receivable",
+          "isGroup": 1
+        }
+      },
+      "Activo no Corriente": {
+        "Activo por Impuestos Diferidos": {
+          "isGroup": 1
+        },
+        "Activos Intangibles": {
+          "Amortizacion de Activos Intangibles": {
+            "isGroup": 1
+          },
+          "Concesiones": {
+            "isGroup": 1
+          },
+          "Derechos de Autor": {
+            "isGroup": 1
+          },
+          "Deterioro de Valor de Activos Intangibles": {},
+          "Gastos de investigacion": {
+            "isGroup": 1
+          },
+          "Licencias": {
+            "isGroup": 1
+          },
+          "Marcas Registradas": {
+            "isGroup": 1
+          },
+          "Patentes": {
+            "isGroup": 1
+          }
+        },
+        "Amortizables": {
+          "Amortizacion de Activos Amortizables": {},
+          "Deterioro de Valaor de Activos Amortizables": {},
+          "Gastos Pre Operativos": {
+            "accountType": "Expenses Included In Valuation"
+          },
+          "Gastos de Consitucion": {
+            "accountType": "Expenses Included In Valuation"
+          },
+          "Mejoras en Bienes Arrendados": {
+            "isGroup": 1
+          }
+        },
+        "Bienes en Arrendamiento Financiero": {
+          "Equipos y Maquinaria en Arrendamiento": {},
+          "Locales y Edificios en Arrendamiento": {}
+        },
+        "Cuentas por Cobrar a Largo Plazo": {
+          "Creditos a Largo Plazo": {
+            "isGroup": 1
+          }
+        },
+        "Inversiones Permanentes": {
+          "Inversiones Permanentes 1": {
+            "accountType": "Fixed Asset",
+            "isGroup": 1
+          },
+          "Negocios Conjuntos": {
+            "accountType": "Fixed Asset",
+            "isGroup": 1
+          }
+        },
+        "Inversiones a Largo Plazo": {
+          "Depositos Bancarios a Plazo": {
+            "isGroup": 1
+          },
+          "Intereses percibidos por adelantado": {
+            "isGroup": 1
+          },
+          "Titulos y Acciones": {
+            "isGroup": 1
+          }
+        },
+        "Propiedad Planta y Equipo": {
+          "Almacenes": {},
+          "Depresiacion Acumulada": {
+            "accountType": "Depreciation"
+          },
+          "Edificios": {},
+          "Equipo de Computo": {},
+          "Maquinaria Industrial": {},
+          "Mobiliario y Equipo de Oficinas": {},
+          "Otra Bienes Mobiliarios": {
+            "accountType": "Fixed Asset"
+          },
+          "Otros Activos Inmobiliarios": {},
+          "Parque Vehicular": {},
+          "Terrenos": {},
+          "accountType": "Fixed Asset"
+        }
+      },
+      "rootType": "Asset"
+    },
+    "Capital y Patrimonio": {
+      "Aporte de Socios": {
+        "Capital": {
+          "Capital Social Pagado": {
+            "accountType": "Equity"
+          },
+          "Capital Social no Pagado": {
+            "accountType": "Equity"
+          }
+        }
+      },
+      "Donaciones": {
+        "isGroup": 1
+      },
+      "Ganancias Acumuladas": {
+        "Reservas": {
+          "Reservas Legales": {
+            "accountType": "Equity"
+          },
+          "Reservas Voluntarias": {
+            "accountType": "Equity"
+          }
+        },
+        "Resultados": {
+          "Ajustes a Periodos Anteriores": {
+            "accountType": "Equity"
+          },
+          "Resultado del ejercicio": {
+            "accountType": "Equity"
+          },
+          "Resultados Acumulados": {
+            "accountType": "Equity"
+          }
+        }
+      },
+      "rootType": "Equity"
+    },
+    "Costos y Gastos": {
+      "Costo de Venta": {
+        "Costo de Bienes": {
+          "accountType": "Cost of Goods Sold"
+        },
+        "Costo de Produccion": {
+          "accountType": "Cost of Goods Sold"
+        },
+        "Costo de Servicios": {
+          "accountType": "Cost of Goods Sold"
+        },
+        "accountType": "Cost of Goods Sold"
+      },
+      "Costos y Gastos No Deducibles": {},
+      "Gastopor Depreciacion": {
+        "accountType": "Depreciation"
+      },
+      "Gastos de Administracion": {
+        "Alquileres": {},
+        "Amortizaciones": {},
+        "Ayuda a Empleados": {},
+        "Capacitacion al Personal": {},
+        "Combustible": {},
+        "Cuentas Incobrables": {},
+        "Donaciones 1": {},
+        "Fletes y Correos": {},
+        "Gastos Varios": {},
+        "IVA Proporcional no Acreditado": {},
+        "Impuesto Municipal": {},
+        "Inatec": {},
+        "Indemnizacion": {},
+        "Mantenimiento y Reparaciones": {},
+        "Matricula": {},
+        "Papeleria": {},
+        "Recoleccion de Basura": {},
+        "Representacion": {},
+        "Seguros": {},
+        "Servicios Basicos": {
+          "Agua Potable": {},
+          "Celular": {},
+          "Costos por Servicios WEB": {},
+          "Energia Electrica": {},
+          "Internet": {},
+          "Telefono Fijo": {}
+        },
+        "Uniformes": {},
+        "Vigilancia": {}
+      },
+      "Gastos de Ventas": {
+        "Fletes": {},
+        "Mercadeo": {},
+        "Muestras Gratis": {},
+        "Promociones": {},
+        "Publicidad": {},
+        "Regalosa Clientes": {}
+      },
+      "Gastos por Salarios y Otras Compensaciones": {},
+      "Gastos por Servicios Profesionales y Tecnicos": {},
+      "Impuesto por Rentas y Ganancias de Capital": {},
+      "Impuesto sobre la Rentade Activividades Economicas": {},
+      "Otros Gastos": {
+        "Certificacion de Cheques y Chequeras": {},
+        "Perdida Cambiario": {},
+        "P\u00e9rdida en Venta de Activo Fijo": {
+          "accountType": "Cost of Goods Sold"
+        },
+        "Siniestros": {}
+      },
+      "rootType": "Expense"
+    },
+    "Ingresos": {
+      "Ingresos no Grabables": {
+        "Ingreso por Rentas y Ganacias de Capital sujetas a Retencion Definitiva": {},
+        "Interes Bancarios": {},
+        "Otros Ingresos no Grabables": {}
+      },
+      "Otros Ingresos Grabables": {
+        "Ganacia Cambiaria": {},
+        "Otros Ingresos Grabables 1": {},
+        "Sobrante en Arqueo de Caja": {}
+      },
+      "Ventas": {
+        "Venta de Bienes o Prestacion de Servicios Exentos": {},
+        "Venta de Bienes o Prestacion de Servicios Exonerados": {},
+        "Venta de Bienes o Prestacion de Servicios Grabados": {},
+        "Venta por Exportaciones": {}
+      },
+      "rootType": "Income"
+    },
+    "Pasivo": {
+      "Obligaciones por Arrendamiento Financiero a Largo Plazo": {
+        "isGroup": 1
+      },
+      "Pasivo Corriente": {
+        "Anticipos de Clientes": {},
+        "Cuentas por Pagar Proveedores": {
+          "Bienes Adquiridos no Pagados": {
+            "accountType": "Stock Received But Not Billed"
+          },
+          "Cuentas por Pagar Moneda Extrangera": {
+            "accountType": "Payable"
+          },
+          "Cuentas por Pagar Moneda Nacional": {
+            "accountType": "Payable"
+          },
+          "Cuentas por Pagar por Importaciones": {
+            "accountType": "Payable"
+          },
+          "Documentos por Pagar Moneda Extrangera": {
+            "accountType": "Payable"
+          },
+          "Documentos por Pagar Moneda Nacional": {
+            "accountType": "Payable"
+          }
+        },
+        "Gastos por Pagar": {
+          "Prestaciones Sociales": {
+            "isGroup": 1
+          },
+          "Salarios por Pagar": {},
+          "Servicios Basicos 1": {
+            "isGroup": 1
+          }
+        },
+        "Impuestos por Pagar": {
+          "Impuesto al Valor Agregado por Pagar": {
+            "accountType": "Tax"
+          },
+          "Impuesto sobre la Renta por Actividades Economicas": {
+            "accountType": "Tax"
+          },
+          "Impuestos Municipales": {
+            "Impuesto Municipal Sobre Ingresos": {
+              "accountType": "Tax"
+            },
+            "Matricula Municipal": {
+              "accountType": "Tax"
+            },
+            "Recoleccion Basura": {
+              "accountType": "Tax"
+            }
+          }
+        },
+        "Otras Cuentas por Pagar": {
+          "isGroup": 1
+        },
+        "Pasivos Financieros a Corto Plazo": {
+          "Otras Deudas Bancarias": {
+            "isGroup": 1
+          },
+          "Prestamos por Pagar a Corto Plazo": {
+            "isGroup": 1
+          },
+          "Sobregiros Bancarios": {
+            "isGroup": 1
+          }
+        },
+        "Provisiones por Pagar": {
+          "Pasivos Laborales": {
+            "Aguinaldo por Pagar": {},
+            "Indemnizacion Laboral": {}
+          },
+          "Reclamos por Pagar": {},
+          "Responsabilidad frente a terceros": {}
+        },
+        "Retenciones por Pagar": {
+          "Rentas de Actividades Economicas": {
+            "Otras Retenciones 10%": {
+              "accountType": "Tax"
+            },
+            "Retencion 10% Servicios Profesionales": {
+              "accountType": "Tax"
+            },
+            "Retencion 2% por C/Bienes o P/Servicios": {
+              "accountType": "Tax"
+            },
+            "Retencion 3% compra Bienes Agropecuarios": {
+              "accountType": "Tax"
+            },
+            "Retencion 5% compra Madera en Rollo": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 1.5% Actividades Economicas No Residentes": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 10% Actividades Economicas No Residentes": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 15% Actividades Economicas No Residentes": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 3% Actividades Economicas No Residentes": {
+              "accountType": "Tax"
+            }
+          },
+          "Rentas del Trabajo": {
+            "Retencion Definitiva 10% por Rentas del Trabajo - Indemnizacion Adicional": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 12.5% por Rentas del Trabajo - Dietas": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 15% por Rentas del Trabajo - No Residentes": {
+              "accountType": "Tax"
+            },
+            "Retencion Rentas del Trabajo Tarifa Progresiva": {
+              "accountType": "Tax"
+            }
+          },
+          "Rentas y Ganancias de Capital": {
+            "Retencion Definitiva 0.25% Transacciones Bursatiles": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 1% Transacciones Bursatiles": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 1.5% Transacciones Bursatiles": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 10% por Ganancia de Capital": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 2% Transacciones Bursatiles": {
+              "accountType": "Tax"
+            },
+            "Retencion Definitiva 5% por Rentas de Capital": {
+              "accountType": "Tax"
+            },
+            "Retencion Defintiva 10% por Rentas de Capital": {
+              "accountType": "Tax"
+            },
+            "Retencion Defintiva 15% por Rentas de Capital": {
+              "accountType": "Tax"
+            },
+            "Retenciones Defintiva 5% Fondos de Inversion": {
+              "accountType": "Tax"
+            }
+          },
+          "Retencion 17% Operaciones con Paraisos Fiscales": {
+            "accountType": "Tax"
+          }
+        }
+      },
+      "Pasivo No Corriente": {
+        "Cuentas por Pagar a Largo Plaso": {
+          "isGroup": 1
+        },
+        "Otras Cuentas por Pagar a Largo Plazo": {
+          "isGroup": 1
+        },
+        "Otros Pasivos Financieros a Largo Plaso": {
+          "isGroup": 1
+        },
+        "Prestamos a Largo Plazo": {
+          "isGroup": 1
+        }
+      },
+      "Pasivo por Impuestos Diferidos": {
+        "isGroup": 1
+      },
+      "rootType": "Liability"
+    }
   }
 }

--- a/fixtures/verified/nl.json
+++ b/fixtures/verified/nl.json
@@ -1,693 +1,693 @@
 {
-  "country_code": "nl", 
-  "name": "Netherlands - Grootboekschema", 
+  "countryCode": "nl",
+  "name": "Netherlands - Grootboekschema",
   "tree": {
-      "FABRIKAGEREKENINGEN": {
-    "is_group": 1,
-          "root_type": "Expense"
-      }, 
-      "FINANCIELE REKENINGEN, KORTLOPENDE VORDERINGEN EN SCHULDEN": {
-          "Bank": {
-              "RABO Bank": {
-                  "account_type": "Bank"
-              }, 
-              "account_type": "Bank"
-          }, 
-          "KORTLOPENDE SCHULDEN": {
-              "Af te dragen Btw-verlegd": {
-                  "account_type": "Tax"
-              }, 
-              "Afdracht loonheffing": {}, 
-              "Btw af te dragen hoog": {
-                  "account_type": "Tax"
-              }, 
-              "Btw af te dragen laag": {
-                  "account_type": "Tax"
-              }, 
-              "Btw af te dragen overig": {
-                  "account_type": "Tax"
-              }, 
-              "Btw oude jaren": {
-                  "account_type": "Tax"
-              }, 
-              "Btw te vorderen hoog": {
-                  "account_type": "Tax"
-              }, 
-              "Btw te vorderen laag": {
-                  "account_type": "Tax"
-              }, 
-              "Btw te vorderen overig": {
-                  "account_type": "Tax"
-              }, 
-              "Btw-afdracht": {
-                  "account_type": "Tax"
-              }, 
-              "Crediteuren": {
-                  "account_type": "Payable"
-              }, 
-              "Dividend": {}, 
-              "Dividendbelasting": {}, 
-              "Energiekosten 1": {}, 
-              "Investeringsaftrek": {}, 
-              "Loonheffing": {}, 
-              "Overige te betalen posten": {}, 
-              "Pensioenpremies 1": {}, 
-              "Premie WIR": {}, 
-              "Rekening-courant inkoopvereniging": {}, 
-              "Rente": {}, 
-              "Sociale lasten 1": {}, 
-              "Stock Recieved niet gefactureerd": {
-                  "account_type": "Stock Received But Not Billed"
-              }, 
-              "Tanti\u00e8mes 1": {}, 
-              "Te vorderen Btw-verlegd": {
-                  "account_type": "Tax"
-              }, 
-              "Telefoon/telefax 1": {}, 
-              "Termijnen onderh. werk": {}, 
-              "Vakantiedagen": {}, 
-              "Vakantiegeld 1": {}, 
-              "Vakantiezegels": {}, 
-              "Vennootschapsbelasting": {}, 
-              "Vooruit ontvangen bedr.": {}
-          }, 
-          "LIQUIDE MIDDELEN": {
-              "ABN-AMRO bank": {}, 
-              "Bankbetaalkaarten": {}, 
-              "Effecten": {}, 
-              "Girobetaalkaarten": {}, 
-              "Kas": {
-                  "account_type": "Cash"
-              }, 
-              "Kas  valuta": {
-                  "account_type": "Cash"
-              }, 
-              "Kleine kas": {
-                  "account_type": "Cash"
-              }, 
-              "Kruisposten": {}, 
-              "Postbank": {
-                  "account_type": "Cash"
-              }, 
-              "account_type": "Cash"
-          }, 
-          "VORDERINGEN": {
-              "Debiteuren": {
-                  "account_type": "Receivable"
-              }, 
-              "Dubieuze debiteuren": {}, 
-              "Overige vorderingen": {}, 
-              "Rekening-courant directie 1": {}, 
-              "Te ontvangen ziekengeld": {}, 
-              "Voorschotten personeel": {}, 
-              "Vooruitbetaalde kosten": {}, 
-              "Voorziening dubieuze debiteuren": {}
-          }, 
-          "root_type": "Asset"
-      }, 
-      "INDIRECTE KOSTEN": {
-    "is_group": 1,
-          "root_type": "Expense"
-      }, 
-      "KOSTENREKENINGEN": {
-          "AFSCHRIJVINGEN": {
-              "Aanhangwagens": {}, 
-              "Aankoopkosten": {}, 
-              "Aanloopkosten": {}, 
-              "Auteursrechten": {}, 
-              "Bedrijfsgebouwen": {}, 
-              "Bedrijfsinventaris": {
-                  "account_type": "Depreciation"
-              }, 
-              "Drankvergunningen": {}, 
-              "Fabrieksinventaris": {
-                  "account_type": "Depreciation"
-              }, 
-              "Gebouwen": {}, 
-              "Gereedschappen": {}, 
-              "Goodwill": {}, 
-              "Grondverbetering": {}, 
-              "Heftrucks": {}, 
-              "Kantine-inventaris": {}, 
-              "Kantoorinventaris": {
-                  "account_type": "Depreciation"
-              }, 
-              "Kantoormachines": {}, 
-              "Licenties": {}, 
-              "Machines 1": {}, 
-              "Magazijninventaris": {}, 
-              "Octrooien": {}, 
-              "Ontwikkelingskosten": {}, 
-              "Pachtersinvestering": {}, 
-              "Parkeerplaats": {}, 
-              "Personenauto's": {
-                  "account_type": "Depreciation"
-              }, 
-              "Rijwielen en bromfietsen": {}, 
-              "Tonnagevergunningen": {}, 
-              "Verbouwingen": {}, 
-              "Vergunningen": {}, 
-              "Voorraadverschillen": {}, 
-              "Vrachtauto's": {}, 
-              "Winkels": {}, 
-              "Woon-winkelhuis": {}, 
-              "account_type": "Depreciation"
-          }, 
-          "ALGEMENE KOSTEN": {
-              "Accountantskosten": {}, 
-              "Advieskosten": {}, 
-              "Assuranties 1": {}, 
-              "Bankkosten": {}, 
-              "Juridische kosten": {}, 
-              "Overige algemene kosten": {}, 
-              "Toev. Ass. eigen risico": {}
-          }, 
-          "BEDRIJFSKOSTEN": {
-              "Assuranties 2": {}, 
-              "Energie (krachtstroom)": {}, 
-              "Gereedschappen 1": {}, 
-              "Hulpmaterialen 1": {}, 
-              "Huur inventaris": {}, 
-              "Huur machines": {}, 
-              "Leasing invent.operational": {}, 
-              "Leasing mach. operational": {}, 
-              "Onderhoud inventaris": {}, 
-              "Onderhoud machines": {}, 
-              "Ophalen/vervoer afval": {}, 
-              "Overige bedrijfskosten": {}
-          }, 
-          "FINANCIERINGSKOSTEN 1": {
-              "Overige rentebaten": {}, 
-              "Overige rentelasten": {}, 
-              "Rente bankkrediet": {}, 
-              "Rente huurkoopcontracten": {}, 
-              "Rente hypotheek": {}, 
-              "Rente leasecontracten": {}, 
-              "Rente lening o/g": {}, 
-              "Rente lening u/g": {}
-          }, 
-          "HUISVESTINGSKOSTEN": {
-              "Assurantie onroerend goed": {}, 
-              "Belastingen onr. Goed": {}, 
-              "Energiekosten": {}, 
-              "Groot onderhoud onr. Goed": {}, 
-              "Huur": {}, 
-              "Huurwaarde woongedeelte": {}, 
-              "Onderhoud onroerend goed": {}, 
-              "Ontvangen huren": {}, 
-              "Overige huisvestingskosten": {}, 
-              "Pacht": {}, 
-              "Schoonmaakkosten": {}, 
-              "Toevoeging egalisatieres. Groot onderhoud": {}
-          }, 
-          "KANTOORKOSTEN": {
-              "Administratiekosten": {}, 
-              "Contributies/abonnementen": {}, 
-              "Huur kantoorapparatuur": {}, 
-              "Internetaansluiting": {}, 
-              "Kantoorbenodigdh./drukw.": {}, 
-              "Onderhoud kantoorinvent.": {}, 
-              "Overige kantoorkosten": {}, 
-              "Porti": {}, 
-              "Telefoon/telefax": {}
-          }, 
-          "OVERIGE BATEN EN LASTEN": {
-              "Betaalde schadevergoed.": {}, 
-              "Boekverlies vaste activa": {}, 
-              "Boekwinst van vaste activa": {}, 
-              "K.O. regeling OB": {}, 
-              "Kasverschillen": {}, 
-              "Kosten loonbelasting": {}, 
-              "Kosten omzetbelasting": {}, 
-              "Nadelige koersverschillen": {}, 
-              "Naheffing bedrijfsver.": {}, 
-              "Ontvangen schadevergoed.": {}, 
-              "Overige baten": {}, 
-              "Overige lasten": {}, 
-              "Voordelige koersverschil.": {}
-          }, 
-          "PERSONEELSKOSTEN": {
-              "Autokostenvergoeding": {}, 
-              "Bedrijfskleding": {}, 
-              "Belastingvrije uitkeringen": {}, 
-              "Bijzondere beloningen": {}, 
-              "Congressen, seminars en symposia": {}, 
-              "Gereedschapsgeld": {}, 
-              "Geschenken personeel": {}, 
-              "Gratificaties": {}, 
-              "Inhouding pensioenpremies": {}, 
-              "Inhouding sociale lasten": {}, 
-              "Kantinekosten": {}, 
-              "Lonen en salarissen": {}, 
-              "Loonwerk": {}, 
-              "Managementvergoedingen": {}, 
-              "Opleidingskosten": {}, 
-              "Oprenting stamrechtverpl.": {}, 
-              "Overhevelingstoeslag": {}, 
-              "Overige kostenverg.": {}, 
-              "Overige personeelskosten": {}, 
-              "Overige uitkeringen": {}, 
-              "Pensioenpremies": {}, 
-              "Provisie 1": {}, 
-              "Reiskosten": {}, 
-              "Rijwielvergoeding": {}, 
-              "Sociale lasten": {}, 
-              "Tanti\u00e8mes": {}, 
-              "Thuiswerkers": {}, 
-              "Toev. Backservice pens.verpl.": {}, 
-              "Toevoeging pensioenverpl.": {}, 
-              "Uitkering ziekengeld": {}, 
-              "Uitzendkrachten": {}, 
-              "Vakantiebonnen": {}, 
-              "Vakantiegeld": {}, 
-              "Vergoeding studiekosten": {}, 
-              "Wervingskosten personeel": {}
-          }, 
-          "VERKOOPKOSTEN": {
-              "Advertenties": {}, 
-              "Afschrijving dubieuze deb.": {}, 
-              "Beurskosten": {}, 
-              "Etalagekosten": {}, 
-              "Exportkosten": {}, 
-              "Kascorrecties": {}, 
-              "Overige verkoopkosten": {}, 
-              "Provisie": {}, 
-              "Reclame": {}, 
-              "Reis en verblijfkosten": {}, 
-              "Relatiegeschenken": {}, 
-              "Representatiekosten": {}, 
-              "Uitgaande vrachten": {}, 
-              "Veilingkosten": {}, 
-              "Verpakkingsmateriaal 1": {}, 
-              "Websitekosten": {}
-          }, 
-          "VERVOERSKOSTEN": {
-              "Assuranties auto's": {}, 
-              "Brandstoffen": {}, 
-              "Leasing auto's": {}, 
-              "Onderhoud personenauto's": {}, 
-              "Onderhoud vrachtauto's": {}, 
-              "Overige vervoerskosten": {}, 
-              "Priv\u00e9-gebruik auto's": {}, 
-              "Wegenbelasting": {}
-          }, 
-          "root_type": "Expense"
-      }, 
-      "TUSSENREKENINGEN": {
-          "Betaalwijze cadeaubonnen": {
-              "account_type": "Cash"
-          }, 
-          "Betaalwijze chipknip": {
-              "account_type": "Cash"
-          }, 
-          "Betaalwijze contant": {
-              "account_type": "Cash"
-          }, 
-          "Betaalwijze pin": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen Nederland hoog": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen Nederland laag": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen Nederland onbelast": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen Nederland overig": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen Nederland verlegd": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen binnen EU hoog": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen binnen EU laag": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen binnen EU overig": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen buiten EU hoog": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen buiten EU laag": {
-              "account_type": "Cash"
-          }, 
-          "Inkopen buiten EU overig": {
-              "account_type": "Cash"
-          }, 
-          "Kassa 1": {
-              "account_type": "Cash"
-          }, 
-          "Kassa 2": {
-              "account_type": "Cash"
-          }, 
-          "Netto lonen": {
-              "account_type": "Cash"
-          }, 
-          "Tegenrekening Inkopen": {
-              "account_type": "Cash"
-          }, 
-          "Tussenrek. autom. betalingen": {
-              "account_type": "Cash"
-          }, 
-          "Tussenrek. autom. loonbetalingen": {
-              "account_type": "Cash"
-          }, 
-          "Tussenrek. cadeaubonbetalingen": {
-              "account_type": "Cash"
-          }, 
-          "Tussenrekening balans": {
-              "account_type": "Cash"
-          }, 
-          "Tussenrekening chipknip": {
-              "account_type": "Cash"
-          }, 
-          "Tussenrekening correcties": {
-              "account_type": "Cash"
-          }, 
-          "Tussenrekening pin": {
-              "account_type": "Cash"
-          }, 
-          "Vraagposten": {
-              "account_type": "Cash"
-          }, 
-          "root_type": "Asset"
-      }, 
-      "VASTE ACTIVA, EIGEN VERMOGEN, LANGLOPEND VREEMD VERMOGEN EN VOORZIENINGEN": {
-          "EIGEN VERMOGEN": {
-              "Aandelenkapitaal": {
-                  "account_type": "Equity"
-              }, 
-              "Assuranties": {
-                  "account_type": "Equity"
-              }, 
-              "Buitengewone lasten": {
-                  "account_type": "Equity"
-              }, 
-              "Giften": {
-                  "account_type": "Equity"
-              }, 
-              "Huishoudgeld": {
-                  "account_type": "Equity"
-              }, 
-              "Inkomstenbelasting": {
-                  "account_type": "Equity"
-              }, 
-              "Kapitaal": {
-                  "account_type": "Equity"
-              }, 
-              "Overige persoonlijke verplichtingen": {
-                  "account_type": "Equity"
-              }, 
-              "Overige priv\u00e9-uitgaven": {
-                  "account_type": "Equity"
-              }, 
-              "Overige reserves": {
-                  "account_type": "Equity"
-              }, 
-              "Premie lijfrenteverzekeringen": {
-                  "account_type": "Equity"
-              }, 
-              "Premie volksverzekeringen": {
-                  "account_type": "Equity"
-              }, 
-              "Priv\u00e9-gebruik": {
-                  "account_type": "Equity"
-              }, 
-              "Priv\u00e9-opnamen/stortingen": {
-                  "account_type": "Equity"
-              }, 
-              "Vermogensbelasting": {
-                  "account_type": "Equity"
-              }, 
-              "WAO en ziekengeldverzekeringen": {
-                  "account_type": "Equity"
-              }, 
-              "Wettelijke reserves": {
-                  "account_type": "Equity"
-              }
-          }, 
-          "FINANCIELE VASTE ACTIVA EN LANGLOPENDE VORDERINGEN": {
-              "FINANCIELE VASTE ACTIVA": {
-                  "Aandeel inkoopcombinatie": {}, 
-                  "Meerderheidsdeelnemingen": {}, 
-                  "Minderheidsdeelnemingen": {}
-              }, 
-              "LANGLOPENDE VORDERINGEN": {
-                  "Financieringskosten": {}, 
-                  "Financieringskosten huurkoop": {}, 
-                  "Hypotheken u/g 1": {}, 
-                  "Hypotheken u/g 2": {}, 
-                  "Hypotheken u/g 3": {}, 
-                  "Leningen u/g 1": {}, 
-                  "Leningen u/g 2": {}, 
-                  "Leningen u/g 3": {}, 
-                  "Leningen u/g 4": {}, 
-                  "Leningen u/g 5": {}, 
-                  "Vorderingen op deelnemingen": {}, 
-                  "Waarborgsommen": {}
-              }
-          }, 
-          "IMMATERIELE ACTIVA": {
-              "Aanschafwaarde Aanloopkosten": {}, 
-              "Aanschafwaarde Auteursrechten": {}, 
-              "Aanschafwaarde Drankvergunningen": {}, 
-              "Aanschafwaarde Goodwill": {}, 
-              "Aanschafwaarde Octrooien": {}, 
-              "Aanschafwaarde Ontwikkelingskosten": {}, 
-              "Aanschafwaarde Tonnagevergunningen": {}, 
-              "Aanschafwaarde Vergunningen": {}, 
-              "Afschrijving Aanloopkosten": {}, 
-              "Afschrijving Auteursrechten": {}, 
-              "Afschrijving Drankvergunningen": {}, 
-              "Afschrijving Goodwill": {}, 
-              "Afschrijving Licenties": {}, 
-              "Afschrijving Octrooien": {}, 
-              "Afschrijving Ontwikkelingskosten": {}, 
-              "Afschrijving Tonnagevergunningen": {}, 
-              "Afschrijving Vergunningen": {}
-          }, 
-          "LANGLOPENDE SCHULDEN EN AFLOSSINGEN": {
-              "AFLOSSINGEN": {
-                  "Huurkoopverplichtingen": {}, 
-                  "Hypotheek o/g 1": {}, 
-                  "Hypotheek o/g 2": {}, 
-                  "Hypotheek o/g 3": {}, 
-                  "Hypotheek o/g 4": {}, 
-                  "Hypotheek o/g 5": {}, 
-                  "Lease-verplichtingen": {}
-              }, 
-              "LANGLOPENDE SCHULDEN": {
-                  "Huurkoopverplichtingen 1": {}, 
-                  "Hypotheken o/g 1": {}, 
-                  "Hypotheken o/g 2": {}, 
-                  "Hypotheken o/g 3": {}, 
-                  "Hypotheken o/g 4": {}, 
-                  "Hypotheken o/g 5": {}, 
-                  "Lease-verplichtingen 1": {}, 
-                  "Leningen o/g 1": {}, 
-                  "Leningen o/g 2": {}, 
-                  "Leningen o/g 3": {}, 
-                  "Leningen o/g 4": {}, 
-                  "Leningen o/g 5": {}, 
-                  "Rekening-courant directie": {}
-              }
-          }, 
-          "MACHINES EN INVENTARIS": {
-              "INVENTARIS": {
-                  "Aanschafwaarde Bedrijfsinventaris": {}, 
-                  "Aanschafwaarde Fabrieksinventaris": {}, 
-                  "Aanschafwaarde Gereedschappen": {}, 
-                  "Aanschafwaarde Kantine-inventaris": {}, 
-                  "Aanschafwaarde Kantoorinventaris": {}, 
-                  "Aanschafwaarde Kantoormachines": {}, 
-                  "Aanschafwaarde Magazijninventaris": {}, 
-                  "Afschrijving Bedrijfsinventaris": {}, 
-                  "Afschrijving Fabrieksinventaris": {}, 
-                  "Afschrijving Gereedschappen": {}, 
-                  "Afschrijving Kantine-inventaris": {}, 
-                  "Afschrijving Kantoorinventaris": {}, 
-                  "Afschrijving Kantoormachines": {}, 
-                  "Afschrijving Magazijninventaris": {}, 
-                  "account_type": "Stock"
-              }, 
-              "MACHINES": {
-                  "Aanschafwaarde Machines 1": {
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "Aanschafwaarde Machines 2": {}, 
-                  "Aanschafwaarde Machines 3": {}, 
-                  "Aanschafwaarde Machines 4": {}, 
-                  "Aanschafwaarde Machines 5": {}, 
-                  "Afschrijving Machines 1": {
-                      "account_type": "Accumulated Depreciation"
-                  }, 
-                  "Afschrijving Machines 2": {}, 
-                  "Afschrijving Machines 3": {}, 
-                  "Afschrijving Machines 4": {}, 
-                  "Afschrijving Machines 5": {}, 
-                  "account_type": "Fixed Asset"
-              }
-          }, 
-          "ONROERENDE GOEDEREN": {
-              "Aanschafwaarde Aanloopkosten 1": {}, 
-              "Aanschafwaarde Bedrijfsgebouwen": {}, 
-              "Aanschafwaarde Gebouwen": {}, 
-              "Aanschafwaarde Grondverbetering": {}, 
-              "Aanschafwaarde Landerijen": {}, 
-              "Aanschafwaarde Ondergrond gebouwen": {}, 
-              "Aanschafwaarde Pachtersinvesteringen": {}, 
-              "Aanschafwaarde Parkeerplaats": {}, 
-              "Aanschafwaarde Verbouwingen": {}, 
-              "Aanschafwaarde Winkels": {}, 
-              "Aanschafwaarde Woon-winkelhuis": {}, 
-              "Afschrijving Aanloopkosten 1": {}, 
-              "Afschrijving Bedrijfsgebouwen": {}, 
-              "Afschrijving Gebouwen": {}, 
-              "Afschrijving Grondverbetering": {}, 
-              "Afschrijving Pachtersinvesteringen": {}, 
-              "Afschrijving Parkeerplaats": {}, 
-              "Afschrijving Verbouwingen": {}, 
-              "Afschrijving Winkels": {}, 
-              "Afschrijving Woon-winkelhuis": {}
-          }, 
-          "VERVOERMIDDELEN": {
-              "Aanschafwaarde Aanhangwagens": {}, 
-              "Aanschafwaarde Heftrucks": {}, 
-              "Aanschafwaarde Personenauto's": {}, 
-              "Aanschafwaarde Rijwielen en bromfietsen": {}, 
-              "Aanschafwaarde Vrachtauto's": {}, 
-              "Afschrijving Aanhangwagens": {}, 
-              "Afschrijving Heftrucks": {}, 
-              "Afschrijving Personenauto's": {}, 
-              "Afschrijving Rijwielen en bromfietsen": {}, 
-              "Afschrijving Vrachtauto's": {}
-          }, 
-          "VOORZIENINGEN": {
-              "Assurantie eigen risico": {
-                  "account_type": "Equity"
-              }, 
-              "Backservice pensioenverpl.": {
-                  "account_type": "Equity"
-              }, 
-              "Egalisatierekening WIR": {
-                  "account_type": "Equity"
-              }, 
-              "Egalisatieres. grootonderh.": {
-                  "account_type": "Equity"
-              }, 
-              "Garantieverplichtingen": {
-                  "account_type": "Equity"
-              }, 
-              "Latente belastingverpl.": {
-                  "account_type": "Equity"
-              }, 
-              "Pens.voorz. eigen beheer": {
-                  "account_type": "Equity"
-              }, 
-              "Pensioenverplichtingen": {
-                  "account_type": "Equity"
-              }, 
-              "Stamrechtverplichtingen": {
-                  "account_type": "Equity"
-              }, 
-              "Vervangingsreserve": {
-                  "account_type": "Equity"
-              }, 
-              "Voorziening deelnemingen": {
-                  "account_type": "Equity"
-              }
-          }, 
-          "root_type": "Asset"
-      }, 
-      "VERKOOPRESULTATEN": {
-          "Diensten fabric. 0% niet-EU": {}, 
-          "Diensten fabricage 0% EU": {}, 
-          "Diensten fabricage hoog": {}, 
-          "Diensten fabricage laag": {}, 
-          "Diensten fabricage overig": {}, 
-          "Diensten handel 0% EU": {}, 
-          "Diensten handel 0% niet-EU": {}, 
-          "Diensten handel hoog tarief": {}, 
-          "Diensten handel laag tarief": {}, 
-          "Verkopen Fabric. 0% niet-EU": {}, 
-          "Verkopen Handel 0% niet-EU": {}, 
-          "Verkopen fabric. 0 % EU": {}, 
-          "Verkopen fabricage hoog": {}, 
-          "Verkopen fabricage laag": {}, 
-          "Verkopen fabricage overig": {}, 
-          "Verkopen handel 0% EU": {}, 
-          "Verkopen handel hoog": {}, 
-          "Verkopen handel laag": {}, 
-          "Verkopen handel overig": {}, 
-          "Verleende Kredietbep. fabricage": {}, 
-          "Verleende Kredietbep. handel": {}, 
-          "root_type": "Income"
-      }, 
-      "VOORRAAD GEREED PRODUCT EN ONDERHANDEN WERK": {
-          "Betalingskort. crediteuren": {}, 
-          "Garantiekosten": {}, 
-          "Hulpmaterialen": {}, 
-          "Inkomende vrachten": {
-              "account_type": "Expenses Included In Valuation"
-          }, 
-          "Inkoop import buiten EU hoog": {}, 
-          "Inkoop import buiten EU laag": {}, 
-          "Inkoop import buiten EU overig": {}, 
-          "Inkoopbonussen": {}, 
-          "Inkoopkosten": {}, 
-          "Inkoopprovisie": {}, 
-          "Inkopen BTW verlegd": {}, 
-          "Inkopen EU hoog tarief": {}, 
-          "Inkopen EU laag tarief": {}, 
-          "Inkopen EU overig": {}, 
-          "Inkopen hoog": {}, 
-          "Inkopen laag": {}, 
-          "Inkopen nul": {}, 
-          "Inkopen overig": {}, 
-          "Invoerkosten": {}, 
-          "Kosten inkoopvereniging": {}, 
-          "Kostprijs omzet grondstoffen": {
-              "account_type": "Cost of Goods Sold"
-          }, 
-          "Kostprijs omzet handelsgoederen": {}, 
-          "Onttrekking uitgev.garantie": {}, 
-          "Priv\u00e9-gebruik goederen": {}, 
-          "Stock aanpassing": {
-              "account_type": "Stock Adjustment"
-          }, 
-          "Tegenrekening inkoop": {}, 
-          "Toev. Voorz. incour. grondst.": {}, 
-          "Toevoeging garantieverpl.": {}, 
-          "Toevoeging voorz. incour. handelsgoed.": {}, 
-          "Uitbesteed werk": {}, 
-          "Voorz. Incourourant grondst.": {}, 
-          "Voorz.incour. handelsgoed.": {}, 
-          "root_type": "Expense"
-      }, 
-      "VOORRAAD GRONDSTOFFEN, HULPMATERIALEN EN HANDELSGOEDEREN": {
-          "Emballage": {}, 
-          "Gereed product 1": {}, 
-          "Gereed product 2": {}, 
-          "Goederen 1": {}, 
-          "Goederen 2": {}, 
-          "Goederen in consignatie": {}, 
-          "Goederen onderweg": {}, 
-          "Grondstoffen 1": {}, 
-          "Grondstoffen 2": {}, 
-          "Halffabrikaten 1": {}, 
-          "Halffabrikaten 2": {}, 
-          "Hulpstoffen 1": {}, 
-          "Hulpstoffen 2": {}, 
-          "Kantoorbenodigdheden": {}, 
-          "Onderhanden werk": {}, 
-          "Verpakkingsmateriaal": {}, 
-          "Zegels": {}, 
-          "root_type": "Asset"
-      }
+    "FABRIKAGEREKENINGEN": {
+      "isGroup": 1,
+      "rootType": "Expense"
+    },
+    "FINANCIELE REKENINGEN, KORTLOPENDE VORDERINGEN EN SCHULDEN": {
+      "Bank": {
+        "RABO Bank": {
+          "accountType": "Bank"
+        },
+        "accountType": "Bank"
+      },
+      "KORTLOPENDE SCHULDEN": {
+        "Af te dragen Btw-verlegd": {
+          "accountType": "Tax"
+        },
+        "Afdracht loonheffing": {},
+        "Btw af te dragen hoog": {
+          "accountType": "Tax"
+        },
+        "Btw af te dragen laag": {
+          "accountType": "Tax"
+        },
+        "Btw af te dragen overig": {
+          "accountType": "Tax"
+        },
+        "Btw oude jaren": {
+          "accountType": "Tax"
+        },
+        "Btw te vorderen hoog": {
+          "accountType": "Tax"
+        },
+        "Btw te vorderen laag": {
+          "accountType": "Tax"
+        },
+        "Btw te vorderen overig": {
+          "accountType": "Tax"
+        },
+        "Btw-afdracht": {
+          "accountType": "Tax"
+        },
+        "Crediteuren": {
+          "accountType": "Payable"
+        },
+        "Dividend": {},
+        "Dividendbelasting": {},
+        "Energiekosten 1": {},
+        "Investeringsaftrek": {},
+        "Loonheffing": {},
+        "Overige te betalen posten": {},
+        "Pensioenpremies 1": {},
+        "Premie WIR": {},
+        "Rekening-courant inkoopvereniging": {},
+        "Rente": {},
+        "Sociale lasten 1": {},
+        "Stock Recieved niet gefactureerd": {
+          "accountType": "Stock Received But Not Billed"
+        },
+        "Tanti\u00e8mes 1": {},
+        "Te vorderen Btw-verlegd": {
+          "accountType": "Tax"
+        },
+        "Telefoon/telefax 1": {},
+        "Termijnen onderh. werk": {},
+        "Vakantiedagen": {},
+        "Vakantiegeld 1": {},
+        "Vakantiezegels": {},
+        "Vennootschapsbelasting": {},
+        "Vooruit ontvangen bedr.": {}
+      },
+      "LIQUIDE MIDDELEN": {
+        "ABN-AMRO bank": {},
+        "Bankbetaalkaarten": {},
+        "Effecten": {},
+        "Girobetaalkaarten": {},
+        "Kas": {
+          "accountType": "Cash"
+        },
+        "Kas  valuta": {
+          "accountType": "Cash"
+        },
+        "Kleine kas": {
+          "accountType": "Cash"
+        },
+        "Kruisposten": {},
+        "Postbank": {
+          "accountType": "Cash"
+        },
+        "accountType": "Cash"
+      },
+      "VORDERINGEN": {
+        "Debiteuren": {
+          "accountType": "Receivable"
+        },
+        "Dubieuze debiteuren": {},
+        "Overige vorderingen": {},
+        "Rekening-courant directie 1": {},
+        "Te ontvangen ziekengeld": {},
+        "Voorschotten personeel": {},
+        "Vooruitbetaalde kosten": {},
+        "Voorziening dubieuze debiteuren": {}
+      },
+      "rootType": "Asset"
+    },
+    "INDIRECTE KOSTEN": {
+      "isGroup": 1,
+      "rootType": "Expense"
+    },
+    "KOSTENREKENINGEN": {
+      "AFSCHRIJVINGEN": {
+        "Aanhangwagens": {},
+        "Aankoopkosten": {},
+        "Aanloopkosten": {},
+        "Auteursrechten": {},
+        "Bedrijfsgebouwen": {},
+        "Bedrijfsinventaris": {
+          "accountType": "Depreciation"
+        },
+        "Drankvergunningen": {},
+        "Fabrieksinventaris": {
+          "accountType": "Depreciation"
+        },
+        "Gebouwen": {},
+        "Gereedschappen": {},
+        "Goodwill": {},
+        "Grondverbetering": {},
+        "Heftrucks": {},
+        "Kantine-inventaris": {},
+        "Kantoorinventaris": {
+          "accountType": "Depreciation"
+        },
+        "Kantoormachines": {},
+        "Licenties": {},
+        "Machines 1": {},
+        "Magazijninventaris": {},
+        "Octrooien": {},
+        "Ontwikkelingskosten": {},
+        "Pachtersinvestering": {},
+        "Parkeerplaats": {},
+        "Personenauto's": {
+          "accountType": "Depreciation"
+        },
+        "Rijwielen en bromfietsen": {},
+        "Tonnagevergunningen": {},
+        "Verbouwingen": {},
+        "Vergunningen": {},
+        "Voorraadverschillen": {},
+        "Vrachtauto's": {},
+        "Winkels": {},
+        "Woon-winkelhuis": {},
+        "accountType": "Depreciation"
+      },
+      "ALGEMENE KOSTEN": {
+        "Accountantskosten": {},
+        "Advieskosten": {},
+        "Assuranties 1": {},
+        "Bankkosten": {},
+        "Juridische kosten": {},
+        "Overige algemene kosten": {},
+        "Toev. Ass. eigen risico": {}
+      },
+      "BEDRIJFSKOSTEN": {
+        "Assuranties 2": {},
+        "Energie (krachtstroom)": {},
+        "Gereedschappen 1": {},
+        "Hulpmaterialen 1": {},
+        "Huur inventaris": {},
+        "Huur machines": {},
+        "Leasing invent.operational": {},
+        "Leasing mach. operational": {},
+        "Onderhoud inventaris": {},
+        "Onderhoud machines": {},
+        "Ophalen/vervoer afval": {},
+        "Overige bedrijfskosten": {}
+      },
+      "FINANCIERINGSKOSTEN 1": {
+        "Overige rentebaten": {},
+        "Overige rentelasten": {},
+        "Rente bankkrediet": {},
+        "Rente huurkoopcontracten": {},
+        "Rente hypotheek": {},
+        "Rente leasecontracten": {},
+        "Rente lening o/g": {},
+        "Rente lening u/g": {}
+      },
+      "HUISVESTINGSKOSTEN": {
+        "Assurantie onroerend goed": {},
+        "Belastingen onr. Goed": {},
+        "Energiekosten": {},
+        "Groot onderhoud onr. Goed": {},
+        "Huur": {},
+        "Huurwaarde woongedeelte": {},
+        "Onderhoud onroerend goed": {},
+        "Ontvangen huren": {},
+        "Overige huisvestingskosten": {},
+        "Pacht": {},
+        "Schoonmaakkosten": {},
+        "Toevoeging egalisatieres. Groot onderhoud": {}
+      },
+      "KANTOORKOSTEN": {
+        "Administratiekosten": {},
+        "Contributies/abonnementen": {},
+        "Huur kantoorapparatuur": {},
+        "Internetaansluiting": {},
+        "Kantoorbenodigdh./drukw.": {},
+        "Onderhoud kantoorinvent.": {},
+        "Overige kantoorkosten": {},
+        "Porti": {},
+        "Telefoon/telefax": {}
+      },
+      "OVERIGE BATEN EN LASTEN": {
+        "Betaalde schadevergoed.": {},
+        "Boekverlies vaste activa": {},
+        "Boekwinst van vaste activa": {},
+        "K.O. regeling OB": {},
+        "Kasverschillen": {},
+        "Kosten loonbelasting": {},
+        "Kosten omzetbelasting": {},
+        "Nadelige koersverschillen": {},
+        "Naheffing bedrijfsver.": {},
+        "Ontvangen schadevergoed.": {},
+        "Overige baten": {},
+        "Overige lasten": {},
+        "Voordelige koersverschil.": {}
+      },
+      "PERSONEELSKOSTEN": {
+        "Autokostenvergoeding": {},
+        "Bedrijfskleding": {},
+        "Belastingvrije uitkeringen": {},
+        "Bijzondere beloningen": {},
+        "Congressen, seminars en symposia": {},
+        "Gereedschapsgeld": {},
+        "Geschenken personeel": {},
+        "Gratificaties": {},
+        "Inhouding pensioenpremies": {},
+        "Inhouding sociale lasten": {},
+        "Kantinekosten": {},
+        "Lonen en salarissen": {},
+        "Loonwerk": {},
+        "Managementvergoedingen": {},
+        "Opleidingskosten": {},
+        "Oprenting stamrechtverpl.": {},
+        "Overhevelingstoeslag": {},
+        "Overige kostenverg.": {},
+        "Overige personeelskosten": {},
+        "Overige uitkeringen": {},
+        "Pensioenpremies": {},
+        "Provisie 1": {},
+        "Reiskosten": {},
+        "Rijwielvergoeding": {},
+        "Sociale lasten": {},
+        "Tanti\u00e8mes": {},
+        "Thuiswerkers": {},
+        "Toev. Backservice pens.verpl.": {},
+        "Toevoeging pensioenverpl.": {},
+        "Uitkering ziekengeld": {},
+        "Uitzendkrachten": {},
+        "Vakantiebonnen": {},
+        "Vakantiegeld": {},
+        "Vergoeding studiekosten": {},
+        "Wervingskosten personeel": {}
+      },
+      "VERKOOPKOSTEN": {
+        "Advertenties": {},
+        "Afschrijving dubieuze deb.": {},
+        "Beurskosten": {},
+        "Etalagekosten": {},
+        "Exportkosten": {},
+        "Kascorrecties": {},
+        "Overige verkoopkosten": {},
+        "Provisie": {},
+        "Reclame": {},
+        "Reis en verblijfkosten": {},
+        "Relatiegeschenken": {},
+        "Representatiekosten": {},
+        "Uitgaande vrachten": {},
+        "Veilingkosten": {},
+        "Verpakkingsmateriaal 1": {},
+        "Websitekosten": {}
+      },
+      "VERVOERSKOSTEN": {
+        "Assuranties auto's": {},
+        "Brandstoffen": {},
+        "Leasing auto's": {},
+        "Onderhoud personenauto's": {},
+        "Onderhoud vrachtauto's": {},
+        "Overige vervoerskosten": {},
+        "Priv\u00e9-gebruik auto's": {},
+        "Wegenbelasting": {}
+      },
+      "rootType": "Expense"
+    },
+    "TUSSENREKENINGEN": {
+      "Betaalwijze cadeaubonnen": {
+        "accountType": "Cash"
+      },
+      "Betaalwijze chipknip": {
+        "accountType": "Cash"
+      },
+      "Betaalwijze contant": {
+        "accountType": "Cash"
+      },
+      "Betaalwijze pin": {
+        "accountType": "Cash"
+      },
+      "Inkopen Nederland hoog": {
+        "accountType": "Cash"
+      },
+      "Inkopen Nederland laag": {
+        "accountType": "Cash"
+      },
+      "Inkopen Nederland onbelast": {
+        "accountType": "Cash"
+      },
+      "Inkopen Nederland overig": {
+        "accountType": "Cash"
+      },
+      "Inkopen Nederland verlegd": {
+        "accountType": "Cash"
+      },
+      "Inkopen binnen EU hoog": {
+        "accountType": "Cash"
+      },
+      "Inkopen binnen EU laag": {
+        "accountType": "Cash"
+      },
+      "Inkopen binnen EU overig": {
+        "accountType": "Cash"
+      },
+      "Inkopen buiten EU hoog": {
+        "accountType": "Cash"
+      },
+      "Inkopen buiten EU laag": {
+        "accountType": "Cash"
+      },
+      "Inkopen buiten EU overig": {
+        "accountType": "Cash"
+      },
+      "Kassa 1": {
+        "accountType": "Cash"
+      },
+      "Kassa 2": {
+        "accountType": "Cash"
+      },
+      "Netto lonen": {
+        "accountType": "Cash"
+      },
+      "Tegenrekening Inkopen": {
+        "accountType": "Cash"
+      },
+      "Tussenrek. autom. betalingen": {
+        "accountType": "Cash"
+      },
+      "Tussenrek. autom. loonbetalingen": {
+        "accountType": "Cash"
+      },
+      "Tussenrek. cadeaubonbetalingen": {
+        "accountType": "Cash"
+      },
+      "Tussenrekening balans": {
+        "accountType": "Cash"
+      },
+      "Tussenrekening chipknip": {
+        "accountType": "Cash"
+      },
+      "Tussenrekening correcties": {
+        "accountType": "Cash"
+      },
+      "Tussenrekening pin": {
+        "accountType": "Cash"
+      },
+      "Vraagposten": {
+        "accountType": "Cash"
+      },
+      "rootType": "Asset"
+    },
+    "VASTE ACTIVA, EIGEN VERMOGEN, LANGLOPEND VREEMD VERMOGEN EN VOORZIENINGEN": {
+      "EIGEN VERMOGEN": {
+        "Aandelenkapitaal": {
+          "accountType": "Equity"
+        },
+        "Assuranties": {
+          "accountType": "Equity"
+        },
+        "Buitengewone lasten": {
+          "accountType": "Equity"
+        },
+        "Giften": {
+          "accountType": "Equity"
+        },
+        "Huishoudgeld": {
+          "accountType": "Equity"
+        },
+        "Inkomstenbelasting": {
+          "accountType": "Equity"
+        },
+        "Kapitaal": {
+          "accountType": "Equity"
+        },
+        "Overige persoonlijke verplichtingen": {
+          "accountType": "Equity"
+        },
+        "Overige priv\u00e9-uitgaven": {
+          "accountType": "Equity"
+        },
+        "Overige reserves": {
+          "accountType": "Equity"
+        },
+        "Premie lijfrenteverzekeringen": {
+          "accountType": "Equity"
+        },
+        "Premie volksverzekeringen": {
+          "accountType": "Equity"
+        },
+        "Priv\u00e9-gebruik": {
+          "accountType": "Equity"
+        },
+        "Priv\u00e9-opnamen/stortingen": {
+          "accountType": "Equity"
+        },
+        "Vermogensbelasting": {
+          "accountType": "Equity"
+        },
+        "WAO en ziekengeldverzekeringen": {
+          "accountType": "Equity"
+        },
+        "Wettelijke reserves": {
+          "accountType": "Equity"
+        }
+      },
+      "FINANCIELE VASTE ACTIVA EN LANGLOPENDE VORDERINGEN": {
+        "FINANCIELE VASTE ACTIVA": {
+          "Aandeel inkoopcombinatie": {},
+          "Meerderheidsdeelnemingen": {},
+          "Minderheidsdeelnemingen": {}
+        },
+        "LANGLOPENDE VORDERINGEN": {
+          "Financieringskosten": {},
+          "Financieringskosten huurkoop": {},
+          "Hypotheken u/g 1": {},
+          "Hypotheken u/g 2": {},
+          "Hypotheken u/g 3": {},
+          "Leningen u/g 1": {},
+          "Leningen u/g 2": {},
+          "Leningen u/g 3": {},
+          "Leningen u/g 4": {},
+          "Leningen u/g 5": {},
+          "Vorderingen op deelnemingen": {},
+          "Waarborgsommen": {}
+        }
+      },
+      "IMMATERIELE ACTIVA": {
+        "Aanschafwaarde Aanloopkosten": {},
+        "Aanschafwaarde Auteursrechten": {},
+        "Aanschafwaarde Drankvergunningen": {},
+        "Aanschafwaarde Goodwill": {},
+        "Aanschafwaarde Octrooien": {},
+        "Aanschafwaarde Ontwikkelingskosten": {},
+        "Aanschafwaarde Tonnagevergunningen": {},
+        "Aanschafwaarde Vergunningen": {},
+        "Afschrijving Aanloopkosten": {},
+        "Afschrijving Auteursrechten": {},
+        "Afschrijving Drankvergunningen": {},
+        "Afschrijving Goodwill": {},
+        "Afschrijving Licenties": {},
+        "Afschrijving Octrooien": {},
+        "Afschrijving Ontwikkelingskosten": {},
+        "Afschrijving Tonnagevergunningen": {},
+        "Afschrijving Vergunningen": {}
+      },
+      "LANGLOPENDE SCHULDEN EN AFLOSSINGEN": {
+        "AFLOSSINGEN": {
+          "Huurkoopverplichtingen": {},
+          "Hypotheek o/g 1": {},
+          "Hypotheek o/g 2": {},
+          "Hypotheek o/g 3": {},
+          "Hypotheek o/g 4": {},
+          "Hypotheek o/g 5": {},
+          "Lease-verplichtingen": {}
+        },
+        "LANGLOPENDE SCHULDEN": {
+          "Huurkoopverplichtingen 1": {},
+          "Hypotheken o/g 1": {},
+          "Hypotheken o/g 2": {},
+          "Hypotheken o/g 3": {},
+          "Hypotheken o/g 4": {},
+          "Hypotheken o/g 5": {},
+          "Lease-verplichtingen 1": {},
+          "Leningen o/g 1": {},
+          "Leningen o/g 2": {},
+          "Leningen o/g 3": {},
+          "Leningen o/g 4": {},
+          "Leningen o/g 5": {},
+          "Rekening-courant directie": {}
+        }
+      },
+      "MACHINES EN INVENTARIS": {
+        "INVENTARIS": {
+          "Aanschafwaarde Bedrijfsinventaris": {},
+          "Aanschafwaarde Fabrieksinventaris": {},
+          "Aanschafwaarde Gereedschappen": {},
+          "Aanschafwaarde Kantine-inventaris": {},
+          "Aanschafwaarde Kantoorinventaris": {},
+          "Aanschafwaarde Kantoormachines": {},
+          "Aanschafwaarde Magazijninventaris": {},
+          "Afschrijving Bedrijfsinventaris": {},
+          "Afschrijving Fabrieksinventaris": {},
+          "Afschrijving Gereedschappen": {},
+          "Afschrijving Kantine-inventaris": {},
+          "Afschrijving Kantoorinventaris": {},
+          "Afschrijving Kantoormachines": {},
+          "Afschrijving Magazijninventaris": {},
+          "accountType": "Stock"
+        },
+        "MACHINES": {
+          "Aanschafwaarde Machines 1": {
+            "accountType": "Fixed Asset"
+          },
+          "Aanschafwaarde Machines 2": {},
+          "Aanschafwaarde Machines 3": {},
+          "Aanschafwaarde Machines 4": {},
+          "Aanschafwaarde Machines 5": {},
+          "Afschrijving Machines 1": {
+            "accountType": "Accumulated Depreciation"
+          },
+          "Afschrijving Machines 2": {},
+          "Afschrijving Machines 3": {},
+          "Afschrijving Machines 4": {},
+          "Afschrijving Machines 5": {},
+          "accountType": "Fixed Asset"
+        }
+      },
+      "ONROERENDE GOEDEREN": {
+        "Aanschafwaarde Aanloopkosten 1": {},
+        "Aanschafwaarde Bedrijfsgebouwen": {},
+        "Aanschafwaarde Gebouwen": {},
+        "Aanschafwaarde Grondverbetering": {},
+        "Aanschafwaarde Landerijen": {},
+        "Aanschafwaarde Ondergrond gebouwen": {},
+        "Aanschafwaarde Pachtersinvesteringen": {},
+        "Aanschafwaarde Parkeerplaats": {},
+        "Aanschafwaarde Verbouwingen": {},
+        "Aanschafwaarde Winkels": {},
+        "Aanschafwaarde Woon-winkelhuis": {},
+        "Afschrijving Aanloopkosten 1": {},
+        "Afschrijving Bedrijfsgebouwen": {},
+        "Afschrijving Gebouwen": {},
+        "Afschrijving Grondverbetering": {},
+        "Afschrijving Pachtersinvesteringen": {},
+        "Afschrijving Parkeerplaats": {},
+        "Afschrijving Verbouwingen": {},
+        "Afschrijving Winkels": {},
+        "Afschrijving Woon-winkelhuis": {}
+      },
+      "VERVOERMIDDELEN": {
+        "Aanschafwaarde Aanhangwagens": {},
+        "Aanschafwaarde Heftrucks": {},
+        "Aanschafwaarde Personenauto's": {},
+        "Aanschafwaarde Rijwielen en bromfietsen": {},
+        "Aanschafwaarde Vrachtauto's": {},
+        "Afschrijving Aanhangwagens": {},
+        "Afschrijving Heftrucks": {},
+        "Afschrijving Personenauto's": {},
+        "Afschrijving Rijwielen en bromfietsen": {},
+        "Afschrijving Vrachtauto's": {}
+      },
+      "VOORZIENINGEN": {
+        "Assurantie eigen risico": {
+          "accountType": "Equity"
+        },
+        "Backservice pensioenverpl.": {
+          "accountType": "Equity"
+        },
+        "Egalisatierekening WIR": {
+          "accountType": "Equity"
+        },
+        "Egalisatieres. grootonderh.": {
+          "accountType": "Equity"
+        },
+        "Garantieverplichtingen": {
+          "accountType": "Equity"
+        },
+        "Latente belastingverpl.": {
+          "accountType": "Equity"
+        },
+        "Pens.voorz. eigen beheer": {
+          "accountType": "Equity"
+        },
+        "Pensioenverplichtingen": {
+          "accountType": "Equity"
+        },
+        "Stamrechtverplichtingen": {
+          "accountType": "Equity"
+        },
+        "Vervangingsreserve": {
+          "accountType": "Equity"
+        },
+        "Voorziening deelnemingen": {
+          "accountType": "Equity"
+        }
+      },
+      "rootType": "Asset"
+    },
+    "VERKOOPRESULTATEN": {
+      "Diensten fabric. 0% niet-EU": {},
+      "Diensten fabricage 0% EU": {},
+      "Diensten fabricage hoog": {},
+      "Diensten fabricage laag": {},
+      "Diensten fabricage overig": {},
+      "Diensten handel 0% EU": {},
+      "Diensten handel 0% niet-EU": {},
+      "Diensten handel hoog tarief": {},
+      "Diensten handel laag tarief": {},
+      "Verkopen Fabric. 0% niet-EU": {},
+      "Verkopen Handel 0% niet-EU": {},
+      "Verkopen fabric. 0 % EU": {},
+      "Verkopen fabricage hoog": {},
+      "Verkopen fabricage laag": {},
+      "Verkopen fabricage overig": {},
+      "Verkopen handel 0% EU": {},
+      "Verkopen handel hoog": {},
+      "Verkopen handel laag": {},
+      "Verkopen handel overig": {},
+      "Verleende Kredietbep. fabricage": {},
+      "Verleende Kredietbep. handel": {},
+      "rootType": "Income"
+    },
+    "VOORRAAD GEREED PRODUCT EN ONDERHANDEN WERK": {
+      "Betalingskort. crediteuren": {},
+      "Garantiekosten": {},
+      "Hulpmaterialen": {},
+      "Inkomende vrachten": {
+        "accountType": "Expenses Included In Valuation"
+      },
+      "Inkoop import buiten EU hoog": {},
+      "Inkoop import buiten EU laag": {},
+      "Inkoop import buiten EU overig": {},
+      "Inkoopbonussen": {},
+      "Inkoopkosten": {},
+      "Inkoopprovisie": {},
+      "Inkopen BTW verlegd": {},
+      "Inkopen EU hoog tarief": {},
+      "Inkopen EU laag tarief": {},
+      "Inkopen EU overig": {},
+      "Inkopen hoog": {},
+      "Inkopen laag": {},
+      "Inkopen nul": {},
+      "Inkopen overig": {},
+      "Invoerkosten": {},
+      "Kosten inkoopvereniging": {},
+      "Kostprijs omzet grondstoffen": {
+        "accountType": "Cost of Goods Sold"
+      },
+      "Kostprijs omzet handelsgoederen": {},
+      "Onttrekking uitgev.garantie": {},
+      "Priv\u00e9-gebruik goederen": {},
+      "Stock aanpassing": {
+        "accountType": "Stock Adjustment"
+      },
+      "Tegenrekening inkoop": {},
+      "Toev. Voorz. incour. grondst.": {},
+      "Toevoeging garantieverpl.": {},
+      "Toevoeging voorz. incour. handelsgoed.": {},
+      "Uitbesteed werk": {},
+      "Voorz. Incourourant grondst.": {},
+      "Voorz.incour. handelsgoed.": {},
+      "rootType": "Expense"
+    },
+    "VOORRAAD GRONDSTOFFEN, HULPMATERIALEN EN HANDELSGOEDEREN": {
+      "Emballage": {},
+      "Gereed product 1": {},
+      "Gereed product 2": {},
+      "Goederen 1": {},
+      "Goederen 2": {},
+      "Goederen in consignatie": {},
+      "Goederen onderweg": {},
+      "Grondstoffen 1": {},
+      "Grondstoffen 2": {},
+      "Halffabrikaten 1": {},
+      "Halffabrikaten 2": {},
+      "Hulpstoffen 1": {},
+      "Hulpstoffen 2": {},
+      "Kantoorbenodigdheden": {},
+      "Onderhanden werk": {},
+      "Verpakkingsmateriaal": {},
+      "Zegels": {},
+      "rootType": "Asset"
+    }
   }
 }

--- a/fixtures/verified/sg.json
+++ b/fixtures/verified/sg.json
@@ -1,311 +1,311 @@
 {
-  "country_code": "sg", 
-  "name": "Singapore - Chart of Accounts", 
+  "countryCode": "sg",
+  "name": "Singapore - Chart of Accounts",
   "tree": {
-      "Assets": {
-          "Current assets": {
-              "Accounts Receivable": {
-                  "Credit Cards": {
-                      "AMEX Receivable": {}, 
-                      "CUP Receivale": {}, 
-                      "MC Receivable": {}, 
-                      "NETS Receivable": {}, 
-                      "VISA Receivable": {}
-                  }, 
-                  "Debtors": {
-                      "account_type": "Receivable"
-                  }
-              }, 
-              "Bank Accounts": {
-                  "Paypal Account": {
-                      "account_type": "Bank"
-                  }, 
-                  "account_type": "Bank"
-              }, 
-              "Cash in Hand": {
-                  "Cash in Transit": {
-                      "account_type": "Cash"
-                  }, 
-                  "Petty Cash": {
-                      "account_type": "Cash"
-                  }, 
-                  "account_type": "Cash"
-              }, 
-              "Loans and Advances-Assets": {
-                  "Prepayments": {}
-              }, 
-              "Securities and Deposits": {
-                  "Bank Deposits": {}, 
-                  "Bank Guarantees": {}, 
-                  "Rental Deposits": {}
-              }, 
-              "Stock Assets": {
-                  "Stock in Hand": {
-                      "account_type": "Stock"
-                  }
-              }, 
-              "Tax Assets": {
-                  "GST-Input": {}
-              }
-          }, 
-          "Non-current assets": {
-              "Fixed Assets": {
-                  "Accumulated Depreciation": {
-                      "AccDep-Equipment-ICT": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "AccDep-Equipment-Office": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "AccDep-Furniture and Fixtures": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "AccDep-Motor Vehicle": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "AccDep-Plant and Machinery": {
-                          "account_type": "Accumulated Depreciation"
-                      }, 
-                      "account_type": "Accumulated Depreciation"
-                  }, 
-                  "Equipment-ICT": {
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "Equipment-Office": {
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "Furniture and Fixtures": {
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "Motor Vehicle": {
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "Plant and Machinery": {
-                      "account_type": "Fixed Asset"
-                  }, 
-                  "account_type": "Fixed Asset"
-              }, 
-              "Non-Fixed Assets": {
-                  "Goodwill": {}, 
-                  "Investments": {
-                      "Investments-Associated Company": {}, 
-                      "Investments-Subsidiary": {}
-                  }
-              }, 
-              "Shares": {
-                  "Shares-Quoted": {}, 
-                  "Shares-Unquoted": {}
-              }
-          }, 
-          "Temporary Accunts": {
-              "Temporary Opening": {
-                  "account_type": "Temporary"
-              }
-          }, 
-          "root_type": "Asset"
-      }, 
-      "Equity": {
-          "Current Year Earnings": {}, 
-          "Proposed Dividends": {}, 
-          "Retained Earnings": {}, 
-          "Share Capital": {}, 
-          "root_type": "Equity"
-      }, 
-      "Expenses": {
-          "Expenses-Administrative": {
-              "Audit Fees": {}, 
-              "Bank charges and interest": {}, 
-              "Currency Exchange Differences": {}, 
-              "Insurance": {}, 
-              "Interest on Loan": {}, 
-              "Legal and Professional Fees": {}, 
-              "Loss on Disposal of FA": {}, 
-              "Postal and Courier Charges": {}, 
-              "Printing and Stationery": {}, 
-              "Secretarial Fees": {}, 
-              "Tax Agent Fees": {}
-          }, 
-          "Expenses-Direct": {
-              "Cost of Goods Sold": {
-                  "account_type": "Cost of Goods Sold"
-              }, 
-              "Cost of Sales": {}, 
-              "Expenses Included in Valuation": {
-                  "account_type": "Expenses Included In Valuation"
-              }, 
-              "Stock Adjustment": {
-                  "account_type": "Stock Adjustment"
-              }
-          }, 
-          "Expenses-Marketing": {
-              "Advertising and Promotion": {}, 
-              "Graphic Design Fees": {}, 
-              "Internet Marketing": {}
-          }, 
-          "Expenses-Operating": {
-              "Cleaning Costs": {}, 
-              "Commission Charges": {
-                  "Comm-Credit Card": {}, 
-                  "Comm-NETS": {}, 
-                  "Comm-Paypal": {}
-              }, 
-              "Communication Costs": {
-                  "Internet Connection": {}, 
-                  "Telephone Costs": {}
-              }, 
-              "Entertainment Expenses": {}, 
-              "General Expenses": {}, 
-              "Licence Fees": {}, 
-              "Rental Costs": {
-                  "Rental-Equipment": {}, 
-                  "Rental-Premises": {}, 
-                  "Rental-Storage": {}
-              }, 
-              "Repairs and Maintenance": {
-                  "R&M-Building": {}, 
-                  "R&M-Fixtures & Furniture": {}, 
-                  "R&M-ICT": {}, 
-                  "R&M-Office": {}, 
-                  "R&M-Plant & Machinery": {}
-              }, 
-              "Service Fees": {}, 
-              "Subscription Fees": {
-                  "Publication Subscriptions": {}, 
-                  "TV Subscriptions": {}
-              }, 
-              "Travel Expenses": {}, 
-              "Utilities": {
-                  "Utility-Electricity": {}, 
-                  "Utility-Gas": {}, 
-                  "Utility-Refuse Removal": {}, 
-                  "Utility-Water": {}
-              }
-          }, 
-          "Expenses-Other": {
-              "Bad Debts Written Off": {}, 
-              "Depreciation": {
-                  "Dep-Fixtures & Furniture": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Dep-ICT Equipment": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Dep-Motor Vehicle": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Dep-Office Equipment": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Dep-Plant & Machinery": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "Dep-Renovation": {
-                      "account_type": "Depreciation"
-                  }, 
-                  "account_type": "Depreciation"
-              }, 
-              "Donations": {}, 
-              "Round Off": {}, 
-              "Tax Expenses": {
-                  "Tax Expenses 1": {}
-              }
-          }, 
-          "Expenses-Staff": {
-              "Bonuses": {
-                  "Bonus-Executive": {}, 
-                  "Bonus-Non Executive": {}, 
-                  "Bonus-Performance": {}
-              }, 
-              "CPF": {}, 
-              "Directors Fees": {}, 
-              "FWL": {}, 
-              "Incentives": {}, 
-              "Medical Expenses": {}, 
-              "SDF": {}, 
-              "Salaries": {
-                  "Casual Labour": {}, 
-                  "Salary-Executive": {}, 
-                  "Salary-Non Executive-Full Time": {}, 
-                  "Salary-Non Executive-Part Time": {}
-              }, 
-              "Security Expenses": {}, 
-              "Staff Advertising": {}, 
-              "Staff Commission Paid": {}, 
-              "Staff Meals": {}, 
-              "Staff Training": {}, 
-              "Staff Transport": {}, 
-              "Staff Welfare": {}
-          }, 
-          "root_type": "Expense"
-      }, 
-      "Income": {
-          "Direct Income": {
-              "Management Income": {}, 
-              "Sales Income": {}
-          }, 
-          "Indirect Income": {
-              "Government Grants": {}, 
-              "Interest Income": {
-                  "Current Account Interest Earned": {}, 
-                  "Fixed Deposit Interest Earned": {}
-              }, 
-              "Other Income": {}, 
-              "Service Charges": {}
-          }, 
-          "root_type": "Income"
-      }, 
-      "Liabilities": {
-          "Capital Account": {
-              "Reserves and Surplus": {}, 
-              "Shareholder Funds": {}
-          }, 
-          "Current liabilities": {
-              "Accounts Payable": {
-                  "Creditors": {
-                      "account_type": "Payable"
-                  },
-        "Payroll Payable": {}
-              }, 
-              "Duties and Taxes": {
-                  "Deferred Tax Liabilities-Current": {}, 
-                  "GST-Output": {}, 
-                  "Income Tax Payable": {}, 
-                  "account_type": "Tax"
-              }, 
-              "Loans-Current": {
-                  "Amount Owing to Directors": {}, 
-                  "Bank Overdaft Account": {}, 
-                  "Secured Loans": {}, 
-                  "Unsecured Loans": {}
-              }, 
-              "Provision and Accruals": {
-                  "Accruals": {
-                      "Accr-CPF": {}, 
-                      "Accr-Sundry": {}, 
-                      "Accr-Withholding Tax": {}
-                  }, 
-                  "Provisions": {
-                      "Prov-Audit Fee": {}, 
-                      "Prov-Bonus": {
-                          "Prov-Bonus-Executive": {}, 
-                          "Prov-Bonus-Non Executive": {}
-                      }, 
-                      "Prov-Others": {}, 
-                      "Prov-Tax Fee": {}
-                  }
-              }, 
-              "Sponsorship Funds": {}, 
-              "Stock Liabilities": {
-                  "Stock Received But Not Billed": {
-                      "account_type": "Stock Received But Not Billed"
-                  }
-              }
-          }, 
-          "Non-current liabilities": {
-              "Deferred Tax Liabilities": {}, 
-              "Loans-Non Current": {}
-          }, 
-          "root_type": "Liability"
-      }
+    "Assets": {
+      "Current assets": {
+        "Accounts Receivable": {
+          "Credit Cards": {
+            "AMEX Receivable": {},
+            "CUP Receivale": {},
+            "MC Receivable": {},
+            "NETS Receivable": {},
+            "VISA Receivable": {}
+          },
+          "Debtors": {
+            "accountType": "Receivable"
+          }
+        },
+        "Bank Accounts": {
+          "Paypal Account": {
+            "accountType": "Bank"
+          },
+          "accountType": "Bank"
+        },
+        "Cash in Hand": {
+          "Cash in Transit": {
+            "accountType": "Cash"
+          },
+          "Petty Cash": {
+            "accountType": "Cash"
+          },
+          "accountType": "Cash"
+        },
+        "Loans and Advances-Assets": {
+          "Prepayments": {}
+        },
+        "Securities and Deposits": {
+          "Bank Deposits": {},
+          "Bank Guarantees": {},
+          "Rental Deposits": {}
+        },
+        "Stock Assets": {
+          "Stock in Hand": {
+            "accountType": "Stock"
+          }
+        },
+        "Tax Assets": {
+          "GST-Input": {}
+        }
+      },
+      "Non-current assets": {
+        "Fixed Assets": {
+          "Accumulated Depreciation": {
+            "AccDep-Equipment-ICT": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "AccDep-Equipment-Office": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "AccDep-Furniture and Fixtures": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "AccDep-Motor Vehicle": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "AccDep-Plant and Machinery": {
+              "accountType": "Accumulated Depreciation"
+            },
+            "accountType": "Accumulated Depreciation"
+          },
+          "Equipment-ICT": {
+            "accountType": "Fixed Asset"
+          },
+          "Equipment-Office": {
+            "accountType": "Fixed Asset"
+          },
+          "Furniture and Fixtures": {
+            "accountType": "Fixed Asset"
+          },
+          "Motor Vehicle": {
+            "accountType": "Fixed Asset"
+          },
+          "Plant and Machinery": {
+            "accountType": "Fixed Asset"
+          },
+          "accountType": "Fixed Asset"
+        },
+        "Non-Fixed Assets": {
+          "Goodwill": {},
+          "Investments": {
+            "Investments-Associated Company": {},
+            "Investments-Subsidiary": {}
+          }
+        },
+        "Shares": {
+          "Shares-Quoted": {},
+          "Shares-Unquoted": {}
+        }
+      },
+      "Temporary Accunts": {
+        "Temporary Opening": {
+          "accountType": "Temporary"
+        }
+      },
+      "rootType": "Asset"
+    },
+    "Equity": {
+      "Current Year Earnings": {},
+      "Proposed Dividends": {},
+      "Retained Earnings": {},
+      "Share Capital": {},
+      "rootType": "Equity"
+    },
+    "Expenses": {
+      "Expenses-Administrative": {
+        "Audit Fees": {},
+        "Bank charges and interest": {},
+        "Currency Exchange Differences": {},
+        "Insurance": {},
+        "Interest on Loan": {},
+        "Legal and Professional Fees": {},
+        "Loss on Disposal of FA": {},
+        "Postal and Courier Charges": {},
+        "Printing and Stationery": {},
+        "Secretarial Fees": {},
+        "Tax Agent Fees": {}
+      },
+      "Expenses-Direct": {
+        "Cost of Goods Sold": {
+          "accountType": "Cost of Goods Sold"
+        },
+        "Cost of Sales": {},
+        "Expenses Included in Valuation": {
+          "accountType": "Expenses Included In Valuation"
+        },
+        "Stock Adjustment": {
+          "accountType": "Stock Adjustment"
+        }
+      },
+      "Expenses-Marketing": {
+        "Advertising and Promotion": {},
+        "Graphic Design Fees": {},
+        "Internet Marketing": {}
+      },
+      "Expenses-Operating": {
+        "Cleaning Costs": {},
+        "Commission Charges": {
+          "Comm-Credit Card": {},
+          "Comm-NETS": {},
+          "Comm-Paypal": {}
+        },
+        "Communication Costs": {
+          "Internet Connection": {},
+          "Telephone Costs": {}
+        },
+        "Entertainment Expenses": {},
+        "General Expenses": {},
+        "Licence Fees": {},
+        "Rental Costs": {
+          "Rental-Equipment": {},
+          "Rental-Premises": {},
+          "Rental-Storage": {}
+        },
+        "Repairs and Maintenance": {
+          "R&M-Building": {},
+          "R&M-Fixtures & Furniture": {},
+          "R&M-ICT": {},
+          "R&M-Office": {},
+          "R&M-Plant & Machinery": {}
+        },
+        "Service Fees": {},
+        "Subscription Fees": {
+          "Publication Subscriptions": {},
+          "TV Subscriptions": {}
+        },
+        "Travel Expenses": {},
+        "Utilities": {
+          "Utility-Electricity": {},
+          "Utility-Gas": {},
+          "Utility-Refuse Removal": {},
+          "Utility-Water": {}
+        }
+      },
+      "Expenses-Other": {
+        "Bad Debts Written Off": {},
+        "Depreciation": {
+          "Dep-Fixtures & Furniture": {
+            "accountType": "Depreciation"
+          },
+          "Dep-ICT Equipment": {
+            "accountType": "Depreciation"
+          },
+          "Dep-Motor Vehicle": {
+            "accountType": "Depreciation"
+          },
+          "Dep-Office Equipment": {
+            "accountType": "Depreciation"
+          },
+          "Dep-Plant & Machinery": {
+            "accountType": "Depreciation"
+          },
+          "Dep-Renovation": {
+            "accountType": "Depreciation"
+          },
+          "accountType": "Depreciation"
+        },
+        "Donations": {},
+        "Round Off": {},
+        "Tax Expenses": {
+          "Tax Expenses 1": {}
+        }
+      },
+      "Expenses-Staff": {
+        "Bonuses": {
+          "Bonus-Executive": {},
+          "Bonus-Non Executive": {},
+          "Bonus-Performance": {}
+        },
+        "CPF": {},
+        "Directors Fees": {},
+        "FWL": {},
+        "Incentives": {},
+        "Medical Expenses": {},
+        "SDF": {},
+        "Salaries": {
+          "Casual Labour": {},
+          "Salary-Executive": {},
+          "Salary-Non Executive-Full Time": {},
+          "Salary-Non Executive-Part Time": {}
+        },
+        "Security Expenses": {},
+        "Staff Advertising": {},
+        "Staff Commission Paid": {},
+        "Staff Meals": {},
+        "Staff Training": {},
+        "Staff Transport": {},
+        "Staff Welfare": {}
+      },
+      "rootType": "Expense"
+    },
+    "Income": {
+      "Direct Income": {
+        "Management Income": {},
+        "Sales Income": {}
+      },
+      "Indirect Income": {
+        "Government Grants": {},
+        "Interest Income": {
+          "Current Account Interest Earned": {},
+          "Fixed Deposit Interest Earned": {}
+        },
+        "Other Income": {},
+        "Service Charges": {}
+      },
+      "rootType": "Income"
+    },
+    "Liabilities": {
+      "Capital Account": {
+        "Reserves and Surplus": {},
+        "Shareholder Funds": {}
+      },
+      "Current liabilities": {
+        "Accounts Payable": {
+          "Creditors": {
+            "accountType": "Payable"
+          },
+          "Payroll Payable": {}
+        },
+        "Duties and Taxes": {
+          "Deferred Tax Liabilities-Current": {},
+          "GST-Output": {},
+          "Income Tax Payable": {},
+          "accountType": "Tax"
+        },
+        "Loans-Current": {
+          "Amount Owing to Directors": {},
+          "Bank Overdaft Account": {},
+          "Secured Loans": {},
+          "Unsecured Loans": {}
+        },
+        "Provision and Accruals": {
+          "Accruals": {
+            "Accr-CPF": {},
+            "Accr-Sundry": {},
+            "Accr-Withholding Tax": {}
+          },
+          "Provisions": {
+            "Prov-Audit Fee": {},
+            "Prov-Bonus": {
+              "Prov-Bonus-Executive": {},
+              "Prov-Bonus-Non Executive": {}
+            },
+            "Prov-Others": {},
+            "Prov-Tax Fee": {}
+          }
+        },
+        "Sponsorship Funds": {},
+        "Stock Liabilities": {
+          "Stock Received But Not Billed": {
+            "accountType": "Stock Received But Not Billed"
+          }
+        }
+      },
+      "Non-current liabilities": {
+        "Deferred Tax Liabilities": {},
+        "Loans-Non Current": {}
+      },
+      "rootType": "Liability"
+    }
   }
 }

--- a/models/doctype/Item/Item.js
+++ b/models/doctype/Item/Item.js
@@ -12,25 +12,25 @@ export default {
       label: 'Item Name',
       fieldtype: 'Data',
       placeholder: 'Item Name',
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'image',
       label: 'Image',
-      fieldtype: 'AttachImage'
+      fieldtype: 'AttachImage',
     },
     {
       fieldname: 'description',
       label: 'Description',
       placeholder: 'Item Description',
-      fieldtype: 'Text'
+      fieldtype: 'Text',
     },
     {
       fieldname: 'unit',
       label: 'Unit Type',
       fieldtype: 'Select',
       default: 'Unit',
-      options: ['Unit', 'Kg', 'Gram', 'Hour', 'Day']
+      options: ['Unit', 'Kg', 'Gram', 'Hour', 'Day'],
     },
     {
       fieldname: 'itemType',
@@ -38,7 +38,7 @@ export default {
       placeholder: 'Sales',
       fieldtype: 'Select',
       default: 'Product',
-      options: ['Product', 'Service']
+      options: ['Product', 'Service'],
     },
     {
       fieldname: 'incomeAccount',
@@ -51,18 +51,22 @@ export default {
       getFilters: () => {
         return {
           isGroup: 0,
-          accountType: 'Income Account'
+          rootType: 'Income',
         };
       },
       formulaDependsOn: ['itemType'],
-      formula(doc) {
+      async formula(doc) {
+        let accountName = 'Service';
         if (doc.itemType === 'Product') {
-          return 'Sales';
+          accountName = 'Sales';
         }
-        if (doc.itemType === 'Service') {
-          return 'Service';
+
+        const accountExists = await frappe.db.exists('Account', accountName);
+        if (!accountExists) {
+          return '';
         }
-      }
+        return accountName;
+      },
     },
     {
       fieldname: 'expenseAccount',
@@ -75,20 +79,27 @@ export default {
       getFilters: () => {
         return {
           isGroup: 0,
-          accountType: ['in', ['Cost of Goods Sold', 'Expense Account']]
+          rootType: 'Expense',
         };
       },
       formulaDependsOn: ['itemType'],
-      formula() {
-        return 'Cost of Goods Sold';
-      }
+      async formula() {
+        const cogs = await frappe.db
+          .knex('Account')
+          .where({ accountType: 'Cost of Goods Sold' });
+        if (cogs.length === 0) {
+          return '';
+        } else {
+          return cogs[0].name;
+        }
+      },
     },
     {
       fieldname: 'tax',
       label: 'Tax',
       fieldtype: 'Link',
       target: 'Tax',
-      placeholder: 'GST'
+      placeholder: 'GST',
     },
     {
       fieldname: 'rate',
@@ -101,36 +112,44 @@ export default {
             'Rate must be greater than 0'
           );
         }
-      }
-    }
+      },
+    },
   ],
-  quickEditFields: ['rate', 'unit', 'itemType', 'tax', 'description'],
+  quickEditFields: [
+    'rate',
+    'unit',
+    'itemType',
+    'tax',
+    'description',
+    'incomeAccount',
+    'expenseAccount',
+  ],
   actions: [
     {
       label: _('New Invoice'),
-      condition: doc => !doc.isNew(),
+      condition: (doc) => !doc.isNew(),
       action: async (doc, router) => {
         const invoice = await frappe.getNewDoc('SalesInvoice');
         invoice.append('items', {
           item: doc.name,
           rate: doc.rate,
-          tax: doc.tax
+          tax: doc.tax,
         });
         router.push(`/edit/SalesInvoice/${invoice.name}`);
-      }
+      },
     },
     {
       label: _('New Bill'),
-      condition: doc => !doc.isNew(),
+      condition: (doc) => !doc.isNew(),
       action: async (doc, router) => {
         const invoice = await frappe.getNewDoc('PurchaseInvoice');
         invoice.append('items', {
           item: doc.name,
           rate: doc.rate,
-          tax: doc.tax
+          tax: doc.tax,
         });
         router.push(`/edit/PurchaseInvoice/${invoice.name}`);
-      }
-    }
-  ]
+      },
+    },
+  ],
 };

--- a/src/pages/SetupWizard/setupCompany.js
+++ b/src/pages/SetupWizard/setupCompany.js
@@ -1,6 +1,7 @@
 import frappe from 'frappejs';
 import countryList from '~/fixtures/countryInfo.json';
 import generateTaxes from '../../../models/doctype/Tax/RegionalChanges';
+import { getCountryCOA } from '../../../accounting/importCOA';
 import config from '@/config';
 
 export default async function setupCompany(setupWizardValues) {
@@ -36,7 +37,7 @@ export default async function setupCompany(setupWizardValues) {
   });
 
   await setupGlobalCurrencies(countryList);
-  await setupChartOfAccounts(bankName);
+  await setupChartOfAccounts(bankName, country);
   await setupRegionalChanges(country);
   updateCompanyNameInConfig();
 
@@ -72,34 +73,30 @@ async function setupGlobalCurrencies(countries) {
       numberFormat: numberFormat || '#,###.##',
     };
 
-    const canCreate = await checkIfExactRecordAbsent(docObject);
-    if (canCreate) {
-      const doc = await frappe.newDoc(docObject);
-      promises.push(doc.insert());
+    const doc = checkAndCreateDoc(docObject);
+    if (doc) {
+      promises.push(doc);
       queue.push(currency);
     }
   }
   return Promise.all(promises);
 }
 
-async function setupChartOfAccounts(bankName) {
+async function setupChartOfAccounts(bankName, country) {
   await frappe.call({
     method: 'import-coa',
   });
-
+  const parentAccount = await getBankAccountParentName(country);
+  console.log('parent account gonna be', parentAccount, ` for ${country} `);
   const docObject = {
     doctype: 'Account',
     name: bankName,
     rootType: 'Asset',
-    parentAccount: 'Bank Accounts',
+    parentAccount,
     accountType: 'Bank',
     isGroup: 0,
   };
-
-  if (await checkIfExactRecordAbsent(docObject)) {
-    const accountDoc = await frappe.newDoc(docObject);
-    accountDoc.insert();
-  }
+  await checkAndCreateDoc(docObject);
 }
 
 async function setupRegionalChanges(country) {
@@ -146,4 +143,34 @@ export async function checkIfExactRecordAbsent(docObject) {
   }
 
   return false;
+}
+
+async function checkAndCreateDoc(docObject) {
+  const canCreate = await checkIfExactRecordAbsent(docObject);
+  if (!canCreate) {
+    return;
+  }
+
+  const doc = await frappe.newDoc(docObject);
+  return doc.insert();
+}
+
+async function getBankAccountParentName(country) {
+  const parentBankAccount = await frappe.db
+    .knex('Account')
+    .where({ isGroup: true, accountType: 'Bank' });
+
+  if (parentBankAccount.length === 0) {
+    // This should not happen if the fixtures are correct.
+    return 'Bank Accounts';
+  } else if (parentBankAccount.length > 1) {
+    switch (country) {
+      case 'Indonesia':
+        return 'Bank Rupiah - 1121.000';
+      default:
+        break;
+    }
+  }
+
+  return parentBankAccount[0].name;
 }


### PR DESCRIPTION
Fixes 2 issues:
- [x] Bank account parent not being set due to hard coded value _"Bank Accounts"_.
- [x] Accounts not being set in the Item master. Should fix https://github.com/frappe/books/issues/175

_Note: large diff cause CoA fixtures had `snake_cased` keys and 💩  formatting which was fixed. This was also causing spurious accounts being created, like an Account named "account_number" when country was set to Indonesia._