### PR TITLE
fix(ux): remove tax rate from invoice breakdown

### DIFF
--- a/src/pages/InvoiceForm.vue
+++ b/src/pages/InvoiceForm.vue
@@ -137,7 +137,7 @@
               v-for="tax in doc.taxes"
               :key="tax.name"
             >
-              <div>{{ tax.account }} ({{ tax.rate }}%)</div>
+              <div>{{ tax.account }}</div>
               <div>
                 {{
                   frappe.format(tax.amount, {


### PR DESCRIPTION
Removed display of tax rate from the tax breakdown section.

**Why**
- One would be more concerned with how much is paid for each tax.
- Item-wise breakdown on the invoice level is cluttersome.
- This information can be displayed at the item level, will add this later by allowing row expansion.

(created a PR to add the above message)