### PR TITLE
Fixed payment entries not getting posted in general ledger

### DIFF
--- a/models/doctype/Payment/PaymentServer.js
+++ b/models/doctype/Payment/PaymentServer.js
@@ -132,6 +132,11 @@ export default class PaymentServer extends BaseDocument {
     }
   }
 
+  async afterSubmit() {
+    const entries = await this.getPosting();
+    await entries.post();
+  }
+
   async afterRevert() {
     this.updateReferenceOutstandingAmount();
     const entries = await this.getPosting();


### PR DESCRIPTION
Fixed the payment entries not getting posted in the general ledger,
also thereby causing the cashflow graph to go blank.

cc: @ankitsinghaniyaz @18alantom 

https://user-images.githubusercontent.com/69912046/143854646-bcded849-ef36-4861-bfd1-faccd00ee034.mp4


