### PR TITLE
refactor: shift autoupdate to systemsettings

### DIFF
--- a/models/doctype/AccountingSettings/AccountingSettings.js
+++ b/models/doctype/AccountingSettings/AccountingSettings.js
@@ -107,12 +107,6 @@ export default {
       default: 0
     },
 
-    {
-      fieldname: 'autoUpdate',
-      label: 'Auto Update',
-      fieldtype: 'Check',
-      default: 1
-    }
   ],
   quickEditFields: [
     'fullname',

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -111,7 +111,12 @@ export default {
   },
   async mounted() {
     this.companyName = await sidebarConfig.getTitle();
-    this.groups = sidebarConfig.groups;
+    this.groups = sidebarConfig.groups.filter(group=>{
+      if(group.route === '/get-started' && frappe.SystemSettings.hideGetStarted) {
+        return false
+      }
+      return true;
+    });
 
     let currentPath = this.$router.currentRoute.fullPath;
     this.activeGroup = this.groups.find((g) => {

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,7 @@ import { IPC_MESSAGES } from './messages';
   });
 
   frappe.events.on('check-for-updates', () => {
-    let { autoUpdate } = frappe.AccountingSettings;
+    let { autoUpdate } = frappe.SystemSettings;
     if (autoUpdate == null || autoUpdate === 1) {
       ipcRenderer.send(IPC_MESSAGES.CHECK_FOR_UPDATES);
     }

--- a/src/pages/Settings/TabSystem.vue
+++ b/src/pages/Settings/TabSystem.vue
@@ -1,31 +1,17 @@
 <template>
   <div>
     <TwoColumnForm v-if="doc" :doc="doc" :fields="fields" :autosave="true" />
-    <div class="mt-6">
-      <FormControl
-        :show-label="true"
-        :df="AccountingSettings.meta.getField('autoUpdate')"
-        @change="(value) => AccountingSettings.update('autoUpdate', value)"
-        :value="AccountingSettings.autoUpdate"
-      />
-      <p class="pl-6 mt-1 text-sm text-gray-600">
-        <!-- prettier-ignore -->
-        {{ _('Automatically check for updates and download them if available. The update will be applied after you restart the app.') }}
-      </p>
-    </div>
   </div>
 </template>
 
 <script>
 import frappe from 'frappejs';
 import TwoColumnForm from '@/components/TwoColumnForm';
-import FormControl from '@/components/Controls/FormControl';
 
 export default {
   name: 'TabSystem',
   components: {
     TwoColumnForm,
-    FormControl,
   },
   data() {
     return {
@@ -40,9 +26,6 @@ export default {
     fields() {
       let meta = frappe.getMeta('SystemSettings');
       return meta.getQuickEditFields();
-    },
-    AccountingSettings() {
-      return frappe.AccountingSettings;
     },
   },
 };


### PR DESCRIPTION
Cross ref: https://github.com/frappe/frappejs/pull/155

Shifted `autoUpdate` to system settings, while the code it affects is in books, it should be in the framework really. More shifts later.