### PR TITLE
refactor: move fjs init boilerplate out, shift db init

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,8 +30,9 @@ import DatabaseSelector from './pages/DatabaseSelector';
 import WindowsTitleBar from '@/components/WindowsTitleBar';
 import { ipcRenderer } from 'electron';
 import config from '@/config';
-import { connectToLocalDatabase, routeTo, purgeCache } from '@/utils';
+import {  routeTo  } from '@/utils';
 import { IPC_MESSAGES, IPC_ACTIONS } from '@/messages';
+import { connectToLocalDatabase, purgeCache } from '@/initialization';
 
 export default {
   name: 'App',

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -4,8 +4,8 @@ import { _ } from 'frappejs';
 import SQLite from 'frappejs/backends/sqlite';
 import fs from 'fs';
 import postStart from '../server/postStart';
-import migrate from './migrate';
 import { IPC_ACTIONS } from './messages';
+import migrate from './migrate';
 
 export async function createNewDatabase() {
   const options = {
@@ -34,23 +34,6 @@ export async function createNewDatabase() {
   }
 
   return filePath;
-}
-
-export async function loadExistingDatabase() {
-  const options = {
-    title: _('Select file'),
-    properties: ['openFile'],
-    filters: [{ name: 'SQLite DB File', extensions: ['db'] }],
-  };
-
-  const { filePaths } = await ipcRenderer.invoke(
-    IPC_ACTIONS.GET_OPEN_FILEPATH,
-    options
-  );
-
-  if (filePaths && filePaths[0]) {
-    return filePaths[0];
-  }
 }
 
 export async function connectToLocalDatabase(filePath) {

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -1,0 +1,103 @@
+import config from '@/config';
+import { ipcRenderer } from 'electron';
+import { _ } from 'frappejs';
+import SQLite from 'frappejs/backends/sqlite';
+import fs from 'fs';
+import postStart from '../server/postStart';
+import migrate from './migrate';
+import { IPC_ACTIONS } from './messages';
+
+export async function createNewDatabase() {
+  const options = {
+    title: _('Select folder'),
+    defaultPath: 'frappe-books.db',
+  };
+
+  let { canceled, filePath } = await ipcRenderer.invoke(
+    IPC_ACTIONS.GET_SAVE_FILEPATH,
+    options
+  );
+
+  if (canceled || filePath.length === 0) {
+    return '';
+  }
+
+  if (!filePath.endsWith('.db')) {
+    showMessageDialog({
+      message: "Please select a filename ending with '.db'.",
+    });
+    return '';
+  }
+
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+
+  return filePath;
+}
+
+export async function loadExistingDatabase() {
+  const options = {
+    title: _('Select file'),
+    properties: ['openFile'],
+    filters: [{ name: 'SQLite DB File', extensions: ['db'] }],
+  };
+
+  const { filePaths } = await ipcRenderer.invoke(
+    IPC_ACTIONS.GET_OPEN_FILEPATH,
+    options
+  );
+
+  if (filePaths && filePaths[0]) {
+    return filePaths[0];
+  }
+}
+
+export async function connectToLocalDatabase(filePath) {
+  if (!filePath) {
+    return false;
+  }
+
+  frappe.login('Administrator');
+  try {
+    frappe.db = new SQLite({
+      dbPath: filePath,
+    });
+    await frappe.db.connect();
+  } catch (error) {
+    return false;
+  }
+
+  await migrate();
+  await postStart();
+
+  // set file info in config
+  let files = config.get('files') || [];
+  if (!files.find((file) => file.filePath === filePath)) {
+    files = [
+      {
+        companyName: frappe.AccountingSettings.companyName,
+        filePath: filePath,
+      },
+      ...files,
+    ];
+    config.set('files', files);
+  }
+
+  // set last selected file
+  config.set('lastSelectedFilePath', filePath);
+  return true;
+}
+
+export function purgeCache(purgeAll = false) {
+  const filterFunction = purgeAll
+    ? (d) => true
+    : (d) => frappe.docs[d][d] instanceof frappe.BaseMeta;
+
+  Object.keys(frappe.docs)
+    .filter(filterFunction)
+    .forEach((d) => {
+      frappe.removeFromCache(d, d);
+      delete frappe[d];
+    });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,28 +1,18 @@
-// frappejs imports
+import { ipcRenderer } from 'electron';
 import frappe from 'frappejs';
-import common from 'frappejs/common';
-import coreModels from 'frappejs/models';
 import FeatherIcon from 'frappejs/ui/components/FeatherIcon';
 import outsideClickDirective from 'frappejs/ui/plugins/outsideClickDirective';
-import models from '../models';
-
-// vue imports
-import Vue from 'vue';
 import PortalVue from 'portal-vue';
+import Vue from 'vue';
+import models from '../models';
 import App from './App';
-import router from './router';
-
-// other imports
-import { ipcRenderer } from 'electron';
 import { IPC_MESSAGES } from './messages';
+import router from './router';
 
 (async () => {
   frappe.isServer = true;
   frappe.isElectron = true;
-  frappe.init();
-  frappe.registerLibs(common);
-  frappe.registerModels(coreModels);
-  frappe.registerModels(models);
+  frappe.initializeAndRegister(models);
   frappe.fetch = window.fetch.bind();
 
   frappe.events.on('reload-main-window', () => {

--- a/src/pages/DatabaseSelector.vue
+++ b/src/pages/DatabaseSelector.vue
@@ -157,7 +157,7 @@ import {
   createNewDatabase,
   loadExistingDatabase,
   connectToLocalDatabase,
-} from '@/utils';
+} from '@/initialization';
 
 export default {
   name: 'DatabaseSelector',

--- a/src/pages/DatabaseSelector.vue
+++ b/src/pages/DatabaseSelector.vue
@@ -152,12 +152,10 @@
 import fs from 'fs';
 import config from '@/config';
 import { DateTime } from 'luxon';
+import { ipcRenderer } from 'electron';
+import { IPC_ACTIONS } from '../messages';
 
-import {
-  createNewDatabase,
-  loadExistingDatabase,
-  connectToLocalDatabase,
-} from '@/initialization';
+import { createNewDatabase, connectToLocalDatabase } from '@/initialization';
 
 export default {
   name: 'DatabaseSelector',
@@ -191,7 +189,11 @@ export default {
     },
     async existingDatabase() {
       this.fileSelectedFrom = 'Existing File';
-      let filePath = await loadExistingDatabase();
+      const filePath = (await ipcRenderer.invoke(IPC_ACTIONS.GET_OPEN_FILEPATH, {
+        title: this._('Select file'),
+        properties: ['openFile'],
+        filters: [{ name: 'SQLite DB File', extensions: ['db'] }],
+      }))?.filePaths?.[0];
       this.connectToDatabase(filePath);
     },
     async selectFile(file) {

--- a/src/pages/SetupWizard/SetupWizard.vue
+++ b/src/pages/SetupWizard/SetupWizard.vue
@@ -68,13 +68,11 @@ import Popover from '@/components/Popover';
 import config from '@/config';
 import path from 'path';
 import fs from 'fs';
-import { connectToLocalDatabase } from '@/utils';
-
+import { purgeCache, connectToLocalDatabase } from '@/initialization';
 import {
   getErrorMessage,
   handleErrorWithDialog,
   showMessageDialog,
-  purgeCache,
 } from '@/utils';
 
 export default {


### PR DESCRIPTION
Moved some initialization code around.
- `frappejs` init boilerplate has been moved to `frappejs`
- Db (create, connect)