### PR TITLE
Refactor currency handling to use pesa

### DIFF
--- a/accounting/ledgerPosting.js
+++ b/accounting/ledgerPosting.js
@@ -29,13 +29,13 @@ export default class LedgerPosting {
     const debitAccounts = ['Asset', 'Expense'];
     const { rootType } = await frappe.getDoc('Account', accountName);
     if (debitAccounts.indexOf(rootType) === -1) {
-      const change = type == 'credit' ? amount : amount.mul(-1);
+      const change = type == 'credit' ? amount : amount.neg();
       this.accountEntries.push({
         name: accountName,
         balanceChange: change,
       });
     } else {
-      const change = type == 'debit' ? amount : amount.mul(-1);
+      const change = type == 'debit' ? amount : amount.neg();
       this.accountEntries.push({
         name: accountName,
         balanceChange: change,
@@ -95,7 +95,7 @@ export default class LedgerPosting {
       entry.reverted = 1;
     }
     for (let entry of this.accountEntries) {
-      entry.balanceChange = entry.balanceChange.mul(-1);
+      entry.balanceChange = entry.balanceChange.neg();
     }
     await this.insertEntries();
   }
@@ -121,7 +121,7 @@ export default class LedgerPosting {
 
   validateEntries() {
     let { debit, credit } = this.getTotalDebitAndCredit();
-    if (!debit.eq(credit)) {
+    if (debit.neq(credit)) {
       throw new Error(
         `Total Debit: ${frappe.format(
           debit,

--- a/accounting/ledgerPosting.js
+++ b/accounting/ledgerPosting.js
@@ -123,7 +123,10 @@ export default class LedgerPosting {
     let { debit, credit } = this.getTotalDebitAndCredit();
     if (!debit.eq(credit)) {
       throw new Error(
-        `Total Debit (${debit.round()}) must be equal to Total Credit (${credit.round()})`
+        `Total Debit: ${frappe.format(
+          debit,
+          'Currency'
+        )} must be equal to Total Credit: ${frappe.format(credit, 'Currency')}`
       );
     }
   }

--- a/accounting/ledgerPosting.js
+++ b/accounting/ledgerPosting.js
@@ -1,5 +1,4 @@
 import frappe from 'frappejs';
-import { round } from 'frappejs/utils/numberFormat';
 
 export default class LedgerPosting {
   constructor({ reference, party, date, description }) {
@@ -16,13 +15,13 @@ export default class LedgerPosting {
 
   async debit(account, amount, referenceType, referenceName) {
     const entry = this.getEntry(account, referenceType, referenceName);
-    entry.debit += amount;
+    entry.debit = entry.debit.add(amount);
     await this.setAccountBalanceChange(account, 'debit', amount);
   }
 
   async credit(account, amount, referenceType, referenceName) {
     const entry = this.getEntry(account, referenceType, referenceName);
-    entry.credit += amount;
+    entry.credit = entry.credit.add(amount);
     await this.setAccountBalanceChange(account, 'credit', amount);
   }
 
@@ -30,16 +29,16 @@ export default class LedgerPosting {
     const debitAccounts = ['Asset', 'Expense'];
     const { rootType } = await frappe.getDoc('Account', accountName);
     if (debitAccounts.indexOf(rootType) === -1) {
-      const change = type == 'credit' ? amount : -1 * amount;
+      const change = type == 'credit' ? amount : amount.mul(-1);
       this.accountEntries.push({
         name: accountName,
-        balanceChange: change
+        balanceChange: change,
       });
     } else {
-      const change = type == 'debit' ? amount : -1 * amount;
+      const change = type == 'debit' ? amount : amount.mul(-1);
       this.accountEntries.push({
         name: accountName,
-        balanceChange: change
+        balanceChange: change,
       });
     }
   }
@@ -54,8 +53,8 @@ export default class LedgerPosting {
         referenceName: referenceName || this.reference.name,
         description: this.description,
         reverted: this.reverted,
-        debit: 0,
-        credit: 0
+        debit: frappe.pesa(0),
+        credit: frappe.pesa(0),
       };
 
       this.entries.push(entry);
@@ -78,8 +77,8 @@ export default class LedgerPosting {
       fields: ['name'],
       filters: {
         referenceName: this.reference.name,
-        reverted: 0
-      }
+        reverted: 0,
+      },
     });
 
     for (let entry of data) {
@@ -96,24 +95,23 @@ export default class LedgerPosting {
       entry.reverted = 1;
     }
     for (let entry of this.accountEntries) {
-      entry.balanceChange = -1 * entry.balanceChange;
+      entry.balanceChange = entry.balanceChange.mul(-1);
     }
     await this.insertEntries();
   }
 
   makeRoundOffEntry() {
     let { debit, credit } = this.getTotalDebitAndCredit();
-    let precision = this.getPrecision();
-    let difference = round(debit - credit, precision);
-    let absoluteValue = Math.abs(difference);
+    let difference = debit.sub(credit);
+    let absoluteValue = difference.abs();
     let allowance = 0.5;
-    if (absoluteValue === 0) {
+    if (absoluteValue.eq(0)) {
       return;
     }
 
     let roundOffAccount = this.getRoundOffAccount();
-    if (absoluteValue <= allowance) {
-      if (difference > 0) {
+    if (absoluteValue.lte(allowance)) {
+      if (difference.gt(0)) {
         this.credit(roundOffAccount, absoluteValue);
       } else {
         this.debit(roundOffAccount, absoluteValue);
@@ -123,25 +121,21 @@ export default class LedgerPosting {
 
   validateEntries() {
     let { debit, credit } = this.getTotalDebitAndCredit();
-    if (debit !== credit) {
+    if (!debit.eq(credit)) {
       throw new Error(
-        `Total Debit (${debit}) must be equal to Total Credit (${credit})`
+        `Total Debit (${debit.round()}) must be equal to Total Credit (${credit.round()})`
       );
     }
   }
 
   getTotalDebitAndCredit() {
-    let debit = 0;
-    let credit = 0;
+    let debit = frappe.pesa(0);
+    let credit = frappe.pesa(0);
 
     for (let entry of this.entries) {
-      debit += entry.debit;
-      credit += entry.credit;
+      debit = debit.add(entry.debit);
+      credit = credit.add(entry.credit);
     }
-
-    let precision = this.getPrecision();
-    debit = round(debit, precision);
-    credit = round(credit, precision);
 
     return { debit, credit };
   }
@@ -149,23 +143,19 @@ export default class LedgerPosting {
   async insertEntries() {
     for (let entry of this.entries) {
       let entryDoc = frappe.newDoc({
-        doctype: 'AccountingLedgerEntry'
+        doctype: 'AccountingLedgerEntry',
       });
       Object.assign(entryDoc, entry);
       await entryDoc.insert();
     }
     for (let entry of this.accountEntries) {
       let entryDoc = await frappe.getDoc('Account', entry.name);
-      entryDoc.balance += entry.balanceChange;
+      entryDoc.balance = entryDoc.balance.add(entry.balanceChange);
       await entryDoc.update();
     }
-  }
-
-  getPrecision() {
-    return frappe.SystemSettings.internalPrecision;
   }
 
   getRoundOffAccount() {
     return frappe.AccountingSettings.roundOffAccount;
   }
-};
+}

--- a/accounting/ledgerPosting.js
+++ b/accounting/ledgerPosting.js
@@ -162,7 +162,7 @@ export default class LedgerPosting {
   }
 
   getPrecision() {
-    return frappe.SystemSettings.floatPrecision;
+    return frappe.SystemSettings.internalPrecision;
   }
 
   getRoundOffAccount() {

--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -1,69 +1,85 @@
 {
-    "Afghanistan": {
+    "Afghanistan": 
+    {
         "code": "af",
         "currency": "AFN",
         "currency_fraction": "Pul",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u060b",
+        "currency_symbol": "؋",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Kabul"
         ],
         "fiscal_year_start": "12-20",
-        "fiscal_year_end": "12-21"
+        "fiscal_year_end": "12-21",
+        "locale": "ps-AF"
     },
-    "Albania": {
+    "Albania": 
+    {
         "code": "al",
         "currency": "ALL",
-        "currency_fraction": "Qindark\u00eb",
+        "currency_fraction": "Qindarkë",
         "currency_fraction_units": 100,
         "currency_name": "Lek",
         "currency_symbol": "L",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Tirane"
-        ]
+        ],
+        "locale": "sq-AL"
     },
-    "Algeria": {
+    "Algeria": 
+    {
         "code": "dz",
         "currency": "DZD",
         "currency_fraction": "Santeem",
         "currency_fraction_units": 100,
         "currency_name": "Algerian Dinar",
-        "currency_symbol": "\u062f.\u062c",
+        "currency_symbol": "د.ج",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Algiers"
-        ]
+        ],
+        "locale": "ar-DZ"
     },
-    "American Samoa": {
+    "American Samoa": 
+    {
         "code": "as",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "en-AS"
     },
-    "Andorra": {
+    "Andorra": 
+    {
         "code": "ad",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Andorra"
         ]
     },
-    "Angola": {
+    "Angola": 
+    {
         "code": "ao",
         "currency": "KZ",
-        "currency_fraction": "C\u00eantimo",
+        "currency_fraction": "Cêntimo",
         "currency_fraction_units": 100,
         "currency_symbol": "AOA",
         "currency_name": "Kwanza",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Luanda"
         ]
     },
-    "Anguilla": {
+    "Anguilla": 
+    {
         "code": "ai",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -71,14 +87,17 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Anguilla"
         ]
     },
-    "Antarctica": {
+    "Antarctica": 
+    {
         "code": "aq",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Antarctica/Casey",
             "Antarctica/Davis",
             "Antarctica/DumontDUrville",
@@ -91,7 +110,8 @@
             "Antarctica/Vostok"
         ]
     },
-    "Antigua and Barbuda": {
+    "Antigua and Barbuda": 
+    {
         "code": "ag",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -99,11 +119,13 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Antigua"
         ]
     },
-    "Argentina": {
+    "Argentina": 
+    {
         "code": "ar",
         "currency": "ARS",
         "currency_fraction": "Centavo",
@@ -111,7 +133,8 @@
         "currency_name": "Argentine Peso",
         "currency_symbol": "$",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Argentina/Buenos_Aires",
             "America/Argentina/Catamarca",
             "America/Argentina/Cordoba",
@@ -124,21 +147,26 @@
             "America/Argentina/San_Luis",
             "America/Argentina/Tucuman",
             "America/Argentina/Ushuaia"
-        ]
+        ],
+        "locale": "es-AR"
     },
-    "Armenia": {
+    "Armenia": 
+    {
         "code": "am",
         "currency": "AMD",
         "currency_fraction": "Luma",
         "currency_fraction_units": 100,
         "currency_name": "Armenian Dram",
-        "currency_symbol": "\u058f",
+        "currency_symbol": "֏",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Yerevan"
-        ]
+        ],
+        "locale": "hy-AM"
     },
-    "Aruba": {
+    "Aruba": 
+    {
         "code": "aw",
         "currency": "AWG",
         "currency_fraction": "Cent",
@@ -146,11 +174,13 @@
         "currency_name": "Aruban Florin",
         "currency_symbol": "Afl",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Aruba"
         ]
     },
-    "Australia": {
+    "Australia": 
+    {
         "code": "au",
         "currency": "AUD",
         "currency_fraction": "Cent",
@@ -158,7 +188,8 @@
         "currency_name": "Australian Dollar",
         "currency_symbol": "$",
         "number_format": "# ###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Australia/Adelaide",
             "Australia/Brisbane",
             "Australia/Broken_Hill",
@@ -173,65 +204,80 @@
             "Australia/Sydney"
         ],
         "fiscal_year_start": "07-01",
-        "fiscal_year_end": "06-30"
+        "fiscal_year_end": "06-30",
+        "locale": "en-AU"
     },
-    "Austria": {
+    "Austria": 
+    {
         "code": "at",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Vienna"
-        ]
+        ],
+        "locale": "de-AT"
     },
-    "Azerbaijan": {
+    "Azerbaijan": 
+    {
         "code": "az",
-        "currency_fraction": "Q\u0259pik",
+        "currency_fraction": "Qəpik",
         "currency_fraction_units": 100,
         "currency_symbol": "",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Baku"
         ]
     },
-    "Bahamas": {
+    "Bahamas": 
+    {
         "code": "bs",
         "currency": "BSD",
         "currency_name": "Bahamian Dollar",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Nassau"
         ]
     },
-    "Bahrain": {
+    "Bahrain": 
+    {
         "code": "bh",
         "currency": "BHD",
         "currency_fraction": "Fils",
         "currency_fraction_units": 1000,
         "currency_name": "Bahraini Dinar",
-        "currency_symbol": ".\u062f.\u0628",
+        "currency_symbol": ".د.ب",
         "number_format": "#,###.###",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Bahrain"
-        ]
+        ],
+        "locale": "ar-BH"
     },
-    "Bangladesh": {
+    "Bangladesh": 
+    {
         "code": "bd",
         "currency": "BDT",
         "currency_fraction": "Paisa",
         "currency_fraction_units": 100,
         "currency_name": "Taka",
-        "currency_symbol": "\u09f3",
+        "currency_symbol": "৳",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Dhaka"
         ],
         "fiscal_year_start": "07-01",
-        "fiscal_year_end": "06-30"
+        "fiscal_year_end": "06-30",
+        "locale": "bn-BD"
     },
-    "Barbados": {
+    "Barbados": 
+    {
         "code": "bb",
         "currency": "BBD",
         "currency_fraction": "Cent",
@@ -239,32 +285,40 @@
         "currency_name": "Barbados Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Barbados"
         ]
     },
-    "Belarus": {
+    "Belarus": 
+    {
         "code": "by",
         "currency_fraction": "Kapyeyka",
         "currency_fraction_units": 100,
         "currency_symbol": "Br",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Minsk"
-        ]
+        ],
+        "locale": "be-BY"
     },
-    "Belgium": {
+    "Belgium": 
+    {
         "code": "be",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Brussels"
-        ]
+        ],
+        "locale": "en-BE"
     },
-    "Belize": {
+    "Belize": 
+    {
         "code": "bz",
         "currency": "BZD",
         "currency_fraction": "Cent",
@@ -273,11 +327,14 @@
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Belize"
-        ]
+        ],
+        "locale": "en-BZ"
     },
-    "Benin": {
+    "Benin": 
+    {
         "code": "bj",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -285,11 +342,14 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Porto-Novo"
-        ]
+        ],
+        "locale": "fr-BJ"
     },
-    "Bermuda": {
+    "Bermuda": 
+    {
         "code": "bm",
         "currency": "BMD",
         "currency_fraction": "Cent",
@@ -297,11 +357,13 @@
         "currency_name": "Bermudian Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Atlantic/Bermuda"
         ]
     },
-    "Bhutan": {
+    "Bhutan": 
+    {
         "code": "bt",
         "currency": "BTN",
         "currency_fraction": "Chetrum",
@@ -309,32 +371,40 @@
         "currency_name": "Ngultrum",
         "currency_symbol": "Nu.",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Thimphu"
         ]
     },
-    "Bolivia, Plurinational State of": {
+    "Bolivia, Plurinational State of": 
+    {
         "code": "bo",
         "currency": "BOB",
         "currency_name": "Boliviano",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "es-BO"
     },
-    "Bonaire, Sint Eustatius and Saba": {
+    "Bonaire, Sint Eustatius and Saba": 
+    {
         "code": "bq",
         "number_format": "#,###.##"
     },
-    "Bosnia and Herzegovina": {
+    "Bosnia and Herzegovina": 
+    {
         "code": "ba",
         "currency": "BAM",
         "currency_fraction": "Fening",
         "currency_fraction_units": 100,
         "currency_symbol": "KM",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Sarajevo"
-        ]
+        ],
+        "locale": "bs-BA"
     },
-    "Botswana": {
+    "Botswana": 
+    {
         "code": "bw",
         "currency": "BWP",
         "currency_fraction": "Thebe",
@@ -342,15 +412,19 @@
         "currency_name": "Pula",
         "currency_symbol": "P",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Gaborone"
-        ]
+        ],
+        "locale": "en-BW"
     },
-    "Bouvet Island": {
+    "Bouvet Island": 
+    {
         "code": "bv",
         "number_format": "#,###.##"
     },
-    "Brazil": {
+    "Brazil": 
+    {
         "code": "br",
         "currency": "BRL",
         "currency_fraction": "Centavo",
@@ -358,7 +432,8 @@
         "currency_symbol": "R$",
         "date_format": "dd/MM/yyyy",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Araguaina",
             "America/Bahia",
             "America/Belem",
@@ -375,40 +450,50 @@
             "America/Rio_Branco",
             "America/Santarem",
             "America/Sao_Paulo"
-        ]
+        ],
+        "locale": "pt-BR"
     },
-    "British Indian Ocean Territory": {
+    "British Indian Ocean Territory": 
+    {
         "code": "io",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Chagos"
         ]
     },
-    "Brunei Darussalam": {
+    "Brunei Darussalam": 
+    {
         "code": "bn",
         "currency": "BND",
         "currency_name": "Brunei Dollar",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Brunei"
-        ]
+        ],
+        "locale": "ms-BN"
     },
-    "Bulgaria": {
+    "Bulgaria": 
+    {
         "code": "bg",
         "currency": "BGN",
         "currency_name": "Bulgarian Lev",
         "currency_fraction": "Stotinka",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u043b\u0432",
+        "currency_symbol": "лв",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Sofia"
-        ]
+        ],
+        "locale": "bg-BG"
     },
-    "Burkina Faso": {
+    "Burkina Faso": 
+    {
         "code": "bf",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -416,11 +501,14 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Ouagadougou"
-        ]
+        ],
+        "locale": "fr-BF"
     },
-    "Burundi": {
+    "Burundi": 
+    {
         "code": "bi",
         "currency": "BIF",
         "currency_fraction": "Centime",
@@ -428,23 +516,29 @@
         "currency_name": "Burundi Franc",
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Bujumbura"
-        ]
+        ],
+        "locale": "fr-BI"
     },
-    "Cambodia": {
+    "Cambodia": 
+    {
         "code": "kh",
         "currency": "KHR",
         "currency_fraction": "Sen",
         "currency_fraction_units": 100,
         "currency_name": "Riel",
-        "currency_symbol": "\u17db",
+        "currency_symbol": "៛",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Phnom_Penh"
-        ]
+        ],
+        "locale": "km-KH"
     },
-    "Cameroon": {
+    "Cameroon": 
+    {
         "code": "cm",
         "currency": "XAF",
         "currency_name": "Central African CFA Franc",
@@ -452,11 +546,14 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Douala"
-        ]
+        ],
+        "locale": "fr-CM"
     },
-    "Canada": {
+    "Canada": 
+    {
         "code": "ca",
         "currency": "CAD",
         "currency_fraction": "Cent",
@@ -465,7 +562,8 @@
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Atikokan",
             "America/Blanc-Sablon",
             "America/Cambridge_Bay",
@@ -496,9 +594,11 @@
             "America/Yellowknife"
         ],
         "fiscal_year_start": "04-01",
-        "fiscal_year_end": "03-31"
+        "fiscal_year_end": "03-31",
+        "locale": "en-CA"
     },
-    "Cape Verde": {
+    "Cape Verde": 
+    {
         "code": "cv",
         "currency": "CVE",
         "currency_fraction": "Centavo",
@@ -506,11 +606,14 @@
         "currency_name": "Cape Verde Escudo",
         "currency_symbol": "Esc or $",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Atlantic/Cape_Verde"
-        ]
+        ],
+        "locale": "kea-CV"
     },
-    "Cayman Islands": {
+    "Cayman Islands": 
+    {
         "code": "ky",
         "currency": "KYD",
         "currency_fraction": "Cent",
@@ -518,11 +621,13 @@
         "currency_name": "Cayman Islands Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Cayman"
         ]
     },
-    "Central African Republic": {
+    "Central African Republic": 
+    {
         "code": "cf",
         "currency": "XAF",
         "currency_fraction": "Centime",
@@ -530,11 +635,14 @@
         "currency_name": "Central African CFA Franc",
         "currency_symbol": "FCFA",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Bangui"
-        ]
+        ],
+        "locale": "fr-CF"
     },
-    "Chad": {
+    "Chad": 
+    {
         "code": "td",
         "currency": "XAF",
         "currency_name": "Central African CFA Franc",
@@ -542,11 +650,14 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Ndjamena"
-        ]
+        ],
+        "locale": "fr-TD"
     },
-    "Chile": {
+    "Chile": 
+    {
         "code": "cl",
         "currency": "CLP",
         "currency_fraction": "Centavo",
@@ -554,43 +665,53 @@
         "currency_name": "Chilean Peso",
         "currency_symbol": "$",
         "number_format": "#.###",
-        "timezones": [
+        "timezones": 
+        [
             "America/Santiago",
             "Pacific/Easter"
-        ]
+        ],
+        "locale": "es-CL"
     },
-    "China": {
+    "China": 
+    {
         "code": "cn",
         "currency": "CNY",
         "currency_name": "Yuan Renminbi",
         "date_format": "yyyy-MM-dd",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Chongqing",
             "Asia/Harbin",
             "Asia/Kashgar",
             "Asia/Shanghai",
             "Asia/Urumqi"
-        ]
+        ],
+        "locale": "ii-CN"
     },
-    "Christmas Island": {
+    "Christmas Island": 
+    {
         "code": "cx",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Christmas"
         ]
     },
-    "Cocos (Keeling) Islands": {
+    "Cocos (Keeling) Islands": 
+    {
         "code": "cc",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Cocos"
         ]
     },
-    "Colombia": {
+    "Colombia": 
+    {
         "code": "co",
         "currency": "COP",
         "currency_fraction": "Centavo",
@@ -598,11 +719,14 @@
         "currency_name": "Colombian Peso",
         "currency_symbol": "$",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Bogota"
-        ]
+        ],
+        "locale": "es-CO"
     },
-    "Comoros": {
+    "Comoros": 
+    {
         "code": "km",
         "currency": "KMF",
         "currency_fraction": "Centime",
@@ -610,48 +734,60 @@
         "currency_name": "Comoro Franc",
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Comoro"
-        ]
+        ],
+        "locale": "fr-KM"
     },
-    "Congo": {
+    "Congo": 
+    {
         "code": "cg",
         "number_format": "#,###.##",
         "currency": "XAF",
         "currency_name": "Central African CFA Franc",
         "currency_symbol": "FCFA",
         "currency_fraction": "Centime",
-        "currency_fraction_units": 100
+        "currency_fraction_units": 100,
+        "locale": "fr-CG"
     },
-    "Congo, The Democratic Republic of the": {
+    "Congo, The Democratic Republic of the": 
+    {
         "code": "cd",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "fr-CD"
     },
-    "Cook Islands": {
+    "Cook Islands": 
+    {
         "code": "ck",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Rarotonga"
         ]
     },
-    "Costa Rica": {
+    "Costa Rica": 
+    {
         "code": "cr",
         "currency": "CRC",
-        "currency_fraction": "C\u00e9ntimo",
+        "currency_fraction": "Céntimo",
         "currency_fraction_units": 100,
         "currency_name": "Costa Rican Colon",
-        "currency_symbol": "\u20a1",
+        "currency_symbol": "₡",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Costa_Rica"
         ],
         "fiscal_year_start": "10-01",
-        "fiscal_year_end": "09-30"
+        "fiscal_year_end": "09-30",
+        "locale": "es-CR"
     },
-    "Croatia": {
+    "Croatia": 
+    {
         "code": "hr",
         "currency": "HRK",
         "currency_fraction": "Lipa",
@@ -659,11 +795,14 @@
         "currency_name": "Croatian Kuna",
         "currency_symbol": "kn",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Zagreb"
-        ]
+        ],
+        "locale": "hr-HR"
     },
-    "Cuba": {
+    "Cuba": 
+    {
         "code": "cu",
         "currency": "CUP",
         "currency_fraction": "Centavo",
@@ -671,54 +810,66 @@
         "currency_name": "Cuban Peso",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Havana"
         ]
     },
-    "Cura\u00e7ao": {
+    "Curaçao": 
+    {
         "code": "cw",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u0192",
+        "currency_symbol": "ƒ",
         "number_format": "#,###.##"
     },
-    "Cyprus": {
+    "Cyprus": 
+    {
         "code": "cy",
         "currency": "CYP",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_name": "Cyprus Pound",
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Nicosia"
-        ]
+        ],
+        "locale": "el-CY"
     },
-    "Czech Republic": {
+    "Czech Republic": 
+    {
         "code": "cz",
         "currency": "CZK",
-        "currency_fraction": "Hal\u00e9\u0159",
+        "currency_fraction": "Haléř",
         "currency_fraction_units": 100,
         "currency_name": "Czech Koruna",
-        "currency_symbol": "K\u010d",
+        "currency_symbol": "Kč",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Prague"
-        ]
+        ],
+        "locale": "cs-CZ"
     },
-    "Denmark": {
+    "Denmark": 
+    {
         "code": "dk",
         "currency": "DKK",
-        "currency_fraction": "\u00d8re",
+        "currency_fraction": "Øre",
         "currency_fraction_units": 100,
         "currency_name": "Danish Krone",
         "currency_symbol": "kr",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Copenhagen"
-        ]
+        ],
+        "locale": "da-DK"
     },
-    "Djibouti": {
+    "Djibouti": 
+    {
         "code": "dj",
         "currency": "DJF",
         "currency_fraction": "Centime",
@@ -726,11 +877,14 @@
         "currency_name": "Djibouti Franc",
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Djibouti"
-        ]
+        ],
+        "locale": "fr-DJ"
     },
-    "Dominica": {
+    "Dominica": 
+    {
         "code": "dm",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -738,11 +892,13 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Dominica"
         ]
     },
-    "Dominican Republic": {
+    "Dominican Republic": 
+    {
         "code": "do",
         "currency": "DOP",
         "currency_fraction": "Centavo",
@@ -750,48 +906,60 @@
         "currency_name": "Dominican Peso",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Santo_Domingo"
-        ]
+        ],
+        "locale": "es-DO"
     },
-    "Ecuador": {
+    "Ecuador": 
+    {
         "code": "ec",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Guayaquil",
             "Pacific/Galapagos"
-        ]
+        ],
+        "locale": "es-EC"
     },
-    "Egypt": {
+    "Egypt": 
+    {
         "code": "eg",
         "currency": "EGP",
         "currency_fraction": "Piastre[F]",
         "currency_fraction_units": 100,
         "currency_name": "Egyptian Pound",
-        "currency_symbol": "\u00a3 or \u062c.\u0645",
+        "currency_symbol": "£ or ج.م",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Cairo"
         ],
         "fiscal_year_start": "07-01",
-        "fiscal_year_end": "06-30"
+        "fiscal_year_end": "06-30",
+        "locale": "ar-EG"
     },
-    "El Salvador": {
+    "El Salvador": 
+    {
         "code": "sv",
         "currency": "SVC",
         "currency_fraction": "Centavo",
         "currency_fraction_units": 100,
         "currency_name": "El Salvador Colon",
-        "currency_symbol": "\u20a1",
+        "currency_symbol": "₡",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/El_Salvador"
-        ]
+        ],
+        "locale": "es-SV"
     },
-    "Equatorial Guinea": {
+    "Equatorial Guinea": 
+    {
         "code": "gq",
         "currency": "XAF",
         "currency_name": "Central African CFA Franc",
@@ -799,11 +967,14 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Malabo"
-        ]
+        ],
+        "locale": "fr-GQ"
     },
-    "Eritrea": {
+    "Eritrea": 
+    {
         "code": "er",
         "currency": "ERN",
         "currency_fraction": "Cent",
@@ -811,50 +982,63 @@
         "currency_name": "Nakfa",
         "currency_symbol": "Nfk",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Asmara"
-        ]
+        ],
+        "locale": "ti-ER"
     },
-    "Estonia": {
+    "Estonia": 
+    {
         "code": "ee",
         "currency": "EEK",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_name": "Kroon",
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Tallinn"
-        ]
+        ],
+        "locale": "et-EE"
     },
-    "Ethiopia": {
+    "Ethiopia": 
+    {
         "code": "et",
         "currency_fraction": "Santim",
         "currency_fraction_units": 100,
         "currency_name": "Ethiopian Birr",
         "currency_symbol": "Br",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Addis_Ababa"
-        ]
+        ],
+        "locale": "am-ET"
     },
-    "Falkland Islands (Malvinas)": {
+    "Falkland Islands (Malvinas)": 
+    {
         "code": "fk",
         "currency": "FKP",
         "currency_name": "Falkland Islands Pound",
         "number_format": "#,###.##"
     },
-    "Faroe Islands": {
+    "Faroe Islands": 
+    {
         "code": "fo",
-        "currency_fraction": "\u00d8re",
+        "currency_fraction": "Øre",
         "currency_fraction_units": 100,
         "currency_symbol": "kr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Atlantic/Faroe"
-        ]
+        ],
+        "locale": "fo-FO"
     },
-    "Fiji": {
+    "Fiji": 
+    {
         "code": "fj",
         "currency": "FJD",
         "currency_fraction": "Cent",
@@ -862,57 +1046,70 @@
         "currency_name": "Fiji Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Fiji"
         ]
     },
-    "Finland": {
+    "Finland": 
+    {
         "code": "fi",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Helsinki"
-        ]
+        ],
+        "locale": "fi-FI"
     },
-    "France": {
+    "France": 
+    {
         "code": "fr",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "# ###,##",
         "date_format": "dd/MM/yyyy",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Paris"
-        ]
+        ],
+        "locale": "fr-FR"
     },
-    "French Guiana": {
+    "French Guiana": 
+    {
         "code": "gf",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Cayenne"
         ]
     },
-    "French Polynesia": {
+    "French Polynesia": 
+    {
         "code": "pf",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Gambier",
             "Pacific/Marquesas",
             "Pacific/Tahiti"
         ]
     },
-    "French Southern Territories": {
+    "French Southern Territories": 
+    {
         "code": "tf",
         "number_format": "#,###.##"
     },
-    "Gabon": {
+    "Gabon": 
+    {
         "code": "ga",
         "currency": "XAF",
         "currency_name": "Central African CFA Franc",
@@ -920,85 +1117,107 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Libreville"
-        ]
+        ],
+        "locale": "fr-GA"
     },
-    "Gambia": {
+    "Gambia": 
+    {
         "code": "gm",
         "currency": "GMD",
         "currency_name": "Dalasi",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Banjul"
         ]
     },
-    "Georgia": {
+    "Georgia": 
+    {
         "code": "ge",
         "currency_fraction": "Tetri",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u10da",
+        "currency_symbol": "ლ",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Tbilisi"
-        ]
+        ],
+        "locale": "ka-GE"
     },
-    "Germany": {
+    "Germany": 
+    {
         "code": "de",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Berlin"
-        ]
+        ],
+        "locale": "de-DE"
     },
-    "Ghana": {
+    "Ghana": 
+    {
         "code": "gh",
         "currency": "GHS",
         "currency_fraction": "Pesewa",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20b5",
+        "currency_symbol": "₵",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Accra"
-        ]
+        ],
+        "locale": "ak-GH"
     },
-    "Gibraltar": {
+    "Gibraltar": 
+    {
         "code": "gi",
         "currency": "GIP",
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
         "currency_name": "Gibraltar Pound",
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Gibraltar"
         ]
     },
-    "Greece": {
+    "Greece": 
+    {
         "code": "gr",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Athens"
-        ]
+        ],
+        "locale": "el-GR"
     },
-    "Greenland": {
+    "Greenland": 
+    {
         "code": "gl",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Danmarkshavn",
             "America/Godthab",
             "America/Scoresbysund",
             "America/Thule"
-        ]
+        ],
+        "locale": "kl-GL"
     },
-    "Grenada": {
+    "Grenada": 
+    {
         "code": "gd",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -1006,25 +1225,33 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Grenada"
         ]
     },
-    "Guadeloupe": {
+    "Guadeloupe": 
+    {
         "code": "gp",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Guadeloupe"
-        ]
+        ],
+        "locale": "fr-GP"
     },
-    "Guam": {
+    "Guam": 
+    {
         "code": "gu",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Guam"
-        ]
+        ],
+        "locale": "en-GU"
     },
-    "Guatemala": {
+    "Guatemala": 
+    {
         "code": "gt",
         "currency": "GTQ",
         "currency_fraction": "Centavo",
@@ -1032,21 +1259,26 @@
         "currency_name": "Quetzal",
         "currency_symbol": "Q",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Guatemala"
-        ]
+        ],
+        "locale": "es-GT"
     },
-    "Guernsey": {
+    "Guernsey": 
+    {
         "code": "gg",
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/London"
         ]
     },
-    "Guinea": {
+    "Guinea": 
+    {
         "code": "gn",
         "currency": "GNF",
         "currency_fraction": "Centime",
@@ -1054,11 +1286,14 @@
         "currency_name": "Guinea Franc",
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Conakry"
-        ]
+        ],
+        "locale": "fr-GN"
     },
-    "Guinea-Bissau": {
+    "Guinea-Bissau": 
+    {
         "code": "gw",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -1066,11 +1301,14 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Bissau"
-        ]
+        ],
+        "locale": "pt-GW"
     },
-    "Guyana": {
+    "Guyana": 
+    {
         "code": "gy",
         "currency": "GYD",
         "currency_fraction": "Cent",
@@ -1078,11 +1316,13 @@
         "currency_name": "Guyana Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Guyana"
         ]
     },
-    "Haiti": {
+    "Haiti": 
+    {
         "code": "ht",
         "currency": "HTG",
         "currency_fraction": "Centime",
@@ -1090,20 +1330,24 @@
         "currency_name": "Gourde",
         "currency_symbol": "G",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Guatemala",
             "America/Port-au-Prince"
         ]
     },
-    "Heard Island and McDonald Islands": {
+    "Heard Island and McDonald Islands": 
+    {
         "code": "hm",
         "number_format": "#,###.##"
     },
-    "Holy See (Vatican City State)": {
+    "Holy See (Vatican City State)": 
+    {
         "code": "va",
         "number_format": "#,###.##"
     },
-    "Honduras": {
+    "Honduras": 
+    {
         "code": "hn",
         "currency": "HNL",
         "currency_fraction": "Centavo",
@@ -1111,11 +1355,14 @@
         "currency_name": "Lempira",
         "currency_symbol": "L",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Tegucigalpa"
-        ]
+        ],
+        "locale": "es-HN"
     },
-    "Hong Kong": {
+    "Hong Kong": 
+    {
         "code": "hk",
         "currency": "HKD",
         "currency_fraction": "Cent",
@@ -1123,26 +1370,32 @@
         "currency_name": "Hong Kong Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Hong_Kong"
         ],
         "fiscal_year_start": "04-01",
-        "fiscal_year_end": "03-31"
+        "fiscal_year_end": "03-31",
+        "locale": "en-HK"
     },
-    "Hungary": {
+    "Hungary": 
+    {
         "code": "hu",
         "currency": "HUF",
-        "currency_fraction": "Fill\u00e9r",
+        "currency_fraction": "Fillér",
         "currency_fraction_units": 100,
         "currency_name": "Forint",
         "currency_symbol": "Ft",
         "date_format": "yyyy-MM-dd",
         "number_format": "#.###",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Budapest"
-        ]
+        ],
+        "locale": "hu-HU"
     },
-    "Iceland": {
+    "Iceland": 
+    {
         "code": "is",
         "currency": "ISK",
         "currency_fraction": "Eyrir",
@@ -1150,26 +1403,32 @@
         "currency_name": "Iceland Krona",
         "currency_symbol": "kr",
         "number_format": "#.###",
-        "timezones": [
+        "timezones": 
+        [
             "Atlantic/Reykjavik"
-        ]
+        ],
+        "locale": "is-IS"
     },
-    "India": {
+    "India": 
+    {
         "code": "in",
         "currency": "INR",
         "currency_fraction": "Paisa",
         "currency_fraction_units": 100,
         "currency_name": "Indian Rupee",
-        "currency_symbol": "\u20b9",
+        "currency_symbol": "₹",
         "date_format": "dd/MM/yyyy",
         "number_format": "#,##,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Kolkata"
         ],
         "fiscal_year_start": "04-01",
-        "fiscal_year_end": "03-31"
+        "fiscal_year_end": "03-31",
+        "locale": "en-IN"
     },
-    "Indonesia": {
+    "Indonesia": 
+    {
         "code": "id",
         "currency": "IDR",
         "currency_fraction": "Sen",
@@ -1177,85 +1436,105 @@
         "currency_name": "Rupiah",
         "currency_symbol": "Rp",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Jakarta",
             "Asia/Jayapura",
             "Asia/Makassar",
             "Asia/Pontianak"
-        ]
+        ],
+        "locale": "id-ID"
     },
-    "Iran": {
+    "Iran": 
+    {
         "code": "ir",
         "currency": "IRR",
         "currency_name": "Iranian Rial",
-        "currency_symbol": "\ufdfc",
+        "currency_symbol": "﷼",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Tehran"
         ],
         "fiscal_year_start": "06-23",
-        "fiscal_year_end": "06-22"
+        "fiscal_year_end": "06-22",
+        "locale": "fa-IR"
     },
-    "Iraq": {
+    "Iraq": 
+    {
         "code": "iq",
         "currency": "IQD",
         "currency_fraction": "Fils",
         "currency_fraction_units": 1000,
         "currency_name": "Iraqi Dinar",
-        "currency_symbol": "\u0639.\u062f",
+        "currency_symbol": "ع.د",
         "number_format": "#,###.###",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Baghdad"
-        ]
+        ],
+        "locale": "ar-IQ"
     },
-    "Ireland": {
+    "Ireland": 
+    {
         "code": "ie",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Dublin"
-        ]
+        ],
+        "locale": "en-IE"
     },
-    "Isle of Man": {
+    "Isle of Man": 
+    {
         "code": "im",
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/London"
         ]
     },
-    "Israel": {
+    "Israel": 
+    {
         "code": "il",
         "currency": "ILS",
         "currency_fraction": "Agora",
         "currency_fraction_units": 100,
         "currency_name": "New Israeli Sheqel",
-        "currency_symbol": "\u20aa",
+        "currency_symbol": "₪",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Jerusalem"
-        ]
+        ],
+        "locale": "en-IL"
     },
-    "Italy": {
+    "Italy": 
+    {
         "code": "it",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#.###,##",
         "date_format": "dd/MM/yyyy",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Rome"
         ],
         "fiscal_year_start": "07-01",
-        "fiscal_year_end": "06-30"
+        "fiscal_year_end": "06-30",
+        "locale": "it-IT"
     },
-    "Ivory Coast": {
+    "Ivory Coast": 
+    {
         "code": "ci",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -1263,11 +1542,14 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timeszones": [
+        "timeszones": 
+        [
             "Africa/Abidjan"
-        ]
+        ],
+        "locale": "fr-CI"
     },
-    "Jamaica": {
+    "Jamaica": 
+    {
         "code": "jm",
         "currency": "JMD",
         "currency_fraction": "Cent",
@@ -1275,53 +1557,65 @@
         "currency_name": "Jamaican Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Jamaica"
-        ]
+        ],
+        "locale": "en-JM"
     },
-    "Japan": {
+    "Japan": 
+    {
         "code": "jp",
         "currency": "JPY",
         "currency_fraction": "Sen[G]",
         "currency_fraction_units": 100,
         "currency_name": "Yen",
-        "currency_symbol": "\u00a5",
+        "currency_symbol": "¥",
         "number_format": "#,###",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Tokyo"
-        ]
+        ],
+        "locale": "ja-JP"
     },
-    "Jersey": {
+    "Jersey": 
+    {
         "code": "je",
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/London"
         ]
     },
-    "Jordan": {
+    "Jordan": 
+    {
         "code": "jo",
         "currency": "JOD",
         "currency_fraction": "Piastre[H]",
         "currency_fraction_units": 100,
         "currency_name": "Jordanian Dinar",
-        "currency_symbol": "\u062f.\u0627",
+        "currency_symbol": "د.ا",
         "number_format": "#,###.###",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Amman"
-        ]
+        ],
+        "locale": "ar-JO"
     },
-    "Kazakhstan": {
+    "Kazakhstan": 
+    {
         "code": "kz",
         "currency": "KZT",
-        "currency_fraction": "T\u00ef\u0131n",
+        "currency_fraction": "Tïın",
         "currency_fraction_units": 100,
         "currency_name": "Tenge",
-        "currency_symbol": "\u20b8",
+        "currency_symbol": "₸",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Almaty",
             "Asia/Aqtau",
             "Asia/Aqtobe",
@@ -1329,7 +1623,8 @@
             "Asia/Qyzylorda"
         ]
     },
-    "Kenya": {
+    "Kenya": 
+    {
         "code": "ke",
         "currency": "KES",
         "currency_fraction": "Cent",
@@ -1337,89 +1632,109 @@
         "currency_name": "Kenyan Shilling",
         "currency_symbol": "Sh",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Nairobi"
-        ]
+        ],
+        "locale": "ebu-KE"
     },
-    "Kiribati": {
+    "Kiribati": 
+    {
         "code": "ki",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Enderbury",
             "Pacific/Kiritimati",
             "Pacific/Tarawa"
         ]
     },
-    "Korea, Democratic Peoples Republic of": {
+    "Korea, Democratic Peoples Republic of": 
+    {
         "code": "kp",
         "currency": "KPW",
         "currency_name": "North Korean Won",
         "number_format": "#,###.##"
     },
-    "Korea, Republic of": {
+    "Korea, Republic of": 
+    {
         "code": "kr",
         "currency": "KRW",
         "currency_name": "Won",
-        "number_format": "#,###"
+        "number_format": "#,###",
+        "locale": "ko-KR"
     },
-    "Kuwait": {
+    "Kuwait": 
+    {
         "code": "kw",
         "currency": "KWD",
         "currency_fraction": "Fils",
         "currency_fraction_units": 1000,
         "currency_name": "Kuwaiti Dinar",
-        "currency_symbol": "\u062f.\u0643",
+        "currency_symbol": "د.ك",
         "number_format": "#,###.###",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Kuwait"
-        ]
+        ],
+        "locale": "ar-KW"
     },
-    "Kyrgyzstan": {
+    "Kyrgyzstan": 
+    {
         "code": "kg",
         "currency": "KGS",
         "currency_fraction": "Tyiyn",
         "currency_fraction_units": 100,
         "currency_name": "Som",
-        "currency_symbol": "\u043b\u0432",
+        "currency_symbol": "лв",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Bishkek"
         ]
     },
-    "Lao Peoples Democratic Republic": {
+    "Lao Peoples Democratic Republic": 
+    {
         "code": "la",
         "currency": "LAK",
         "currency_name": "Kip",
         "number_format": "#,###.##"
     },
-    "Latvia": {
+    "Latvia": 
+    {
         "code": "lv",
         "currency": "LVL",
-        "currency_fraction": "Sant\u012bms",
+        "currency_fraction": "Santīms",
         "currency_fraction_units": 100,
         "currency_name": "Latvian Lats",
         "currency_symbol": "Ls",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Riga"
-        ]
+        ],
+        "locale": "lv-LV"
     },
-    "Lebanon": {
+    "Lebanon": 
+    {
         "code": "lb",
         "currency": "LBP",
         "currency_fraction": "Piastre",
         "currency_fraction_units": 100,
         "currency_name": "Lebanese Pound",
-        "currency_symbol": "\u0644.\u0644",
+        "currency_symbol": "ل.ل",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Beirut"
-        ]
+        ],
+        "locale": "ar-LB"
     },
-    "Lesotho": {
+    "Lesotho": 
+    {
         "code": "ls",
         "currency": "LSL",
         "currency_fraction": "Sente",
@@ -1427,11 +1742,13 @@
         "currency_name": "Loti",
         "currency_symbol": "L",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Maseru"
         ]
     },
-    "Liberia": {
+    "Liberia": 
+    {
         "code": "lr",
         "currency": "LRD",
         "currency_fraction": "Cent",
@@ -1439,81 +1756,101 @@
         "currency_name": "Liberian Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Monrovia"
         ]
     },
-    "Libya": {
+    "Libya": 
+    {
         "code": "ly",
         "currency": "LYD",
         "currency_fraction": "Dirham",
         "currency_fraction_units": 1000,
         "currency_name": "Libyan Dinar",
-        "currency_symbol": "\u0644.\u062f",
+        "currency_symbol": "ل.د",
         "number_format": "#,###.###",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Tripoli"
-        ]
+        ],
+        "locale": "ar-LY"
     },
-    "Liechtenstein": {
+    "Liechtenstein": 
+    {
         "code": "li",
         "currency_fraction": "Rappen",
         "currency_fraction_units": 100,
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Vaduz"
-        ]
+        ],
+        "locale": "de-LI"
     },
-    "Lithuania": {
+    "Lithuania": 
+    {
         "code": "lt",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "date_format": "yyyy-MM-dd",
         "number_format": "# ###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Vilnius"
-        ]
+        ],
+        "locale": "lt-LT"
     },
-    "Luxembourg": {
+    "Luxembourg": 
+    {
         "code": "lu",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Luxembourg"
-        ]
+        ],
+        "locale": "fr-LU"
     },
-    "Macao": {
+    "Macao": 
+    {
         "code": "mo",
         "currency": "MOP",
         "currency_name": "Pataca",
         "number_format": "#,###.##"
     },
-    "Macedonia": {
+    "Macedonia": 
+    {
         "code": "mk",
         "currency": "MKD",
         "currency_fraction": "Deni",
         "currency_fraction_units": 100,
         "currency_name": "Denar",
-        "currency_symbol": "\u0434\u0435\u043d",
-        "number_format": "#,###.##"
+        "currency_symbol": "ден",
+        "number_format": "#,###.##",
+        "locale": "mk-MK"
     },
-    "Madagascar": {
+    "Madagascar": 
+    {
         "code": "mg",
         "currency_fraction": "Iraimbilanja",
         "currency_fraction_units": 5,
         "currency_symbol": "Ar",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Antananarivo"
-        ]
+        ],
+        "locale": "fr-MG"
     },
-    "Malawi": {
+    "Malawi": 
+    {
         "code": "mw",
         "currency": "MWK",
         "currency_fraction": "Tambala",
@@ -1521,11 +1858,13 @@
         "currency_name": "Kwacha",
         "currency_symbol": "MK",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Blantyre"
         ]
     },
-    "Malaysia": {
+    "Malaysia": 
+    {
         "code": "my",
         "currency": "MYR",
         "currency_fraction": "Sen",
@@ -1533,24 +1872,29 @@
         "currency_name": "Malaysian Ringgit",
         "currency_symbol": "RM",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Kuala_Lumpur",
             "Asia/Kuching"
-        ]
+        ],
+        "locale": "ms-MY"
     },
-    "Maldives": {
+    "Maldives": 
+    {
         "code": "mv",
         "currency": "MVR",
         "currency_fraction": "Laari",
         "currency_fraction_units": 100,
         "currency_name": "Rufiyaa",
-        "currency_symbol": ".\u0783",
+        "currency_symbol": ".ރ",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Maldives"
         ]
     },
-    "Mali": {
+    "Mali": 
+    {
         "code": "ml",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -1558,41 +1902,53 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Bamako"
-        ]
+        ],
+        "locale": "bm-ML"
     },
-    "Malta": {
+    "Malta": 
+    {
         "code": "mt",
         "currency": "MTL",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_name": "Maltese Lira",
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Malta"
-        ]
+        ],
+        "locale": "en-MT"
     },
-    "Marshall Islands": {
+    "Marshall Islands": 
+    {
         "code": "mh",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Kwajalein",
             "Pacific/Majuro"
-        ]
+        ],
+        "locale": "en-MH"
     },
-    "Martinique": {
+    "Martinique": 
+    {
         "code": "mq",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Martinique"
-        ]
+        ],
+        "locale": "fr-MQ"
     },
-    "Mauritania": {
+    "Mauritania": 
+    {
         "code": "mr",
         "currency": "MRO",
         "currency_fraction": "Khoums",
@@ -1600,30 +1956,37 @@
         "currency_name": "Ouguiya",
         "currency_symbol": "UM",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Nouakchott"
         ]
     },
-    "Mauritius": {
+    "Mauritius": 
+    {
         "code": "mu",
         "currency": "MUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_name": "Mauritius Rupee",
-        "currency_symbol": "\u20a8",
+        "currency_symbol": "₨",
         "number_format": "#,###",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Mauritius"
-        ]
+        ],
+        "locale": "en-MU"
     },
-    "Mayotte": {
+    "Mayotte": 
+    {
         "code": "yt",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Mayotte"
         ]
     },
-    "Mexico": {
+    "Mexico": 
+    {
         "code": "mx",
         "currency": "MXN",
         "currency_fraction": "Centavo",
@@ -1631,7 +1994,8 @@
         "currency_name": "Mexican Peso",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Bahia_Banderas",
             "America/Cancun",
             "America/Chihuahua",
@@ -1644,56 +2008,68 @@
             "America/Ojinaga",
             "America/Santa_Isabel",
             "America/Tijuana"
-        ]
+        ],
+        "locale": "es-MX"
     },
-    "Micronesia, Federated States of": {
+    "Micronesia, Federated States of": 
+    {
         "code": "fm",
         "number_format": "#,###.##"
     },
-    "Moldova, Republic of": {
+    "Moldova, Republic of": 
+    {
         "code": "md",
         "currency": "MDL",
         "currency_name": "Moldovan Leu",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "ro-MD"
     },
-    "Monaco": {
+    "Monaco": 
+    {
         "code": "mc",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Monaco"
-        ]
+        ],
+        "locale": "fr-MC"
     },
-    "Mongolia": {
+    "Mongolia": 
+    {
         "code": "mn",
         "currency": "MNT",
-        "currency_fraction": "M\u00f6ng\u00f6",
+        "currency_fraction": "Möngö",
         "currency_fraction_units": 100,
         "currency_name": "Tugrik",
-        "currency_symbol": "\u20ae",
+        "currency_symbol": "₮",
         "date_format": "yyyy-MM-dd",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Choibalsan",
             "Asia/Hovd",
             "Asia/Ulaanbaatar"
         ]
     },
-    "Montenegro": {
+    "Montenegro": 
+    {
         "code": "me",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Belgrade"
         ]
     },
-    "Montserrat": {
+    "Montserrat": 
+    {
         "code": "ms",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -1701,44 +2077,55 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Montserrat"
         ]
     },
-    "Morocco": {
+    "Morocco": 
+    {
         "code": "ma",
         "currency": "MAD",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "currency_name": "Moroccan Dirham",
-        "currency_symbol": "\u062f.\u0645.",
+        "currency_symbol": "د.م.",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Casablanca"
-        ]
+        ],
+        "locale": "ar-MA"
     },
-    "Mozambique": {
+    "Mozambique": 
+    {
         "code": "mz",
         "currency_fraction": "Centavo",
         "currency_fraction_units": 100,
         "currency_symbol": "MT",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Maputo"
-        ]
+        ],
+        "locale": "pt-MZ"
     },
-    "Myanmar": {
+    "Myanmar": 
+    {
         "code": "mm",
         "currency": "MMK",
         "currency_name": "Kyat",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Rangoon"
         ],
         "fiscal_year_start": "04-01",
-        "fiscal_year_end": "03-31"
+        "fiscal_year_end": "03-31",
+        "locale": "my-MM"
     },
-    "Namibia": {
+    "Namibia": 
+    {
         "code": "na",
         "currency": "NAD",
         "currency_fraction": "Cent",
@@ -1746,54 +2133,67 @@
         "currency_name": "Namibia Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Windhoek"
-        ]
+        ],
+        "locale": "en-NA"
     },
-    "Nauru": {
+    "Nauru": 
+    {
         "code": "nr",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Nauru"
         ]
     },
-    "Nepal": {
+    "Nepal": 
+    {
         "code": "np",
         "currency": "NPR",
         "currency_fraction": "Paisa",
         "currency_fraction_units": 100,
         "currency_name": "Nepalese Rupee",
-        "currency_symbol": "\u20a8",
+        "currency_symbol": "₨",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Kathmandu"
-        ]
+        ],
+        "locale": "ne-NP"
     },
-    "Netherlands": {
+    "Netherlands": 
+    {
         "code": "nl",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Amsterdam"
-        ]
+        ],
+        "locale": "nl-NL"
     },
-    "New Caledonia": {
+    "New Caledonia": 
+    {
         "code": "nc",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Noumea"
         ]
     },
-    "New Zealand": {
+    "New Zealand": 
+    {
         "code": "nz",
         "currency": "NZD",
         "currency_fraction": "Cent",
@@ -1801,14 +2201,17 @@
         "currency_name": "New Zealand Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Auckland",
             "Pacific/Chatham"
         ],
         "fiscal_year_start": "04-01",
-        "fiscal_year_end": "03-31"
+        "fiscal_year_end": "03-31",
+        "locale": "en-NZ"
     },
-    "Nicaragua": {
+    "Nicaragua": 
+    {
         "code": "ni",
         "currency": "NIO",
         "currency_fraction": "Centavo",
@@ -1816,11 +2219,14 @@
         "currency_name": "Cordoba Oro",
         "currency_symbol": "C$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Managua"
-        ]
+        ],
+        "locale": "es-NI"
     },
-    "Niger": {
+    "Niger": 
+    {
         "code": "ne",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -1828,110 +2234,138 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Niamey"
-        ]
+        ],
+        "locale": "fr-NE"
     },
-    "Nigeria": {
+    "Nigeria": 
+    {
         "code": "ng",
         "currency": "NGN",
         "currency_fraction": "Kobo",
         "currency_fraction_units": 100,
         "currency_name": "Naira",
-        "currency_symbol": "\u20a6",
+        "currency_symbol": "₦",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Lagos"
-        ]
+        ],
+        "locale": "ig-NG"
     },
-    "Niue": {
+    "Niue": 
+    {
         "code": "nu",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Niue"
         ]
     },
-    "Norfolk Island": {
+    "Norfolk Island": 
+    {
         "code": "nf",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Norfolk"
         ]
     },
-    "Northern Mariana Islands": {
+    "Northern Mariana Islands": 
+    {
         "code": "mp",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Saipan"
-        ]
+        ],
+        "locale": "en-MP"
     },
-    "Norway": {
+    "Norway": 
+    {
         "code": "no",
         "currency": "NOK",
-        "currency_fraction": "\u00d8re",
+        "currency_fraction": "Øre",
         "currency_fraction_units": 100,
         "currency_name": "Norwegian Krone",
         "currency_symbol": "kr",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Oslo"
-        ]
+        ],
+        "locale": "nb-NO"
     },
-    "Oman": {
+    "Oman": 
+    {
         "code": "om",
         "currency": "OMR",
         "currency_fraction": "Baisa",
         "currency_fraction_units": 1000,
         "currency_name": "Rial Omani",
-        "currency_symbol": "\u0631.\u0639.",
+        "currency_symbol": "ر.ع.",
         "number_format": "#,###.###",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Muscat"
-        ]
+        ],
+        "locale": "ar-OM"
     },
-    "Pakistan": {
+    "Pakistan": 
+    {
         "code": "pk",
         "currency": "PKR",
         "currency_fraction": "Paisa",
         "currency_fraction_units": 100,
         "currency_name": "Pakistan Rupee",
-        "currency_symbol": "\u20a8",
+        "currency_symbol": "₨",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Karachi"
         ],
         "fiscal_year_start": "07-01",
-        "fiscal_year_end": "06-30"
+        "fiscal_year_end": "06-30",
+        "locale": "en-PK"
     },
-    "Palau": {
+    "Palau": 
+    {
         "code": "pw",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Palau"
         ]
     },
-    "Palestinian Territory, Occupied": {
+    "Palestinian Territory, Occupied": 
+    {
         "code": "ps",
         "number_format": "#,###.##"
     },
-    "Panama": {
+    "Panama": 
+    {
         "code": "pa",
-        "currency_fraction": "Cent\u00e9simo",
+        "currency_fraction": "Centésimo",
         "currency_fraction_units": 100,
         "currency_symbol": "B/.",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Panama"
-        ]
+        ],
+        "locale": "es-PA"
     },
-    "Papua New Guinea": {
+    "Papua New Guinea": 
+    {
         "code": "pg",
         "currency": "PGK",
         "currency_fraction": "Toea",
@@ -1939,98 +2373,123 @@
         "currency_name": "Kina",
         "currency_symbol": "K",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Port_Moresby"
         ]
     },
-    "Paraguay": {
+    "Paraguay": 
+    {
         "code": "py",
         "currency": "PYG",
-        "currency_fraction": "C\u00e9ntimo",
+        "currency_fraction": "Céntimo",
         "currency_fraction_units": 100,
         "currency_name": "Guarani",
-        "currency_symbol": "\u20b2",
+        "currency_symbol": "₲",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Asuncion"
-        ]
+        ],
+        "locale": "es-PY"
     },
-    "Peru": {
+    "Peru": 
+    {
         "code": "pe",
         "currency": "PEN",
-        "currency_fraction": "C\u00e9ntimo",
+        "currency_fraction": "Céntimo",
         "currency_fraction_units": 100,
         "currency_name": "Nuevo Sol",
         "currency_symbol": "S/.",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Lima"
-        ]
+        ],
+        "locale": "es-PE"
     },
-    "Philippines": {
+    "Philippines": 
+    {
         "code": "ph",
         "currency": "PHP",
         "currency_fraction": "Centavo",
         "currency_fraction_units": 100,
         "currency_name": "Philippine Peso",
-        "currency_symbol": "\u20b1",
+        "currency_symbol": "₱",
         "date_format": "MM-dd-yyyy",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Manila"
-        ]
+        ],
+        "locale": "en-PH"
     },
-    "Pitcairn": {
+    "Pitcairn": 
+    {
         "code": "pn",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Pitcairn"
         ]
     },
-    "Poland": {
+    "Poland": 
+    {
         "code": "pl",
         "currency": "PLN",
         "currency_fraction": "Grosz",
         "currency_fraction_units": 100,
-        "currency_symbol": "z\u0142",
+        "currency_symbol": "zł",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Warsaw"
-        ]
+        ],
+        "locale": "pl-PL"
     },
-    "Portugal": {
+    "Portugal": 
+    {
         "code": "pt",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Atlantic/Azores",
             "Atlantic/Madeira",
             "Europe/Lisbon"
-        ]
+        ],
+        "locale": "pt-PT"
     },
-    "Puerto Rico": {
+    "Puerto Rico": 
+    {
         "code": "pr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Puerto_Rico"
-        ]
+        ],
+        "locale": "es-PR"
     },
-    "Qatar": {
+    "Qatar": 
+    {
         "code": "qa",
         "currency": "QAR",
         "currency_fraction": "Dirham",
         "currency_fraction_units": 100,
         "currency_name": "Qatari Rial",
-        "currency_symbol": "\u0631.\u0642",
+        "currency_symbol": "ر.ق",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Qatar"
-        ]
+        ],
+        "locale": "ar-QA"
     },
-    "Romania": {
+    "Romania": 
+    {
         "code": "ro",
         "currency": "RON",
         "currency_fraction": "Bani",
@@ -2038,17 +2497,22 @@
         "currency_name": "Romanian New Leu",
         "currency_symbol": "lei",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Bucharest"
-        ]
+        ],
+        "locale": "ro-RO"
     },
-    "Russian Federation": {
+    "Russian Federation": 
+    {
         "code": "ru",
         "currency": "RUB",
         "currency_name": "Russian Ruble",
-        "number_format": "#.###,##"
+        "number_format": "#.###,##",
+        "locale": "ru-RU"
     },
-    "Rwanda": {
+    "Rwanda": 
+    {
         "code": "rw",
         "currency": "RWF",
         "currency_fraction": "Centime",
@@ -2056,25 +2520,33 @@
         "currency_name": "Rwanda Franc",
         "currency_symbol": "Fr",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Kigali"
-        ]
+        ],
+        "locale": "fr-RW"
     },
-    "R\u00e9union": {
+    "Réunion": 
+    {
         "code": "re",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "fr-RE"
     },
-    "Saint Barth\u00e9lemy": {
+    "Saint Barthélemy": 
+    {
         "code": "bl",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "fr-BL"
     },
-    "Saint Helena, Ascension and Tristan da Cunha": {
+    "Saint Helena, Ascension and Tristan da Cunha": 
+    {
         "code": "sh",
         "currency": "SHP",
         "currency_name": "Saint Helena Pound",
         "number_format": "#,###.##"
     },
-    "Saint Kitts and Nevis": {
+    "Saint Kitts and Nevis": 
+    {
         "code": "kn",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -2082,11 +2554,13 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/St_Kitts"
         ]
     },
-    "Saint Lucia": {
+    "Saint Lucia": 
+    {
         "code": "lc",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -2094,19 +2568,24 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/St_Lucia"
         ]
     },
-    "Saint Martin (French part)": {
+    "Saint Martin (French part)": 
+    {
         "code": "mf",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "fr-MF"
     },
-    "Saint Pierre and Miquelon": {
+    "Saint Pierre and Miquelon": 
+    {
         "code": "pm",
         "number_format": "#,###.##"
     },
-    "Saint Vincent and the Grenadines": {
+    "Saint Vincent and the Grenadines": 
+    {
         "code": "vc",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
@@ -2114,11 +2593,13 @@
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/St_Vincent"
         ]
     },
-    "Samoa": {
+    "Samoa": 
+    {
         "code": "ws",
         "currency": "WST",
         "currency_fraction": "Sene",
@@ -2126,40 +2607,48 @@
         "currency_name": "Tala",
         "currency_symbol": "T",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Apia"
         ]
     },
-    "San Marino": {
+    "San Marino": 
+    {
         "code": "sm",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Rome"
         ]
     },
-    "Sao Tome and Principe": {
+    "Sao Tome and Principe": 
+    {
         "code": "st",
         "currency": "STD",
         "currency_name": "Dobra",
         "number_format": "#,###.##"
     },
-    "Saudi Arabia": {
+    "Saudi Arabia": 
+    {
         "code": "sa",
         "currency": "SAR",
         "currency_fraction": "Halala",
         "currency_fraction_units": 100,
         "currency_name": "Saudi Riyal",
-        "currency_symbol": "\u0631.\u0633",
+        "currency_symbol": "ر.س",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Riyadh"
-        ]
+        ],
+        "locale": "ar-SA"
     },
-    "Senegal": {
+    "Senegal": 
+    {
         "code": "sn",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -2167,35 +2656,42 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Dakar"
-        ]
+        ],
+        "locale": "fr-SN"
     },
-    "Serbia": {
+    "Serbia": 
+    {
         "code": "rs",
         "currency": "RSD",
         "currency_fraction": "Para",
         "currency_fraction_units": 100,
         "currency_name": "Serbian Dinar",
-        "currency_symbol": "\u0434\u0438\u043d.",
+        "currency_symbol": "дин.",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Belgrade"
         ]
     },
-    "Seychelles": {
+    "Seychelles": 
+    {
         "code": "sc",
         "currency": "SCR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_name": "Seychelles Rupee",
-        "currency_symbol": "\u20a8",
+        "currency_symbol": "₨",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Indian/Mahe"
         ]
     },
-    "Sierra Leone": {
+    "Sierra Leone": 
+    {
         "code": "sl",
         "currency": "SLL",
         "currency_fraction": "Cent",
@@ -2203,11 +2699,13 @@
         "currency_name": "Leone",
         "currency_symbol": "Le",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Freetown"
         ]
     },
-    "Singapore": {
+    "Singapore": 
+    {
         "code": "sg",
         "currency": "SGD",
         "currency_fraction": "Sen",
@@ -2215,39 +2713,49 @@
         "currency_name": "Singapore Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Singapore"
         ],
         "fiscal_year_start": "04-01",
-        "fiscal_year_end": "03-31"
+        "fiscal_year_end": "03-31",
+        "locale": "en-SG"
     },
-    "Sint Maarten (Dutch part)": {
+    "Sint Maarten (Dutch part)": 
+    {
         "code": "sx",
         "number_format": "#,###.##"
     },
-    "Slovakia": {
+    "Slovakia": 
+    {
         "code": "sk",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Bratislava"
-        ]
+        ],
+        "locale": "sk-SK"
     },
-    "Slovenia": {
+    "Slovenia": 
+    {
         "code": "si",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Belgrade"
-        ]
+        ],
+        "locale": "sl-SI"
     },
-    "Solomon Islands": {
+    "Solomon Islands": 
+    {
         "code": "sb",
         "currency": "SBD",
         "currency_fraction": "Cent",
@@ -2255,11 +2763,13 @@
         "currency_name": "Solomon Islands Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Guadalcanal"
         ]
     },
-    "Somalia": {
+    "Somalia": 
+    {
         "code": "so",
         "currency": "SOS",
         "currency_fraction": "Cent",
@@ -2267,11 +2777,14 @@
         "currency_name": "Somali Shilling",
         "currency_symbol": "Sh",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Mogadishu"
-        ]
+        ],
+        "locale": "so-SO"
     },
-    "South Africa": {
+    "South Africa": 
+    {
         "code": "za",
         "currency": "ZAR",
         "currency_fraction": "Cent",
@@ -2280,43 +2793,52 @@
         "currency_symbol": "R",
         "date_format": "yyyy-MM-dd",
         "number_format": "# ###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Johannesburg"
         ],
         "fiscal_year_start": "03-01",
-        "fiscal_year_end": "02-28"
+        "fiscal_year_end": "02-28",
+        "locale": "en-ZA"
     },
-    "South Georgia and the South Sandwich Islands": {
+    "South Georgia and the South Sandwich Islands": 
+    {
         "code": "gs",
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##"
     },
-    "South Sudan": {
+    "South Sudan": 
+    {
         "code": "ss",
         "currency_fraction": "Piastre",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Juba"
         ]
     },
-    "Spain": {
+    "Spain": 
+    {
         "code": "es",
         "currency": "EUR",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ac",
+        "currency_symbol": "€",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Ceuta",
             "Atlantic/Canary",
             "Europe/Madrid"
-        ]
+        ],
+        "locale": "eu-ES"
     },
-    "Sri Lanka": {
+    "Sri Lanka": 
+    {
         "code": "lk",
         "currency": "LKR",
         "currency_fraction": "Cent",
@@ -2324,35 +2846,44 @@
         "currency_name": "Sri Lanka Rupee",
         "currency_symbol": "Rs",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Colombo"
-        ]
+        ],
+        "locale": "si-LK"
     },
-    "Sudan": {
+    "Sudan": 
+    {
         "code": "sd",
         "currency_fraction": "Piastre",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Khartoum"
-        ]
+        ],
+        "locale": "ar-SD"
     },
-    "Suriname": {
+    "Suriname": 
+    {
         "code": "sr",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Paramaribo"
         ]
     },
-    "Svalbard and Jan Mayen": {
+    "Svalbard and Jan Mayen": 
+    {
         "code": "sj",
         "number_format": "#,###.##"
     },
-    "Swaziland": {
+    "Swaziland": 
+    {
         "code": "sz",
         "currency": "SZL",
         "currency_fraction": "Cent",
@@ -2360,23 +2891,28 @@
         "currency_name": "Lilangeni",
         "currency_symbol": "L",
         "number_format": "#, ###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Mbabane"
         ]
     },
-    "Sweden": {
+    "Sweden": 
+    {
         "code": "se",
         "currency": "SEK",
-        "currency_fraction": "\u00d6re",
+        "currency_fraction": "Öre",
         "currency_fraction_units": 100,
         "currency_name": "Swedish Krona",
         "currency_symbol": "kr",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Stockholm"
-        ]
+        ],
+        "locale": "sv-SE"
     },
-    "Switzerland": {
+    "Switzerland": 
+    {
         "code": "ch",
         "currency": "CHF",
         "currency_fraction": "Rappen[K]",
@@ -2385,57 +2921,71 @@
         "currency_name": "Swiss Franc",
         "currency_symbol": "Fr",
         "number_format": "#'###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Zurich"
-        ]
+        ],
+        "locale": "fr-CH"
     },
-    "Syria": {
+    "Syria": 
+    {
         "code": "sy",
         "currency": "SYP",
         "currency_name": "Syrian Pound",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "ar-SY"
     },
-    "Taiwan": {
+    "Taiwan": 
+    {
         "code": "tw",
         "currency": "TWD",
         "date_format": "yyyy-MM-dd",
         "number_format": "#,###.##"
     },
-    "Tajikistan": {
+    "Tajikistan": 
+    {
         "code": "tj",
         "currency_fraction": "Diram",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u0405\u041c",
+        "currency_symbol": "ЅМ",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Dushanbe"
         ]
     },
-    "Tanzania": {
+    "Tanzania": 
+    {
         "code": "tz",
         "currency": "TZS",
         "currency_name": "Tanzanian Shilling",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "asa-TZ"
     },
-    "Thailand": {
+    "Thailand": 
+    {
         "code": "th",
         "currency": "THB",
         "currency_fraction": "Satang",
         "currency_fraction_units": 100,
         "currency_name": "Baht",
-        "currency_symbol": "\u0e3f",
+        "currency_symbol": "฿",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Bangkok"
         ],
         "fiscal_year_start": "10-01",
-        "fiscal_year_end": "09-30"
+        "fiscal_year_end": "09-30",
+        "locale": "th-TH"
     },
-    "Timor-Leste": {
+    "Timor-Leste": 
+    {
         "code": "tl",
         "number_format": "#,###.##"
     },
-    "Togo": {
+    "Togo": 
+    {
         "code": "tg",
         "currency": "XOF",
         "currency_name": "West African CFA Franc",
@@ -2443,18 +2993,23 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Lome"
-        ]
+        ],
+        "locale": "ee-TG"
     },
-    "Tokelau": {
+    "Tokelau": 
+    {
         "code": "tk",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Fakaofo"
         ]
     },
-    "Tonga": {
+    "Tonga": 
+    {
         "code": "to",
         "currency": "TOP",
         "currency_fraction": "Seniti[L]",
@@ -2462,11 +3017,14 @@
         "currency_name": "Pa'anga",
         "currency_symbol": "T$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Tongatapu"
-        ]
+        ],
+        "locale": "to-TO"
     },
-    "Trinidad and Tobago": {
+    "Trinidad and Tobago": 
+    {
         "code": "tt",
         "currency": "TTD",
         "currency_fraction": "Cent",
@@ -2474,34 +3032,43 @@
         "currency_name": "Trinidad and Tobago Dollar",
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Port_of_Spain"
-        ]
+        ],
+        "locale": "en-TT"
     },
-    "Tunisia": {
+    "Tunisia": 
+    {
         "code": "tn",
         "currency": "TND",
         "currency_fraction": "Millime",
         "currency_fraction_units": 1000,
         "currency_name": "Tunisian Dinar",
-        "currency_symbol": "\u062f.\u062a",
+        "currency_symbol": "د.ت",
         "number_format": "#,###.###",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Tunis"
-        ]
+        ],
+        "locale": "ar-TN"
     },
-    "Turkey": {
+    "Turkey": 
+    {
         "code": "tr",
         "currency": "TRY",
-        "currency_fraction": "Kuru\u015f",
+        "currency_fraction": "Kuruş",
         "currency_fraction_units": 100,
-        "currency_symbol": "\u20ba",
+        "currency_symbol": "₺",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Istanbul"
-        ]
+        ],
+        "locale": "tr-TR"
     },
-    "Turkmenistan": {
+    "Turkmenistan": 
+    {
         "code": "tm",
         "currency": "TMM",
         "currency_fraction": "Tennesi",
@@ -2509,28 +3076,33 @@
         "currency_name": "Manat",
         "currency_symbol": "m",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Ashgabat"
         ]
     },
-    "Turks and Caicos Islands": {
+    "Turks and Caicos Islands": 
+    {
         "code": "tc",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##"
     },
-    "Tuvalu": {
+    "Tuvalu": 
+    {
         "code": "tv",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Funafuti"
         ]
     },
-    "Uganda": {
+    "Uganda": 
+    {
         "code": "ug",
         "currency": "UGX",
         "currency_fraction": "Cent",
@@ -2538,52 +3110,64 @@
         "currency_name": "Uganda Shilling",
         "currency_symbol": "Sh",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Kampala"
-        ]
+        ],
+        "locale": "cgg-UG"
     },
-    "Ukraine": {
+    "Ukraine": 
+    {
         "code": "ua",
         "currency": "UAH",
         "currency_fraction": "Kopiyka",
         "currency_fraction_units": 100,
         "currency_name": "Ukrainian Hryvnia",
-        "currency_symbol": "\u20b4",
+        "currency_symbol": "₴",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/Kiev",
             "Europe/Simferopol",
             "Europe/Uzhgorod",
             "Europe/Zaporozhye"
-        ]
+        ],
+        "locale": "ru-UA"
     },
-    "United Arab Emirates": {
+    "United Arab Emirates": 
+    {
         "code": "ae",
         "currency": "AED",
         "currency_fraction": "Fils",
         "currency_fraction_units": 100,
         "currency_name": "UAE Dirham",
-        "currency_symbol": "\u062f.\u0625",
+        "currency_symbol": "د.إ",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Dubai"
-        ]
+        ],
+        "locale": "ar-AE"
     },
-    "United Kingdom": {
+    "United Kingdom": 
+    {
         "code": "gb",
         "currency": "GBP",
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
         "currency_name": "Pound Sterling",
-        "currency_symbol": "\u00a3",
+        "currency_symbol": "£",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Europe/London"
         ],
         "fiscal_year_start": "04-01",
-        "fiscal_year_end": "03-31"
+        "fiscal_year_end": "03-31",
+        "locale": "en-GB"
     },
-    "United States": {
+    "United States": 
+    {
         "code": "us",
         "currency": "USD",
         "currency_fraction": "Cent",
@@ -2593,7 +3177,8 @@
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Adak",
             "America/Anchorage",
             "America/Boise",
@@ -2624,38 +3209,47 @@
             "America/Sitka",
             "America/Yakutat",
             "Pacific/Honolulu"
-        ]
+        ],
+        "locale": "en-US"
     },
-    "United States Minor Outlying Islands": {
+    "United States Minor Outlying Islands": 
+    {
         "code": "um",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "en-UM"
     },
-    "Uruguay": {
+    "Uruguay": 
+    {
         "code": "uy",
         "currency": "UYU",
-        "currency_fraction": "Cent\u00e9simo",
+        "currency_fraction": "Centésimo",
         "currency_fraction_units": 100,
         "currency_name": "Peso Uruguayo",
         "currency_symbol": "$",
         "number_format": "#.###,##",
-        "timezones": [
+        "timezones": 
+        [
             "America/Montevideo"
-        ]
+        ],
+        "locale": "es-UY"
     },
-    "Uzbekistan": {
+    "Uzbekistan": 
+    {
         "code": "uz",
         "currency": "UZS",
         "currency_fraction": "Tiyin",
         "currency_fraction_units": 100,
         "currency_name": "Uzbekistan Sum",
-        "currency_symbol": "\u043b\u0432",
+        "currency_symbol": "лв",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Samarkand",
             "Asia/Tashkent"
         ]
     },
-    "Vanuatu": {
+    "Vanuatu": 
+    {
         "code": "vu",
         "currency": "VUV",
         "currency_fraction": "None",
@@ -2663,57 +3257,72 @@
         "currency_name": "Vatu",
         "currency_symbol": "Vt",
         "number_format": "#,###",
-        "timezones": [
+        "timezones": 
+        [
             "Pacific/Efate"
         ]
     },
-    "Venezuela, Bolivarian Republic of": {
+    "Venezuela, Bolivarian Republic of": 
+    {
         "code": "ve",
         "number_format": "#.###,##",
         "currency": "VEF",
         "currency_symbol": "Bs.",
         "currency_fraction": "Centimos",
-        "currency_fraction_units": 100
+        "currency_fraction_units": 100,
+        "locale": "es-VE"
     },
-    "Vietnam": {
+    "Vietnam": 
+    {
         "code": "vn",
         "currency": "VND",
         "currency_name": "Dong",
-        "number_format": "#.###"
+        "number_format": "#.###",
+        "locale": "vi-VN"
     },
-    "Virgin Islands, British": {
+    "Virgin Islands, British": 
+    {
         "code": "vg",
         "number_format": "#,###.##"
     },
-    "Virgin Islands, U.S.": {
+    "Virgin Islands, U.S.": 
+    {
         "code": "vi",
-        "number_format": "#,###.##"
+        "number_format": "#,###.##",
+        "locale": "en-VI"
     },
-    "Wallis and Futuna": {
+    "Wallis and Futuna": 
+    {
         "code": "wf",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "currency_symbol": "Fr",
         "number_format": "#,###.##"
     },
-    "Western Sahara": {
+    "Western Sahara": 
+    {
         "code": "eh",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/El_Aaiun"
         ]
     },
-    "Yemen": {
+    "Yemen": 
+    {
         "code": "ye",
         "currency_fraction": "Fils",
         "currency_fraction_units": 100,
-        "currency_symbol": "\ufdfc",
+        "currency_symbol": "﷼",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Asia/Aden"
-        ]
+        ],
+        "locale": "ar-YE"
     },
-    "Zambia": {
+    "Zambia": 
+    {
         "code": "zm",
         "currency": "ZMW",
         "currency_fraction": "Ngwee",
@@ -2721,11 +3330,14 @@
         "currency_name": "Zambian Kwacha",
         "currency_symbol": "ZK",
         "number_format": "#,###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Lusaka"
-        ]
+        ],
+        "locale": "bem-ZM"
     },
-    "Zimbabwe": {
+    "Zimbabwe": 
+    {
         "code": "zw",
         "currency": "ZWD",
         "currency_fraction": "Thebe",
@@ -2733,11 +3345,14 @@
         "currency_name": "Zimbabwe Dollar",
         "currency_symbol": "P",
         "number_format": "# ###.##",
-        "timezones": [
+        "timezones": 
+        [
             "Africa/Harare"
-        ]
+        ],
+        "locale": "en-ZW"
     },
-    "\u00c5land Islands": {
+    "Åland Islands": 
+    {
         "code": "ax",
         "number_format": "#,###.##"
     }

--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -6,7 +6,6 @@
         "currency_fraction": "Pul",
         "currency_fraction_units": 100,
         "currency_symbol": "؋",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Kabul"
@@ -23,7 +22,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Lek",
         "currency_symbol": "L",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Tirane"
@@ -38,7 +36,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Algerian Dinar",
         "currency_symbol": "د.ج",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Algiers"
@@ -48,7 +45,6 @@
     "American Samoa": 
     {
         "code": "as",
-        "number_format": "#,###.##",
         "locale": "en-AS"
     },
     "Andorra": 
@@ -58,7 +54,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Andorra"
@@ -72,7 +67,6 @@
         "currency_fraction_units": 100,
         "currency_symbol": "AOA",
         "currency_name": "Kwanza",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Luanda"
@@ -86,7 +80,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Anguilla"
@@ -95,7 +88,6 @@
     "Antarctica": 
     {
         "code": "aq",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Antarctica/Casey",
@@ -118,7 +110,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Antigua"
@@ -132,7 +123,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Argentine Peso",
         "currency_symbol": "$",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "America/Argentina/Buenos_Aires",
@@ -158,7 +148,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Armenian Dram",
         "currency_symbol": "֏",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Yerevan"
@@ -173,7 +162,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Aruban Florin",
         "currency_symbol": "Afl",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Aruba"
@@ -187,7 +175,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Australian Dollar",
         "currency_symbol": "$",
-        "number_format": "# ###.##",
         "timezones": 
         [
             "Australia/Adelaide",
@@ -214,7 +201,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Vienna"
@@ -227,7 +213,6 @@
         "currency_fraction": "Qəpik",
         "currency_fraction_units": 100,
         "currency_symbol": "",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Baku"
@@ -238,7 +223,6 @@
         "code": "bs",
         "currency": "BSD",
         "currency_name": "Bahamian Dollar",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Nassau"
@@ -252,7 +236,6 @@
         "currency_fraction_units": 1000,
         "currency_name": "Bahraini Dinar",
         "currency_symbol": ".د.ب",
-        "number_format": "#,###.###",
         "timezones": 
         [
             "Asia/Bahrain"
@@ -267,7 +250,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Taka",
         "currency_symbol": "৳",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Dhaka"
@@ -284,7 +266,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Barbados Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Barbados"
@@ -296,7 +277,6 @@
         "currency_fraction": "Kapyeyka",
         "currency_fraction_units": 100,
         "currency_symbol": "Br",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Minsk"
@@ -310,7 +290,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Brussels"
@@ -326,7 +305,6 @@
         "currency_name": "Belize Dollar",
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Belize"
@@ -341,7 +319,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Porto-Novo"
@@ -356,7 +333,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Bermudian Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Atlantic/Bermuda"
@@ -370,7 +346,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Ngultrum",
         "currency_symbol": "Nu.",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Thimphu"
@@ -381,13 +356,11 @@
         "code": "bo",
         "currency": "BOB",
         "currency_name": "Boliviano",
-        "number_format": "#,###.##",
         "locale": "es-BO"
     },
     "Bonaire, Sint Eustatius and Saba": 
     {
-        "code": "bq",
-        "number_format": "#,###.##"
+        "code": "bq"
     },
     "Bosnia and Herzegovina": 
     {
@@ -396,7 +369,6 @@
         "currency_fraction": "Fening",
         "currency_fraction_units": 100,
         "currency_symbol": "KM",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Europe/Sarajevo"
@@ -411,7 +383,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Pula",
         "currency_symbol": "P",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Gaborone"
@@ -420,8 +391,7 @@
     },
     "Bouvet Island": 
     {
-        "code": "bv",
-        "number_format": "#,###.##"
+        "code": "bv"
     },
     "Brazil": 
     {
@@ -431,7 +401,6 @@
         "currency_fraction_units": 100,
         "currency_symbol": "R$",
         "date_format": "dd/MM/yyyy",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "America/Araguaina",
@@ -459,7 +428,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Chagos"
@@ -470,7 +438,6 @@
         "code": "bn",
         "currency": "BND",
         "currency_name": "Brunei Dollar",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Brunei"
@@ -485,7 +452,6 @@
         "currency_fraction": "Stotinka",
         "currency_fraction_units": 100,
         "currency_symbol": "лв",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Sofia"
@@ -500,7 +466,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Ouagadougou"
@@ -515,7 +480,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Burundi Franc",
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Bujumbura"
@@ -530,7 +494,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Riel",
         "currency_symbol": "៛",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Phnom_Penh"
@@ -545,7 +508,6 @@
         "currency_symbol": "FCFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Douala"
@@ -561,7 +523,6 @@
         "currency_name": "Canadian Dollar",
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Atikokan",
@@ -605,7 +566,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Cape Verde Escudo",
         "currency_symbol": "Esc or $",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Atlantic/Cape_Verde"
@@ -620,7 +580,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Cayman Islands Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Cayman"
@@ -634,7 +593,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Central African CFA Franc",
         "currency_symbol": "FCFA",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Bangui"
@@ -649,7 +607,6 @@
         "currency_symbol": "FCFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Ndjamena"
@@ -664,7 +621,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Chilean Peso",
         "currency_symbol": "$",
-        "number_format": "#.###",
         "timezones": 
         [
             "America/Santiago",
@@ -678,7 +634,6 @@
         "currency": "CNY",
         "currency_name": "Yuan Renminbi",
         "date_format": "yyyy-MM-dd",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Chongqing",
@@ -692,7 +647,6 @@
     "Christmas Island": 
     {
         "code": "cx",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Christmas"
@@ -704,7 +658,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Cocos"
@@ -718,7 +671,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Colombian Peso",
         "currency_symbol": "$",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "America/Bogota"
@@ -733,7 +685,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Comoro Franc",
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Comoro"
@@ -743,7 +694,6 @@
     "Congo": 
     {
         "code": "cg",
-        "number_format": "#,###.##",
         "currency": "XAF",
         "currency_name": "Central African CFA Franc",
         "currency_symbol": "FCFA",
@@ -754,7 +704,6 @@
     "Congo, The Democratic Republic of the": 
     {
         "code": "cd",
-        "number_format": "#,###.##",
         "locale": "fr-CD"
     },
     "Cook Islands": 
@@ -763,7 +712,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Rarotonga"
@@ -777,7 +725,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Costa Rican Colon",
         "currency_symbol": "₡",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "America/Costa_Rica"
@@ -794,7 +741,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Croatian Kuna",
         "currency_symbol": "kn",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Europe/Zagreb"
@@ -809,7 +755,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Cuban Peso",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Havana"
@@ -820,8 +765,7 @@
         "code": "cw",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "ƒ",
-        "number_format": "#,###.##"
+        "currency_symbol": "ƒ"
     },
     "Cyprus": 
     {
@@ -831,7 +775,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Cyprus Pound",
         "currency_symbol": "€",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Asia/Nicosia"
@@ -846,7 +789,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Czech Koruna",
         "currency_symbol": "Kč",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Europe/Prague"
@@ -861,7 +803,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Danish Krone",
         "currency_symbol": "kr",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Europe/Copenhagen"
@@ -876,7 +817,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Djibouti Franc",
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Djibouti"
@@ -891,7 +831,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Dominica"
@@ -905,7 +844,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Dominican Peso",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Santo_Domingo"
@@ -918,7 +856,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Guayaquil",
@@ -934,7 +871,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Egyptian Pound",
         "currency_symbol": "£ or ج.م",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Cairo"
@@ -951,7 +887,6 @@
         "currency_fraction_units": 100,
         "currency_name": "El Salvador Colon",
         "currency_symbol": "₡",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/El_Salvador"
@@ -966,7 +901,6 @@
         "currency_symbol": "FCFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Malabo"
@@ -981,7 +915,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Nakfa",
         "currency_symbol": "Nfk",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Asmara"
@@ -996,7 +929,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Kroon",
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Tallinn"
@@ -1010,7 +942,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Ethiopian Birr",
         "currency_symbol": "Br",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Addis_Ababa"
@@ -1021,8 +952,7 @@
     {
         "code": "fk",
         "currency": "FKP",
-        "currency_name": "Falkland Islands Pound",
-        "number_format": "#,###.##"
+        "currency_name": "Falkland Islands Pound"
     },
     "Faroe Islands": 
     {
@@ -1030,7 +960,6 @@
         "currency_fraction": "Øre",
         "currency_fraction_units": 100,
         "currency_symbol": "kr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Atlantic/Faroe"
@@ -1045,7 +974,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Fiji Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Fiji"
@@ -1058,7 +986,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Helsinki"
@@ -1072,7 +999,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "# ###,##",
         "date_format": "dd/MM/yyyy",
         "timezones": 
         [
@@ -1083,7 +1009,6 @@
     "French Guiana": 
     {
         "code": "gf",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Cayenne"
@@ -1095,7 +1020,6 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Gambier",
@@ -1105,8 +1029,7 @@
     },
     "French Southern Territories": 
     {
-        "code": "tf",
-        "number_format": "#,###.##"
+        "code": "tf"
     },
     "Gabon": 
     {
@@ -1116,7 +1039,6 @@
         "currency_symbol": "FCFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Libreville"
@@ -1128,7 +1050,6 @@
         "code": "gm",
         "currency": "GMD",
         "currency_name": "Dalasi",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Banjul"
@@ -1140,7 +1061,6 @@
         "currency_fraction": "Tetri",
         "currency_fraction_units": 100,
         "currency_symbol": "ლ",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Tbilisi"
@@ -1154,7 +1074,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Berlin"
@@ -1168,7 +1087,6 @@
         "currency_fraction": "Pesewa",
         "currency_fraction_units": 100,
         "currency_symbol": "₵",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Accra"
@@ -1183,7 +1101,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Gibraltar Pound",
         "currency_symbol": "£",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Gibraltar"
@@ -1196,7 +1113,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Athens"
@@ -1206,7 +1122,6 @@
     "Greenland": 
     {
         "code": "gl",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Danmarkshavn",
@@ -1224,7 +1139,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Grenada"
@@ -1233,7 +1147,6 @@
     "Guadeloupe": 
     {
         "code": "gp",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Guadeloupe"
@@ -1243,7 +1156,6 @@
     "Guam": 
     {
         "code": "gu",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Guam"
@@ -1258,7 +1170,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Quetzal",
         "currency_symbol": "Q",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Guatemala"
@@ -1271,7 +1182,6 @@
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
         "currency_symbol": "£",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/London"
@@ -1285,7 +1195,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Guinea Franc",
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Conakry"
@@ -1300,7 +1209,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Bissau"
@@ -1315,7 +1223,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Guyana Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Guyana"
@@ -1329,7 +1236,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Gourde",
         "currency_symbol": "G",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Guatemala",
@@ -1338,13 +1244,11 @@
     },
     "Heard Island and McDonald Islands": 
     {
-        "code": "hm",
-        "number_format": "#,###.##"
+        "code": "hm"
     },
     "Holy See (Vatican City State)": 
     {
-        "code": "va",
-        "number_format": "#,###.##"
+        "code": "va"
     },
     "Honduras": 
     {
@@ -1354,7 +1258,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Lempira",
         "currency_symbol": "L",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Tegucigalpa"
@@ -1369,7 +1272,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Hong Kong Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Hong_Kong"
@@ -1387,7 +1289,6 @@
         "currency_name": "Forint",
         "currency_symbol": "Ft",
         "date_format": "yyyy-MM-dd",
-        "number_format": "#.###",
         "timezones": 
         [
             "Europe/Budapest"
@@ -1402,7 +1303,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Iceland Krona",
         "currency_symbol": "kr",
-        "number_format": "#.###",
         "timezones": 
         [
             "Atlantic/Reykjavik"
@@ -1418,7 +1318,6 @@
         "currency_name": "Indian Rupee",
         "currency_symbol": "₹",
         "date_format": "dd/MM/yyyy",
-        "number_format": "#,##,###.##",
         "timezones": 
         [
             "Asia/Kolkata"
@@ -1435,7 +1334,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Rupiah",
         "currency_symbol": "Rp",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Asia/Jakarta",
@@ -1451,7 +1349,6 @@
         "currency": "IRR",
         "currency_name": "Iranian Rial",
         "currency_symbol": "﷼",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Tehran"
@@ -1468,7 +1365,6 @@
         "currency_fraction_units": 1000,
         "currency_name": "Iraqi Dinar",
         "currency_symbol": "ع.د",
-        "number_format": "#,###.###",
         "timezones": 
         [
             "Asia/Baghdad"
@@ -1482,7 +1378,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Dublin"
@@ -1495,7 +1390,6 @@
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
         "currency_symbol": "£",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/London"
@@ -1509,7 +1403,6 @@
         "currency_fraction_units": 100,
         "currency_name": "New Israeli Sheqel",
         "currency_symbol": "₪",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Jerusalem"
@@ -1523,7 +1416,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#.###,##",
         "date_format": "dd/MM/yyyy",
         "timezones": 
         [
@@ -1541,7 +1433,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timeszones": 
         [
             "Africa/Abidjan"
@@ -1556,7 +1447,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Jamaican Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Jamaica"
@@ -1571,7 +1461,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Yen",
         "currency_symbol": "¥",
-        "number_format": "#,###",
         "timezones": 
         [
             "Asia/Tokyo"
@@ -1584,7 +1473,6 @@
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
         "currency_symbol": "£",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/London"
@@ -1598,7 +1486,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Jordanian Dinar",
         "currency_symbol": "د.ا",
-        "number_format": "#,###.###",
         "timezones": 
         [
             "Asia/Amman"
@@ -1613,7 +1500,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Tenge",
         "currency_symbol": "₸",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Almaty",
@@ -1631,7 +1517,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Kenyan Shilling",
         "currency_symbol": "Sh",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Nairobi"
@@ -1644,7 +1529,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Enderbury",
@@ -1656,15 +1540,13 @@
     {
         "code": "kp",
         "currency": "KPW",
-        "currency_name": "North Korean Won",
-        "number_format": "#,###.##"
+        "currency_name": "North Korean Won"
     },
     "Korea, Republic of": 
     {
         "code": "kr",
         "currency": "KRW",
         "currency_name": "Won",
-        "number_format": "#,###",
         "locale": "ko-KR"
     },
     "Kuwait": 
@@ -1675,7 +1557,6 @@
         "currency_fraction_units": 1000,
         "currency_name": "Kuwaiti Dinar",
         "currency_symbol": "د.ك",
-        "number_format": "#,###.###",
         "timezones": 
         [
             "Asia/Kuwait"
@@ -1690,7 +1571,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Som",
         "currency_symbol": "лв",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Bishkek"
@@ -1700,8 +1580,7 @@
     {
         "code": "la",
         "currency": "LAK",
-        "currency_name": "Kip",
-        "number_format": "#,###.##"
+        "currency_name": "Kip"
     },
     "Latvia": 
     {
@@ -1711,7 +1590,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Latvian Lats",
         "currency_symbol": "Ls",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Riga"
@@ -1726,7 +1604,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Lebanese Pound",
         "currency_symbol": "ل.ل",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Beirut"
@@ -1741,7 +1618,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Loti",
         "currency_symbol": "L",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Maseru"
@@ -1755,7 +1631,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Liberian Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Monrovia"
@@ -1769,7 +1644,6 @@
         "currency_fraction_units": 1000,
         "currency_name": "Libyan Dinar",
         "currency_symbol": "ل.د",
-        "number_format": "#,###.###",
         "timezones": 
         [
             "Africa/Tripoli"
@@ -1782,7 +1656,6 @@
         "currency_fraction": "Rappen",
         "currency_fraction_units": 100,
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Vaduz"
@@ -1797,7 +1670,6 @@
         "currency_fraction_units": 100,
         "currency_symbol": "€",
         "date_format": "yyyy-MM-dd",
-        "number_format": "# ###,##",
         "timezones": 
         [
             "Europe/Vilnius"
@@ -1811,7 +1683,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Luxembourg"
@@ -1822,8 +1693,7 @@
     {
         "code": "mo",
         "currency": "MOP",
-        "currency_name": "Pataca",
-        "number_format": "#,###.##"
+        "currency_name": "Pataca"
     },
     "Macedonia": 
     {
@@ -1833,7 +1703,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Denar",
         "currency_symbol": "ден",
-        "number_format": "#,###.##",
         "locale": "mk-MK"
     },
     "Madagascar": 
@@ -1842,7 +1711,6 @@
         "currency_fraction": "Iraimbilanja",
         "currency_fraction_units": 5,
         "currency_symbol": "Ar",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Antananarivo"
@@ -1857,7 +1725,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Kwacha",
         "currency_symbol": "MK",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Blantyre"
@@ -1871,7 +1738,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Malaysian Ringgit",
         "currency_symbol": "RM",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Kuala_Lumpur",
@@ -1887,7 +1753,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Rufiyaa",
         "currency_symbol": ".ރ",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Maldives"
@@ -1901,7 +1766,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Bamako"
@@ -1916,7 +1780,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Maltese Lira",
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Malta"
@@ -1929,7 +1792,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Kwajalein",
@@ -1940,7 +1802,6 @@
     "Martinique": 
     {
         "code": "mq",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Martinique"
@@ -1955,7 +1816,6 @@
         "currency_fraction_units": 5,
         "currency_name": "Ouguiya",
         "currency_symbol": "UM",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Nouakchott"
@@ -1969,7 +1829,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Mauritius Rupee",
         "currency_symbol": "₨",
-        "number_format": "#,###",
         "timezones": 
         [
             "Indian/Mauritius"
@@ -1979,7 +1838,6 @@
     "Mayotte": 
     {
         "code": "yt",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Mayotte"
@@ -1993,7 +1851,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Mexican Peso",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Bahia_Banderas",
@@ -2013,15 +1870,13 @@
     },
     "Micronesia, Federated States of": 
     {
-        "code": "fm",
-        "number_format": "#,###.##"
+        "code": "fm"
     },
     "Moldova, Republic of": 
     {
         "code": "md",
         "currency": "MDL",
         "currency_name": "Moldovan Leu",
-        "number_format": "#,###.##",
         "locale": "ro-MD"
     },
     "Monaco": 
@@ -2031,7 +1886,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Monaco"
@@ -2047,7 +1901,6 @@
         "currency_name": "Tugrik",
         "currency_symbol": "₮",
         "date_format": "yyyy-MM-dd",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Choibalsan",
@@ -2062,7 +1915,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Belgrade"
@@ -2076,7 +1928,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Montserrat"
@@ -2090,7 +1941,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Moroccan Dirham",
         "currency_symbol": "د.م.",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Casablanca"
@@ -2103,7 +1953,6 @@
         "currency_fraction": "Centavo",
         "currency_fraction_units": 100,
         "currency_symbol": "MT",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Maputo"
@@ -2115,7 +1964,6 @@
         "code": "mm",
         "currency": "MMK",
         "currency_name": "Kyat",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Rangoon"
@@ -2132,7 +1980,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Namibia Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Windhoek"
@@ -2145,7 +1992,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Nauru"
@@ -2159,7 +2005,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Nepalese Rupee",
         "currency_symbol": "₨",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Kathmandu"
@@ -2173,7 +2018,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Amsterdam"
@@ -2186,7 +2030,6 @@
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Noumea"
@@ -2200,7 +2043,6 @@
         "currency_fraction_units": 100,
         "currency_name": "New Zealand Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Auckland",
@@ -2218,7 +2060,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Cordoba Oro",
         "currency_symbol": "C$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Managua"
@@ -2233,7 +2074,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Niamey"
@@ -2248,7 +2088,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Naira",
         "currency_symbol": "₦",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Lagos"
@@ -2261,7 +2100,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Niue"
@@ -2270,7 +2108,6 @@
     "Norfolk Island": 
     {
         "code": "nf",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Norfolk"
@@ -2279,7 +2116,6 @@
     "Northern Mariana Islands": 
     {
         "code": "mp",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Saipan"
@@ -2294,7 +2130,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Norwegian Krone",
         "currency_symbol": "kr",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Europe/Oslo"
@@ -2309,7 +2144,6 @@
         "currency_fraction_units": 1000,
         "currency_name": "Rial Omani",
         "currency_symbol": "ر.ع.",
-        "number_format": "#,###.###",
         "timezones": 
         [
             "Asia/Muscat"
@@ -2324,7 +2158,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Pakistan Rupee",
         "currency_symbol": "₨",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Karachi"
@@ -2340,7 +2173,6 @@
         "currency_fraction_units": 100,
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Palau"
@@ -2348,8 +2180,7 @@
     },
     "Palestinian Territory, Occupied": 
     {
-        "code": "ps",
-        "number_format": "#,###.##"
+        "code": "ps"
     },
     "Panama": 
     {
@@ -2357,7 +2188,6 @@
         "currency_fraction": "Centésimo",
         "currency_fraction_units": 100,
         "currency_symbol": "B/.",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Panama"
@@ -2372,7 +2202,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Kina",
         "currency_symbol": "K",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Port_Moresby"
@@ -2386,7 +2215,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Guarani",
         "currency_symbol": "₲",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Asuncion"
@@ -2401,7 +2229,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Nuevo Sol",
         "currency_symbol": "S/.",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Lima"
@@ -2417,7 +2244,6 @@
         "currency_name": "Philippine Peso",
         "currency_symbol": "₱",
         "date_format": "MM-dd-yyyy",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Manila"
@@ -2427,7 +2253,6 @@
     "Pitcairn": 
     {
         "code": "pn",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Pitcairn"
@@ -2440,7 +2265,6 @@
         "currency_fraction": "Grosz",
         "currency_fraction_units": 100,
         "currency_symbol": "zł",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Europe/Warsaw"
@@ -2454,7 +2278,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Atlantic/Azores",
@@ -2466,7 +2289,6 @@
     "Puerto Rico": 
     {
         "code": "pr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Puerto_Rico"
@@ -2481,7 +2303,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Qatari Rial",
         "currency_symbol": "ر.ق",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Qatar"
@@ -2496,7 +2317,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Romanian New Leu",
         "currency_symbol": "lei",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Bucharest"
@@ -2508,7 +2328,6 @@
         "code": "ru",
         "currency": "RUB",
         "currency_name": "Russian Ruble",
-        "number_format": "#.###,##",
         "locale": "ru-RU"
     },
     "Rwanda": 
@@ -2519,7 +2338,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Rwanda Franc",
         "currency_symbol": "Fr",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Kigali"
@@ -2529,21 +2347,18 @@
     "Réunion": 
     {
         "code": "re",
-        "number_format": "#,###.##",
         "locale": "fr-RE"
     },
     "Saint Barthélemy": 
     {
         "code": "bl",
-        "number_format": "#,###.##",
         "locale": "fr-BL"
     },
     "Saint Helena, Ascension and Tristan da Cunha": 
     {
         "code": "sh",
         "currency": "SHP",
-        "currency_name": "Saint Helena Pound",
-        "number_format": "#,###.##"
+        "currency_name": "Saint Helena Pound"
     },
     "Saint Kitts and Nevis": 
     {
@@ -2553,7 +2368,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/St_Kitts"
@@ -2567,7 +2381,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/St_Lucia"
@@ -2576,13 +2389,11 @@
     "Saint Martin (French part)": 
     {
         "code": "mf",
-        "number_format": "#,###.##",
         "locale": "fr-MF"
     },
     "Saint Pierre and Miquelon": 
     {
-        "code": "pm",
-        "number_format": "#,###.##"
+        "code": "pm"
     },
     "Saint Vincent and the Grenadines": 
     {
@@ -2592,7 +2403,6 @@
         "currency_symbol": "$",
         "currency_name": "Eastern Carribean Dollar",
         "currency": "XCD",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/St_Vincent"
@@ -2606,7 +2416,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Tala",
         "currency_symbol": "T",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Apia"
@@ -2619,7 +2428,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Rome"
@@ -2629,8 +2437,7 @@
     {
         "code": "st",
         "currency": "STD",
-        "currency_name": "Dobra",
-        "number_format": "#,###.##"
+        "currency_name": "Dobra"
     },
     "Saudi Arabia": 
     {
@@ -2640,7 +2447,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Saudi Riyal",
         "currency_symbol": "ر.س",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Riyadh"
@@ -2655,7 +2461,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Dakar"
@@ -2670,7 +2475,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Serbian Dinar",
         "currency_symbol": "дин.",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Belgrade"
@@ -2684,7 +2488,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Seychelles Rupee",
         "currency_symbol": "₨",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Indian/Mahe"
@@ -2698,7 +2501,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Leone",
         "currency_symbol": "Le",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Freetown"
@@ -2712,7 +2514,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Singapore Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Singapore"
@@ -2723,8 +2524,7 @@
     },
     "Sint Maarten (Dutch part)": 
     {
-        "code": "sx",
-        "number_format": "#,###.##"
+        "code": "sx"
     },
     "Slovakia": 
     {
@@ -2733,7 +2533,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Bratislava"
@@ -2747,7 +2546,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Belgrade"
@@ -2762,7 +2560,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Solomon Islands Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Guadalcanal"
@@ -2776,7 +2573,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Somali Shilling",
         "currency_symbol": "Sh",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Mogadishu"
@@ -2792,7 +2588,6 @@
         "currency_name": "Rand",
         "currency_symbol": "R",
         "date_format": "yyyy-MM-dd",
-        "number_format": "# ###.##",
         "timezones": 
         [
             "Africa/Johannesburg"
@@ -2806,8 +2601,7 @@
         "code": "gs",
         "currency_fraction": "Penny",
         "currency_fraction_units": 100,
-        "currency_symbol": "£",
-        "number_format": "#,###.##"
+        "currency_symbol": "£"
     },
     "South Sudan": 
     {
@@ -2815,7 +2609,6 @@
         "currency_fraction": "Piastre",
         "currency_fraction_units": 100,
         "currency_symbol": "£",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Juba"
@@ -2828,7 +2621,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "€",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Ceuta",
@@ -2845,7 +2637,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Sri Lanka Rupee",
         "currency_symbol": "Rs",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Colombo"
@@ -2858,7 +2649,6 @@
         "currency_fraction": "Piastre",
         "currency_fraction_units": 100,
         "currency_symbol": "£",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Khartoum"
@@ -2871,7 +2661,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Paramaribo"
@@ -2879,8 +2668,7 @@
     },
     "Svalbard and Jan Mayen": 
     {
-        "code": "sj",
-        "number_format": "#,###.##"
+        "code": "sj"
     },
     "Swaziland": 
     {
@@ -2890,7 +2678,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Lilangeni",
         "currency_symbol": "L",
-        "number_format": "#, ###.##",
         "timezones": 
         [
             "Africa/Mbabane"
@@ -2904,7 +2691,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Swedish Krona",
         "currency_symbol": "kr",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "Europe/Stockholm"
@@ -2920,7 +2706,6 @@
         "smallest_currency_fraction_value": 0.05,
         "currency_name": "Swiss Franc",
         "currency_symbol": "Fr",
-        "number_format": "#'###.##",
         "timezones": 
         [
             "Europe/Zurich"
@@ -2932,15 +2717,13 @@
         "code": "sy",
         "currency": "SYP",
         "currency_name": "Syrian Pound",
-        "number_format": "#,###.##",
         "locale": "ar-SY"
     },
     "Taiwan": 
     {
         "code": "tw",
         "currency": "TWD",
-        "date_format": "yyyy-MM-dd",
-        "number_format": "#,###.##"
+        "date_format": "yyyy-MM-dd"
     },
     "Tajikistan": 
     {
@@ -2948,7 +2731,6 @@
         "currency_fraction": "Diram",
         "currency_fraction_units": 100,
         "currency_symbol": "ЅМ",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Dushanbe"
@@ -2959,7 +2741,6 @@
         "code": "tz",
         "currency": "TZS",
         "currency_name": "Tanzanian Shilling",
-        "number_format": "#,###.##",
         "locale": "asa-TZ"
     },
     "Thailand": 
@@ -2970,7 +2751,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Baht",
         "currency_symbol": "฿",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Bangkok"
@@ -2981,8 +2761,7 @@
     },
     "Timor-Leste": 
     {
-        "code": "tl",
-        "number_format": "#,###.##"
+        "code": "tl"
     },
     "Togo": 
     {
@@ -2992,7 +2771,6 @@
         "currency_symbol": "CFA",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Lome"
@@ -3002,7 +2780,6 @@
     "Tokelau": 
     {
         "code": "tk",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Fakaofo"
@@ -3016,7 +2793,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Pa'anga",
         "currency_symbol": "T$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Tongatapu"
@@ -3031,7 +2807,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Trinidad and Tobago Dollar",
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Port_of_Spain"
@@ -3046,7 +2821,6 @@
         "currency_fraction_units": 1000,
         "currency_name": "Tunisian Dinar",
         "currency_symbol": "د.ت",
-        "number_format": "#,###.###",
         "timezones": 
         [
             "Africa/Tunis"
@@ -3060,7 +2834,6 @@
         "currency_fraction": "Kuruş",
         "currency_fraction_units": 100,
         "currency_symbol": "₺",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Istanbul"
@@ -3075,7 +2848,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Manat",
         "currency_symbol": "m",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Ashgabat"
@@ -3086,8 +2858,7 @@
         "code": "tc",
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
-        "currency_symbol": "$",
-        "number_format": "#,###.##"
+        "currency_symbol": "$"
     },
     "Tuvalu": 
     {
@@ -3095,7 +2866,6 @@
         "currency_fraction": "Cent",
         "currency_fraction_units": 100,
         "currency_symbol": "$",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Pacific/Funafuti"
@@ -3109,7 +2879,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Uganda Shilling",
         "currency_symbol": "Sh",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Kampala"
@@ -3124,7 +2893,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Ukrainian Hryvnia",
         "currency_symbol": "₴",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/Kiev",
@@ -3142,7 +2910,6 @@
         "currency_fraction_units": 100,
         "currency_name": "UAE Dirham",
         "currency_symbol": "د.إ",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Dubai"
@@ -3157,7 +2924,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Pound Sterling",
         "currency_symbol": "£",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Europe/London"
@@ -3176,7 +2942,6 @@
         "currency_name": "US Dollar",
         "currency_symbol": "$",
         "date_format": "MM-dd-yyyy",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "America/Adak",
@@ -3215,7 +2980,6 @@
     "United States Minor Outlying Islands": 
     {
         "code": "um",
-        "number_format": "#,###.##",
         "locale": "en-UM"
     },
     "Uruguay": 
@@ -3226,7 +2990,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Peso Uruguayo",
         "currency_symbol": "$",
-        "number_format": "#.###,##",
         "timezones": 
         [
             "America/Montevideo"
@@ -3241,7 +3004,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Uzbekistan Sum",
         "currency_symbol": "лв",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Samarkand",
@@ -3256,7 +3018,6 @@
         "currency_fraction_units": 0,
         "currency_name": "Vatu",
         "currency_symbol": "Vt",
-        "number_format": "#,###",
         "timezones": 
         [
             "Pacific/Efate"
@@ -3265,7 +3026,6 @@
     "Venezuela, Bolivarian Republic of": 
     {
         "code": "ve",
-        "number_format": "#.###,##",
         "currency": "VEF",
         "currency_symbol": "Bs.",
         "currency_fraction": "Centimos",
@@ -3277,18 +3037,15 @@
         "code": "vn",
         "currency": "VND",
         "currency_name": "Dong",
-        "number_format": "#.###",
         "locale": "vi-VN"
     },
     "Virgin Islands, British": 
     {
-        "code": "vg",
-        "number_format": "#,###.##"
+        "code": "vg"
     },
     "Virgin Islands, U.S.": 
     {
         "code": "vi",
-        "number_format": "#,###.##",
         "locale": "en-VI"
     },
     "Wallis and Futuna": 
@@ -3296,13 +3053,11 @@
         "code": "wf",
         "currency_fraction": "Centime",
         "currency_fraction_units": 100,
-        "currency_symbol": "Fr",
-        "number_format": "#,###.##"
+        "currency_symbol": "Fr"
     },
     "Western Sahara": 
     {
         "code": "eh",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/El_Aaiun"
@@ -3314,7 +3069,6 @@
         "currency_fraction": "Fils",
         "currency_fraction_units": 100,
         "currency_symbol": "﷼",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Asia/Aden"
@@ -3329,7 +3083,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Zambian Kwacha",
         "currency_symbol": "ZK",
-        "number_format": "#,###.##",
         "timezones": 
         [
             "Africa/Lusaka"
@@ -3344,7 +3097,6 @@
         "currency_fraction_units": 100,
         "currency_name": "Zimbabwe Dollar",
         "currency_symbol": "P",
-        "number_format": "# ###.##",
         "timezones": 
         [
             "Africa/Harare"
@@ -3353,7 +3105,6 @@
     },
     "Åland Islands": 
     {
-        "code": "ax",
-        "number_format": "#,###.##"
+        "code": "ax"
     }
 }

--- a/models/doctype/Account/Account.js
+++ b/models/doctype/Account/Account.js
@@ -68,7 +68,6 @@ export default {
       fieldname: 'balance',
       label: 'Balance',
       fieldtype: 'Currency',
-      default: '0',
       readOnly: 1,
     },
     {

--- a/models/doctype/Currency/Currency.js
+++ b/models/doctype/Currency/Currency.js
@@ -32,23 +32,5 @@ export default {
       fieldname: 'symbol',
       fieldtype: 'Data',
     },
-    {
-      fieldname: 'numberFormat',
-      fieldtype: 'Select',
-      label: 'Number Format',
-      placeholder: 'Number Format',
-      options: [
-        '#,###.##',
-        '#.###,##',
-        '# ###.##',
-        '# ###,##',
-        "#'###.##",
-        '#, ###.##',
-        '#,##,###.##',
-        '#,###.###',
-        '#.###',
-        '#,###',
-      ],
-    },
   ],
 };

--- a/models/doctype/Item/Item.js
+++ b/models/doctype/Item/Item.js
@@ -104,9 +104,8 @@ export default {
       fieldname: 'rate',
       label: 'Rate',
       fieldtype: 'Currency',
-      placeholder: '0.00',
       validate(value) {
-        if (!value) {
+        if (value.lte(0)) {
           throw new frappe.errors.ValidationError(
             'Rate must be greater than 0'
           );

--- a/models/doctype/JournalEntry/JournalEntryServer.js
+++ b/models/doctype/JournalEntry/JournalEntryServer.js
@@ -6,9 +6,9 @@ export default class JournalEntryServer extends BaseDocument {
     let entries = new LedgerPosting({ reference: this });
 
     for (let row of this.accounts) {
-      if (row.debit) {
+      if (!row.debit.isZero()) {
         entries.debit(row.account, row.debit);
-      } else if (row.credit) {
+      } else if (!row.credit.isZero()) {
         entries.credit(row.account, row.credit);
       }
     }
@@ -31,4 +31,4 @@ export default class JournalEntryServer extends BaseDocument {
   async afterRevert() {
     await this.getPosting().postReverse();
   }
-};
+}

--- a/models/doctype/JournalEntryAccount/JournalEntryAccount.js
+++ b/models/doctype/JournalEntryAccount/JournalEntryAccount.js
@@ -10,34 +10,35 @@ export default {
       target: 'Account',
       required: 1,
       groupBy: 'rootType',
-      getFilters: () => ({ isGroup: 0 })
+      getFilters: () => ({ isGroup: 0 }),
     },
     {
       fieldname: 'debit',
       label: 'Debit',
       fieldtype: 'Currency',
-      formula: autoDebitCredit('debit')
+      formula: autoDebitCredit('debit'),
     },
     {
       fieldname: 'credit',
       label: 'Credit',
       fieldtype: 'Currency',
-      formula: autoDebitCredit('credit')
-    }
+      formula: autoDebitCredit('credit'),
+    },
   ],
-  tableFields: ['account', 'debit', 'credit']
+  tableFields: ['account', 'debit', 'credit'],
 };
 
-function autoDebitCredit(type = 'debit') {
+function autoDebitCredit(type) {
   let otherType = type === 'debit' ? 'credit' : 'debit';
-  return (row, doc) => {
-    if (row[type] == 0) return null;
-    if (row[otherType]) return null;
 
-    let totalType = doc.getSum('accounts', type);
-    let totalOtherType = doc.getSum('accounts', otherType);
-    if (totalType < totalOtherType) {
-      return totalOtherType - totalType;
+  return (row, doc) => {
+    if (!row[otherType].isZero()) return frappe.pesa(0);
+
+    let totalType = doc.getSum('accounts', type, false);
+    let totalOtherType = doc.getSum('accounts', otherType, false);
+
+    if (totalType.lt(totalOtherType)) {
+      return totalOtherType.sub(totalType);
     }
   };
 }

--- a/models/doctype/Payment/Payment.js
+++ b/models/doctype/Payment/Payment.js
@@ -113,9 +113,7 @@ export default {
       validate(value, doc) {
         if (value.isNegative()) {
           throw new frappe.errors.ValidationError(
-            frappe._(
-              `Payment amount cannot be less than zero. Amount has been reset.`
-            )
+            frappe._(`Payment amount cannot be less than zero.`)
           );
         }
 
@@ -128,16 +126,13 @@ export default {
               `Payment amount cannot exceed ${frappe.format(
                 amount,
                 'Currency'
-              )}. Amount has been reset.`
+              )}.`
             )
           );
         } else if (value.isZero()) {
           throw new frappe.errors.ValidationError(
             frappe._(
-              `Payment amount cannot be ${frappe.format(
-                value,
-                'Currency'
-              )}. Amount has been reset.`
+              `Payment amount cannot be ${frappe.format(value, 'Currency')}.`
             )
           );
         }

--- a/models/doctype/Payment/Payment.js
+++ b/models/doctype/Payment/Payment.js
@@ -109,9 +109,9 @@ export default {
       label: 'Amount',
       fieldtype: 'Currency',
       required: 1,
-      formula: (doc) => doc.getSum('for', 'amount'),
+      formula: (doc) => doc.getSum('for', 'amount', false),
       validate(value, doc) {
-        if (value < 0) {
+        if (value.isNegative()) {
           throw new frappe.errors.ValidationError(
             frappe._(
               `Payment amount cannot be less than zero. Amount has been reset.`
@@ -120,9 +120,9 @@ export default {
         }
 
         if (doc.for.length === 0) return;
-        const amount = doc.getSum('for', 'amount');
+        const amount = doc.getSum('for', 'amount', false);
 
-        if (value > amount) {
+        if (value.gt(amount)) {
           throw new frappe.errors.ValidationError(
             frappe._(
               `Payment amount cannot exceed ${frappe.format(
@@ -131,7 +131,7 @@ export default {
               )}. Amount has been reset.`
             )
           );
-        } else if (value === 0) {
+        } else if (value.isZero()) {
           throw new frappe.errors.ValidationError(
             frappe._(
               `Payment amount cannot be ${frappe.format(
@@ -147,7 +147,6 @@ export default {
       fieldname: 'writeoff',
       label: 'Write Off / Refund',
       fieldtype: 'Currency',
-      default: 0,
     },
     {
       fieldname: 'for',

--- a/models/doctype/Payment/PaymentServer.js
+++ b/models/doctype/Payment/PaymentServer.js
@@ -126,10 +126,10 @@ export default class PaymentServer extends BaseDocument {
         );
 
         if (this.amount.lte(0)) {
-          const amt = this.amount.lt(0)
-            ? `: ${frappe.format(this.amount, 'Currency')}`
-            : '';
-          message = frappe._(`Payment amount${amt} should be greater than 0.`);
+          const amt = frappe.format(this.amount, 'Currency');
+          message = frappe._(
+            `Payment amount: ${amt} should be greater than 0.`
+          );
         }
 
         throw new frappe.errors.ValidationError(message);

--- a/models/doctype/PaymentFor/PaymentFor.js
+++ b/models/doctype/PaymentFor/PaymentFor.js
@@ -1,4 +1,6 @@
+import frappe from 'frappejs';
 import { _ } from 'frappejs/utils';
+
 const referenceTypeMap = {
   SalesInvoice: _('Invoice'),
   PurchaseInvoice: _('Bill'),
@@ -38,12 +40,13 @@ export default {
       fieldname: 'amount',
       label: 'Amount',
       fieldtype: 'Currency',
-      placeholder: '0.00',
       formula: (row, doc) => {
-        return doc.getFrom(
-          row.referenceType,
-          row.referenceName,
-          'outstandingAmount'
+        return (
+          doc.getFrom(
+            row.referenceType,
+            row.referenceName,
+            'outstandingAmount'
+          ) || frappe.pesa(0)
         );
       },
       required: 1,

--- a/models/doctype/PurchaseInvoice/PurchaseInvoice.js
+++ b/models/doctype/PurchaseInvoice/PurchaseInvoice.js
@@ -54,7 +54,9 @@ export default {
       fieldtype: 'Link',
       target: 'Currency',
       hidden: 1,
-      formula: (doc) => doc.getFrom('Party', doc.supplier, 'currency'),
+      formula: (doc) =>
+        doc.getFrom('Party', doc.supplier, 'currency') ||
+        frappe.AccountingSettings.currency,
       formulaDependsOn: ['supplier'],
     },
     {

--- a/models/doctype/PurchaseInvoice/PurchaseInvoice.js
+++ b/models/doctype/PurchaseInvoice/PurchaseInvoice.js
@@ -1,5 +1,5 @@
-import { getActions } from '../Transaction/Transaction';
 import InvoiceTemplate from '../SalesInvoice/InvoiceTemplate.vue';
+import { getActions } from '../Transaction/Transaction';
 import PurchaseInvoice from './PurchaseInvoiceDocument';
 
 export default {
@@ -61,7 +61,8 @@ export default {
       fieldname: 'exchangeRate',
       label: 'Exchange Rate',
       fieldtype: 'Float',
-      formula: (doc) => doc.getExchangeRate(),
+      default: 1,
+      formula: async (doc) => await doc.getExchangeRate(),
       required: true,
     },
     {
@@ -75,7 +76,7 @@ export default {
       fieldname: 'netTotal',
       label: 'Net Total',
       fieldtype: 'Currency',
-      formula: (doc) => doc.getSum('items', 'amount'),
+      formula: (doc) => doc.getSum('items', 'amount', false),
       readOnly: 1,
       getCurrency: (doc) => doc.currency,
     },
@@ -83,7 +84,7 @@ export default {
       fieldname: 'baseNetTotal',
       label: 'Net Total (Company Currency)',
       fieldtype: 'Currency',
-      formula: (doc) => doc.netTotal * doc.exchangeRate,
+      formula: (doc) => doc.netTotal.mul(doc.exchangeRate),
       readOnly: 1,
     },
     {
@@ -106,7 +107,7 @@ export default {
       fieldname: 'baseGrandTotal',
       label: 'Grand Total (Company Currency)',
       fieldtype: 'Currency',
-      formula: (doc) => doc.grandTotal * doc.exchangeRate,
+      formula: (doc) => doc.grandTotal.mul(doc.exchangeRate),
       readOnly: 1,
     },
     {

--- a/models/doctype/PurchaseInvoiceItem/PurchaseInvoiceItem.js
+++ b/models/doctype/PurchaseInvoiceItem/PurchaseInvoiceItem.js
@@ -32,7 +32,7 @@ export default {
       label: 'Quantity',
       fieldtype: 'Float',
       required: 1,
-      formula: () => 1,
+      default: 1,
     },
     {
       fieldname: 'rate',
@@ -40,9 +40,9 @@ export default {
       fieldtype: 'Currency',
       required: 1,
       formula: async (row, doc) => {
-        const baseRate = (await doc.getFrom('Item', row.item, 'rate')) || 0;
-        const exchangeRate = doc.exchangeRate ?? 1;
-        return baseRate / exchangeRate;
+        const baseRate =
+          (await doc.getFrom('Item', row.item, 'rate')) || frappe.pesa(0);
+        return baseRate.div(doc.exchangeRate);
       },
       getCurrency: (row, doc) => doc.currency,
     },
@@ -50,7 +50,7 @@ export default {
       fieldname: 'baseRate',
       label: 'Rate (Company Currency)',
       fieldtype: 'Currency',
-      formula: (row, doc) => row.rate * doc.exchangeRate,
+      formula: (row, doc) => row.rate.mul(doc.exchangeRate),
       readOnly: 1,
     },
     {
@@ -76,7 +76,7 @@ export default {
       label: 'Amount',
       fieldtype: 'Currency',
       readOnly: 1,
-      formula: (row) => row.quantity * row.rate,
+      formula: (row) => row.rate.mul(row.quantity),
       getCurrency: (row, doc) => doc.currency,
     },
     {
@@ -84,7 +84,7 @@ export default {
       label: 'Amount (Company Currency)',
       fieldtype: 'Currency',
       readOnly: 1,
-      formula: (row, doc) => row.amount * doc.exchangeRate,
+      formula: (row, doc) => row.amount.mul(doc.exchangeRate),
     },
   ],
 };

--- a/models/doctype/SalesInvoice/SalesInvoice.js
+++ b/models/doctype/SalesInvoice/SalesInvoice.js
@@ -53,13 +53,16 @@ export default {
       label: 'Customer Currency',
       fieldtype: 'Link',
       target: 'Currency',
-      formula: (doc) => doc.getFrom('Party', doc.customer, 'currency'),
+      formula: (doc) =>
+        doc.getFrom('Party', doc.customer, 'currency') ||
+        frappe.AccountingSettings.currency,
       formulaDependsOn: ['customer'],
     },
     {
       fieldname: 'exchangeRate',
       label: 'Exchange Rate',
       fieldtype: 'Float',
+      default: 1,
       formula: (doc) => doc.getExchangeRate(),
       readOnly: true,
     },
@@ -74,7 +77,7 @@ export default {
       fieldname: 'netTotal',
       label: 'Net Total',
       fieldtype: 'Currency',
-      formula: (doc) => doc.getSum('items', 'amount'),
+      formula: (doc) => doc.getSum('items', 'amount', false),
       readOnly: 1,
       getCurrency: (doc) => doc.currency,
     },
@@ -82,7 +85,7 @@ export default {
       fieldname: 'baseNetTotal',
       label: 'Net Total (Company Currency)',
       fieldtype: 'Currency',
-      formula: (doc) => doc.netTotal * doc.exchangeRate,
+      formula: (doc) => doc.netTotal.mul(doc.exchangeRate),
       readOnly: 1,
     },
     {
@@ -105,7 +108,7 @@ export default {
       fieldname: 'baseGrandTotal',
       label: 'Grand Total (Company Currency)',
       fieldtype: 'Currency',
-      formula: (doc) => doc.grandTotal * doc.exchangeRate,
+      formula: (doc) => doc.grandTotal.mul(doc.exchangeRate),
       readOnly: 1,
     },
     {

--- a/models/doctype/SalesInvoiceItem/SalesInvoiceItem.js
+++ b/models/doctype/SalesInvoiceItem/SalesInvoiceItem.js
@@ -35,6 +35,15 @@ export default {
       fieldtype: 'Float',
       required: 1,
       default: 1,
+      validate(value, doc) {
+        if (value >= 0) {
+          return;
+        }
+
+        throw new frappe.errors.ValidationError(
+          frappe._(`Quantity (${value}) cannot be less than zero.`)
+        );
+      },
     },
     {
       fieldname: 'rate',
@@ -48,6 +57,17 @@ export default {
       },
       getCurrency: (row, doc) => doc.currency,
       formulaDependsOn: ['item'],
+      validate(value, doc) {
+        if (value.gte(0)) {
+          return;
+        }
+
+        throw new frappe.errors.ValidationError(
+          frappe._(
+            `Rate (${frappe.format(value, 'Currency')}) cannot be less zero.`
+          )
+        );
+      },
     },
     {
       fieldname: 'baseRate',

--- a/models/doctype/SalesInvoiceItem/SalesInvoiceItem.js
+++ b/models/doctype/SalesInvoiceItem/SalesInvoiceItem.js
@@ -34,7 +34,7 @@ export default {
       label: 'Quantity',
       fieldtype: 'Float',
       required: 1,
-      formula: (row) => row.quantity || 1,
+      default: 1,
     },
     {
       fieldname: 'rate',
@@ -42,9 +42,9 @@ export default {
       fieldtype: 'Currency',
       required: 1,
       formula: async (row, doc) => {
-        const baseRate = (await doc.getFrom('Item', row.item, 'rate')) || 0;
-        const exchangeRate = doc.exchangeRate ?? 1;
-        return baseRate / exchangeRate;
+        const baseRate =
+          (await doc.getFrom('Item', row.item, 'rate')) || frappe.pesa(0);
+        return baseRate.div(doc.exchangeRate);
       },
       getCurrency: (row, doc) => doc.currency,
       formulaDependsOn: ['item'],
@@ -53,7 +53,7 @@ export default {
       fieldname: 'baseRate',
       label: 'Rate (Company Currency)',
       fieldtype: 'Currency',
-      formula: (row, doc) => row.rate * doc.exchangeRate,
+      formula: (row, doc) => row.rate.mul(doc.exchangeRate),
       readOnly: 1,
     },
     {
@@ -78,7 +78,7 @@ export default {
       label: 'Amount',
       fieldtype: 'Currency',
       readOnly: 1,
-      formula: (row) => row.quantity * row.rate,
+      formula: (row) => row.rate.mul(row.quantity),
       getCurrency: (row, doc) => doc.currency,
     },
     {
@@ -86,7 +86,7 @@ export default {
       label: 'Amount (Company Currency)',
       fieldtype: 'Currency',
       readOnly: 1,
-      formula: (row, doc) => row.amount * doc.exchangeRate,
+      formula: (row, doc) => row.amount.mul(doc.exchangeRate),
     },
   ],
 };

--- a/models/doctype/TaxSummary/TaxSummary.js
+++ b/models/doctype/TaxSummary/TaxSummary.js
@@ -8,26 +8,26 @@ export default {
       label: 'Tax Account',
       fieldtype: 'Link',
       target: 'Account',
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'rate',
       label: 'Rate',
       fieldtype: 'Float',
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'amount',
       label: 'Amount',
       fieldtype: 'Currency',
-      required: 1
+      required: 1,
     },
     {
       fieldname: 'baseAmount',
       label: 'Amount (Company Currency)',
       fieldtype: 'Currency',
-      formula: (row, doc) => row.amount * doc.exchangeRate,
-      readOnly: 1
-    }
-  ]
+      formula: (row, doc) => row.amount.mul(doc.exchangeRate),
+      readOnly: 1,
+    },
+  ],
 };

--- a/patches/0.0.4/convertCurrencyToStrings.js
+++ b/patches/0.0.4/convertCurrencyToStrings.js
@@ -31,6 +31,11 @@ export default async function execute() {
       for (let field of fields) {
         row[field] = frappe.pesa(row[field] ?? 0).store;
       }
+
+      if ('numberFormat' in row) {
+        delete row.numberFormat;
+      }
+
       return row;
     });
     await frappe.db.prestigeTheTable(name, convertedRows);

--- a/patches/0.0.4/convertCurrencyToStrings.js
+++ b/patches/0.0.4/convertCurrencyToStrings.js
@@ -29,10 +29,7 @@ export default async function execute() {
     const rows = await frappe.db.knex(name);
     const convertedRows = rows.map((row) => {
       for (let field of fields) {
-        if (row[field] === null) {
-          continue;
-        }
-        row[field] = frappe.pesa(row[field]).store;
+        row[field] = frappe.pesa(row[field] ?? 0).store;
       }
       return row;
     });

--- a/patches/0.0.4/convertCurrencyToStrings.js
+++ b/patches/0.0.4/convertCurrencyToStrings.js
@@ -1,0 +1,41 @@
+import frappe from 'frappejs';
+
+function getTablesToConvert() {
+  // Do not change loops to map, doesn't work for some reason.
+  const toConvert = [];
+  for (let key in frappe.models) {
+    const model = frappe.models[key];
+
+    const fieldsToConvert = [];
+    for (let i in model.fields) {
+      const field = model.fields[i];
+
+      if (field.fieldtype === 'Currency') {
+        fieldsToConvert.push(field.fieldname);
+      }
+    }
+
+    if (fieldsToConvert.length > 0 && !model.isSingle && !model.basedOn) {
+      toConvert.push({ name: key, fields: fieldsToConvert });
+    }
+  }
+
+  return toConvert;
+}
+
+export default async function execute() {
+  const toConvert = getTablesToConvert();
+  for (let { name, fields } of toConvert) {
+    const rows = await frappe.db.knex(name);
+    const convertedRows = rows.map((row) => {
+      for (let field of fields) {
+        if (row[field] === null) {
+          continue;
+        }
+        row[field] = frappe.pesa(row[field]).store;
+      }
+      return row;
+    });
+    await frappe.db.prestigeTheTable(name, convertedRows);
+  }
+}

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -3,5 +3,10 @@
     "version": "0.0.3",
     "fileName": "makePaymentRefIdNullable",
     "beforeMigrate": true
+  },
+  {
+    "version": "0.0.4",
+    "fileName": "convertCurrencyToStrings",
+    "beforeMigrate": true
   }
 ]

--- a/reports/FinancialStatements/FinancialStatements.js
+++ b/reports/FinancialStatements/FinancialStatements.js
@@ -1,6 +1,6 @@
 import frappe from 'frappejs';
+import { isPesa } from 'frappejs/utils';
 import { DateTime } from 'luxon';
-import { unique } from 'frappejs/utils';
 
 export async function getData({
   rootType,
@@ -8,7 +8,7 @@ export async function getData({
   fromDate,
   toDate,
   periodicity = 'Monthly',
-  accumulateValues = false
+  accumulateValues = false,
 }) {
   let accounts = await getAccounts(rootType);
   let fiscalYear = await getFiscalYear();
@@ -17,19 +17,19 @@ export async function getData({
 
   for (let account of accounts) {
     const entries = ledgerEntries.filter(
-      entry => entry.account === account.name
+      (entry) => entry.account === account.name
     );
 
     for (let entry of entries) {
       let periodKey = getPeriodKey(entry.date, periodicity);
 
       if (!account[periodKey]) {
-        account[periodKey] = 0.0;
+        account[periodKey] = frappe.pesa(0.0);
       }
 
       const multiplier = balanceMustBe === 'Debit' ? 1 : -1;
-      const value = (entry.debit - entry.credit) * multiplier;
-      account[periodKey] += value;
+      const value = entry.debit.sub(entry.credit).mul(multiplier);
+      account[periodKey] = value.add(account[periodKey]);
     }
   }
 
@@ -40,27 +40,33 @@ export async function getData({
 
       for (let account of accounts) {
         if (!account[periodKey]) {
-          account[periodKey] = 0.0;
+          account[periodKey] = frappe.pesa(0.0);
         }
-        account[periodKey] += account[previousPeriodKey] || 0.0;
+
+        account[periodKey] = account[periodKey].add(
+          account[previousPeriodKey] ?? 0
+        );
       }
     });
   }
 
   // calculate totalRow
   let totalRow = {
-    account: `Total ${rootType} (${balanceMustBe})`
+    account: `Total ${rootType} (${balanceMustBe})`,
   };
 
-  periodList.forEach(periodKey => {
+  periodList.forEach((periodKey) => {
     if (!totalRow[periodKey]) {
-      totalRow[periodKey] = 0.0;
+      totalRow[periodKey] = frappe.pesa(0.0);
     }
 
     for (let account of accounts) {
-      totalRow[periodKey] += account[periodKey] || 0.0;
+      totalRow[periodKey] = totalRow[periodKey].add(account[periodKey] ?? 0.0);
     }
   });
+
+  convertToFloat(totalRow);
+  accounts.forEach(convertToFloat);
 
   return { accounts, totalRow, periodList };
 }
@@ -71,42 +77,50 @@ export async function getTrialBalance({ rootType, fromDate, toDate }) {
 
   for (let account of accounts) {
     const accountEntries = ledgerEntries.filter(
-      entry => entry.account === account.name
+      (entry) => entry.account === account.name
     );
     // opening
     const beforePeriodEntries = accountEntries.filter(
-      entry => entry.date < fromDate
+      (entry) => entry.date < fromDate
     );
-    account.opening = beforePeriodEntries.reduce((acc, entry) => {
-      return acc + (entry.debit - entry.credit);
-    }, 0);
+    account.opening = beforePeriodEntries.reduce(
+      (acc, entry) => acc.add(entry.debit).sub(entry.credit),
+      frappe.pesa(0)
+    );
 
-    if (account.opening >= 0) {
+    if (account.opening.gte(0)) {
       account.openingDebit = account.opening;
+      account.openingCredit = frappe.pesa(0);
     } else {
-      account.openingCredit = -account.opening;
+      account.openingCredit = account.opening.neg();
+      account.openingDebit = frappe.pesa(0);
     }
 
     // debit / credit
     const periodEntries = accountEntries.filter(
-      entry => entry.date >= fromDate && entry.date < toDate
+      (entry) => entry.date >= fromDate && entry.date < toDate
     );
-    account.debit = periodEntries.reduce((acc, entry) => acc + entry.debit, 0);
+    account.debit = periodEntries.reduce(
+      (acc, entry) => acc.add(entry.debit),
+      frappe.pesa(0)
+    );
     account.credit = periodEntries.reduce(
-      (acc, entry) => acc + entry.credit,
-      0
+      (acc, entry) => acc.add(entry.credit),
+      frappe.pesa(0)
     );
 
     // closing
-    account.closing = account.opening + account.debit - account.credit;
+    account.closing = account.opening.add(account.debit).sub(account.credit);
 
-    if (account.closing >= 0) {
+    if (account.closing.gte(0)) {
       account.closingDebit = account.closing;
+      account.closingCredit = frappe.pesa(0);
     } else {
-      account.closingCredit = -account.closing;
+      account.closingCredit = account.closing.neg();
+      account.closingDebit = frappe.pesa(0);
     }
 
-    if (account.debit != 0 || account.credit != 0) {
+    if (account.debit.neq(0) || account.credit.neq(0)) {
       setParentEntry(account, account.parentAccount);
     }
   }
@@ -114,13 +128,13 @@ export async function getTrialBalance({ rootType, fromDate, toDate }) {
   function setParentEntry(leafAccount, parentName) {
     for (let acc of accounts) {
       if (acc.name === parentName) {
-        acc.debit += leafAccount.debit;
-        acc.credit += leafAccount.credit;
-        acc.closing = acc.opening + acc.debit - acc.credit;
-        if (acc.closing >= 0) {
+        acc.debit = acc.debit.add(leafAccount.debit);
+        acc.credit = acc.credit.add(leafAccount.credit);
+        acc.closing = acc.opening.add(acc.debit).sub(acc.credit);
+        if (acc.closing.gte(0)) {
           acc.closingDebit = acc.closing;
         } else {
-          acc.closingCredit = -acc.closing;
+          acc.closingCredit = acc.closing.neg();
         }
         if (acc.parentAccount) {
           setParentEntry(leafAccount, acc.parentAccount);
@@ -131,6 +145,7 @@ export async function getTrialBalance({ rootType, fromDate, toDate }) {
     }
   }
 
+  accounts.forEach(convertToFloat);
   return accounts;
 }
 
@@ -143,7 +158,7 @@ export function getPeriodList(fromDate, toDate, periodicity, fiscalYear) {
     Monthly: 1,
     Quarterly: 3,
     'Half Yearly': 6,
-    Yearly: 12
+    Yearly: 12,
   }[periodicity];
 
   let startDate = DateTime.fromISO(fromDate).startOf('month');
@@ -173,13 +188,13 @@ function getPeriodKey(date, periodicity) {
         1: `Jan ${year} - Mar ${year}`,
         2: `Apr ${year} - Jun ${year}`,
         3: `Jun ${year} - Sep ${year}`,
-        4: `Oct ${year} - Dec ${year}`
+        4: `Oct ${year} - Dec ${year}`,
       }[quarter];
     },
     'Half Yearly': () => {
       return {
         1: `Apr ${year} - Sep ${year}`,
-        2: `Oct ${year} - Mar ${year}`
+        2: `Oct ${year} - Mar ${year}`,
       }[[2, 3].includes(quarter) ? 1 : 2];
     },
     Yearly: () => {
@@ -187,7 +202,7 @@ function getPeriodKey(date, periodicity) {
         return `${year} - ${year + 1}`;
       }
       return `${year - 1} - ${year}`;
-    }
+    },
   }[periodicity];
 
   return getKey();
@@ -200,7 +215,7 @@ function setIndentLevel(accounts, parentAccount, level) {
     level = 0;
   }
 
-  accounts.forEach(account => {
+  accounts.forEach((account) => {
     if (
       account.parentAccount === parentAccount &&
       account.indent === undefined
@@ -220,7 +235,7 @@ function sortAccounts(accounts) {
   pushToOut(null);
 
   function pushToOut(parentAccount) {
-    accounts.forEach(account => {
+    accounts.forEach((account) => {
       if (account.parentAccount === parentAccount && !pushed[account.name]) {
         out.push(account);
         pushed[account.name] = 1;
@@ -247,9 +262,9 @@ async function getLedgerEntries(fromDate, toDate, accounts) {
     doctype: 'AccountingLedgerEntry',
     fields: ['account', 'debit', 'credit', 'date'],
     filters: {
-      account: ['in', accounts.map(d => d.name)],
-      date: dateFilter()
-    }
+      account: ['in', accounts.map((d) => d.name)],
+      date: dateFilter(),
+    },
   });
 
   return ledgerEntries;
@@ -260,14 +275,14 @@ async function getAccounts(rootType) {
     doctype: 'Account',
     fields: ['name', 'parentAccount', 'isGroup'],
     filters: {
-      rootType
-    }
+      rootType,
+    },
   });
 
   accounts = setIndentLevel(accounts);
   accounts = sortAccounts(accounts);
 
-  accounts.forEach(account => {
+  accounts.forEach((account) => {
     account.account = account.name;
   });
 
@@ -280,12 +295,20 @@ async function getFiscalYear() {
   );
   return {
     start: fiscalYearStart,
-    end: fiscalYearEnd
+    end: fiscalYearEnd,
   };
+}
+
+function convertToFloat(obj) {
+  Object.keys(obj).forEach((key) => {
+    if (!isPesa(obj[key])) return;
+
+    obj[key] = obj[key].float;
+  });
 }
 
 export default {
   getData,
   getTrialBalance,
-  getPeriodList
+  getPeriodList,
 };

--- a/reports/FinancialStatements/FinancialStatements.js
+++ b/reports/FinancialStatements/FinancialStatements.js
@@ -1,6 +1,6 @@
 import frappe from 'frappejs';
-import { isPesa } from 'frappejs/utils';
 import { DateTime } from 'luxon';
+import { convertPesaValuesToFloat } from '../../src/utils';
 
 export async function getData({
   rootType,
@@ -65,8 +65,8 @@ export async function getData({
     }
   });
 
-  convertToFloat(totalRow);
-  accounts.forEach(convertToFloat);
+  convertPesaValuesToFloat(totalRow);
+  accounts.forEach(convertPesaValuesToFloat);
 
   return { accounts, totalRow, periodList };
 }
@@ -145,7 +145,7 @@ export async function getTrialBalance({ rootType, fromDate, toDate }) {
     }
   }
 
-  accounts.forEach(convertToFloat);
+  accounts.forEach(convertPesaValuesToFloat);
   return accounts;
 }
 
@@ -297,14 +297,6 @@ async function getFiscalYear() {
     start: fiscalYearStart,
     end: fiscalYearEnd,
   };
-}
-
-function convertToFloat(obj) {
-  Object.keys(obj).forEach((key) => {
-    if (!isPesa(obj[key])) return;
-
-    obj[key] = obj[key].float;
-  });
 }
 
 export default {

--- a/reports/GeneralLedger/GeneralLedger.js
+++ b/reports/GeneralLedger/GeneralLedger.js
@@ -29,7 +29,14 @@ class GeneralLedger {
         ],
         filters: filters,
       })
-    ).filter((d) => !d.reverted || (d.reverted && params.reverted));
+    )
+      .filter((d) => !d.reverted || (d.reverted && params.reverted))
+      .map((row) => {
+        row.debit = row.debit.float;
+        row.credit = row.credit.float;
+
+        return row;
+      });
 
     return this.appendOpeningEntry(data);
   }

--- a/reports/GoodsAndServiceTax/BaseGSTR.js
+++ b/reports/GoodsAndServiceTax/BaseGSTR.js
@@ -1,5 +1,6 @@
 import frappe from 'frappejs';
 import { stateCodeMap } from '../../accounting/gst';
+import { convertPesaValuesToFloat } from '../../src/utils';
 
 class BaseGSTR {
   async getCompleteReport(gstrType, filters) {
@@ -30,6 +31,7 @@ class BaseGSTR {
         });
       }
 
+      tableData.forEach(convertPesaValuesToFloat);
       return tableData;
     } else {
       return [];
@@ -63,7 +65,7 @@ class BaseGSTR {
 
     ledgerEntry.taxes?.forEach((tax) => {
       row.rate += tax.rate;
-      const taxAmt = (tax.rate * ledgerEntry.netTotal) / 100;
+      const taxAmt = ledgerEntry.netTotal.percent(tax.rate);
 
       switch (tax.account) {
         case 'IGST': {

--- a/src/components/Controls/Base.vue
+++ b/src/components/Controls/Base.vue
@@ -94,33 +94,11 @@ export default {
     triggerChange(value) {
       value = this.parse(value);
 
-      const isValid = this.validate(value);
-      if (!isValid) {
-        return;
-      }
-
       if (value === '') {
         value = null;
       }
 
       this.$emit('change', value);
-    },
-    validate(value) {
-      if (!(typeof this.df.validate === 'function')) {
-        return true;
-      }
-
-      try {
-        this.df.validate(value, this.doc);
-      } catch (error) {
-        showMessageDialog({
-          message: this._('Invalid Value'),
-          description: error.message,
-        });
-        return false;
-      }
-
-      return true;
     },
     parse(value) {
       return value;

--- a/src/components/Controls/Base.vue
+++ b/src/components/Controls/Base.vue
@@ -107,7 +107,7 @@ export default {
     },
     validate(value) {
       if (!(typeof this.df.validate === 'function')) {
-        return;
+        return true;
       }
 
       try {

--- a/src/components/Controls/Base.vue
+++ b/src/components/Controls/Base.vue
@@ -131,3 +131,9 @@ export default {
   },
 };
 </script>
+
+<style>
+input[type='number']::-webkit-inner-spin-button {
+  appearance: none;
+}
+</style>

--- a/src/components/Controls/Currency.vue
+++ b/src/components/Controls/Currency.vue
@@ -13,7 +13,7 @@
       :readonly="isReadOnly"
       @blur="onBlur"
       @focus="onFocus"
-      @input="e => $emit('input', e)"
+      @input="(e) => $emit('input', e)"
     />
     <div
       v-show="!showInput"
@@ -37,13 +37,16 @@ export default {
   data() {
     return {
       showInput: false,
-      currencySymbol: ''
+      currencySymbol: '',
     };
   },
   methods: {
     onFocus(e) {
       this.showInput = true;
       this.$emit('focus', e);
+    },
+    parse(value) {
+      return frappe.pesa(value);
     },
     onBlur(e) {
       this.showInput = false;
@@ -54,12 +57,12 @@ export default {
       this.$nextTick(() => {
         this.focus();
       });
-    }
+    },
   },
   computed: {
     formattedValue() {
       return frappe.format(this.value, this.df, this.doc);
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/components/Controls/Currency.vue
+++ b/src/components/Controls/Currency.vue
@@ -50,7 +50,7 @@ export default {
     },
     onBlur(e) {
       let { value } = e.target;
-      if (value === '') {
+      if (value !== 0 && !value) {
         value = frappe.pesa(0).round();
       }
 

--- a/src/components/Controls/Currency.vue
+++ b/src/components/Controls/Currency.vue
@@ -8,7 +8,7 @@
       ref="input"
       :class="inputClasses"
       :type="inputType"
-      :value="value"
+      :value="value.round()"
       :placeholder="inputPlaceholder"
       :readonly="isReadOnly"
       @blur="onBlur"
@@ -49,8 +49,13 @@ export default {
       return frappe.pesa(value);
     },
     onBlur(e) {
+      let { value } = e.target;
+      if (value === '') {
+        value = frappe.pesa(0).round();
+      }
+
       this.showInput = false;
-      this.triggerChange(e.target.value);
+      this.triggerChange(value);
     },
     activateInput() {
       this.showInput = true;

--- a/src/components/Controls/Float.vue
+++ b/src/components/Controls/Float.vue
@@ -4,11 +4,16 @@ import Int from './Int';
 export default {
   name: 'Float',
   extends: Int,
+  computed: {
+    inputType() {
+      return 'number';
+    }
+  },
   methods: {
     parse(value) {
       let parsedValue = parseFloat(value);
       return isNaN(parsedValue) ? 0 : parsedValue;
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/components/Controls/Int.vue
+++ b/src/components/Controls/Int.vue
@@ -4,11 +4,16 @@ import Data from './Data';
 export default {
   name: 'Int',
   extends: Data,
+  computed: {
+    inputType() {
+      return 'number';
+    },
+  },
   methods: {
     parse(value) {
       let parsedValue = parseInt(value, 10);
       return isNaN(parsedValue) ? 0 : parsedValue;
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/components/TwoColumnForm.vue
+++ b/src/components/TwoColumnForm.vue
@@ -162,6 +162,7 @@ let TwoColumnForm = {
 
       let oldValue = this.doc.get(df.fieldname);
 
+      this.$set(this.errors, df.fieldname, null);
       if (oldValue === value) {
         return;
       }
@@ -170,9 +171,6 @@ let TwoColumnForm = {
       if (this.autosave && df.fieldname === 'name' && !this.doc.isNew()) {
         return this.doc.rename(value);
       }
-
-      // reset error messages
-      this.$set(this.errors, df.fieldname, null);
 
       this.doc.set(df.fieldname, value).catch((e) => {
         // set error message for this field

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -7,6 +7,7 @@ import postStart from '../server/postStart';
 import { DB_CONN_FAILURE } from './messages';
 import migrate from './migrate';
 import { getSavePath } from './utils';
+import { callInitializeMoneyMaker } from './utils';
 
 export async function createNewDatabase() {
   const { canceled, filePath } = await getSavePath('books', 'db');
@@ -48,6 +49,8 @@ export async function connectToLocalDatabase(filePath) {
     console.error(error);
     return { connectionSuccess: false, reason: DB_CONN_FAILURE.CANT_CONNECT };
   }
+
+  await callInitializeMoneyMaker();
 
   try {
     await runRegionalModelUpdates();

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -6,8 +6,7 @@ import regionalModelUpdates from '../models/regionalModelUpdates';
 import postStart from '../server/postStart';
 import { DB_CONN_FAILURE } from './messages';
 import migrate from './migrate';
-import { getSavePath } from './utils';
-import { callInitializeMoneyMaker } from './utils';
+import { callInitializeMoneyMaker, getSavePath } from './utils';
 
 export async function createNewDatabase() {
   const { canceled, filePath } = await getSavePath('books', 'db');
@@ -50,6 +49,7 @@ export async function connectToLocalDatabase(filePath) {
     return { connectionSuccess: false, reason: DB_CONN_FAILURE.CANT_CONNECT };
   }
 
+  // first init no currency, for migratory needs
   await callInitializeMoneyMaker();
 
   try {
@@ -90,6 +90,9 @@ export async function connectToLocalDatabase(filePath) {
 
   // set last selected file
   config.set('lastSelectedFilePath', filePath);
+
+  // second init with currency, normal usage
+  await callInitializeMoneyMaker();
   return { connectionSuccess: true, reason: '' };
 }
 

--- a/src/pages/Dashboard/Cashflow.vue
+++ b/src/pages/Dashboard/Cashflow.vue
@@ -143,7 +143,7 @@ export default {
           heatLine: 1,
         },
         tooltipOptions: {
-          formatTooltipY: (value) => frappe.format(value, 'Currency'),
+          formatTooltipY: (value) => frappe.format(value ?? 0, 'Currency'),
         },
         data: {
           labels: periodList.map((p) => p.split(' ')[0]),

--- a/src/pages/Dashboard/Expenses.vue
+++ b/src/pages/Dashboard/Expenses.vue
@@ -84,9 +84,10 @@ export default {
         .select('name')
         .from('Account')
         .where('rootType', 'Expense');
+      
       let topExpenses = await frappe.db.knex
         .select({
-          total: frappe.db.knex.raw('sum(??) - sum(??)', ['debit', 'credit']),
+          total: frappe.db.knex.raw('sum(cast(?? as real)) - sum(cast(?? as real))', ['debit', 'credit']),
         })
         .select('account')
         .from('AccountingLedgerEntry')

--- a/src/pages/Dashboard/ProfitAndLoss.vue
+++ b/src/pages/Dashboard/ProfitAndLoss.vue
@@ -5,7 +5,7 @@
       <PeriodSelector
         slot="action"
         :value="period"
-        @change="value => (period = value)"
+        @change="(value) => (period = value)"
       />
     </SectionHeader>
     <div v-show="hasData" class="chart-wrapper" ref="profit-and-loss"></div>
@@ -28,14 +28,14 @@ export default {
   name: 'ProfitAndLoss',
   components: {
     PeriodSelector,
-    SectionHeader
+    SectionHeader,
   },
   data: () => ({ period: 'This Year', hasData: false }),
   activated() {
     this.render();
   },
   watch: {
-    period: 'render'
+    period: 'render',
   },
   methods: {
     async render() {
@@ -47,11 +47,11 @@ export default {
       let res = await pl.run({
         fromDate,
         toDate,
-        periodicity
+        periodicity,
       });
 
       let totalRow = res.rows[res.rows.length - 1];
-      this.hasData = res.columns.some(key => totalRow[key] !== 0);
+      this.hasData = res.columns.some((key) => totalRow[key] !== 0);
       if (!this.hasData) return;
       this.$nextTick(() => this.renderChart(res));
     },
@@ -66,10 +66,10 @@ export default {
         axisOptions: {
           xAxisMode: 'tick',
           shortenYAxisNumbers: true,
-          xIsSeries: true
+          xIsSeries: true,
         },
         tooltipOptions: {
-          formatTooltipY: value => frappe.format(value, 'Currency')
+          formatTooltipY: (value) => frappe.format(value ?? 0, 'Currency'),
         },
         data: {
           labels: res.columns,
@@ -77,12 +77,12 @@ export default {
             {
               name: 'Income',
               chartType: 'bar',
-              values: res.columns.map(key => totalRow[key])
-            }
-          ]
-        }
+              values: res.columns.map((key) => totalRow[key]),
+            },
+          ],
+        },
       });
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/pages/Dashboard/UnpaidInvoices.vue
+++ b/src/pages/Dashboard/UnpaidInvoices.vue
@@ -11,7 +11,7 @@
           v-if="invoice.hasData"
           slot="action"
           :value="$data[invoice.periodKey]"
-          @change="value => ($data[invoice.periodKey] = value)"
+          @change="(value) => ($data[invoice.periodKey] = value)"
         />
         <Button
           v-else
@@ -73,14 +73,14 @@ import Button from '@/components/Button';
 import PeriodSelector from './PeriodSelector';
 import SectionHeader from './SectionHeader';
 import { getDatesAndPeriodicity } from './getDatesAndPeriodicity';
-import { routeTo } from '@/utils'
+import { routeTo } from '@/utils';
 
 export default {
   name: 'UnpaidInvoices',
   components: {
     PeriodSelector,
     SectionHeader,
-    Button
+    Button,
   },
   data: () => ({
     invoices: [
@@ -93,7 +93,7 @@ export default {
         color: 'blue',
         periodKey: 'salesInvoicePeriod',
         hasData: false,
-        barWidth: 40
+        barWidth: 40,
       },
       {
         title: 'Bills',
@@ -104,22 +104,22 @@ export default {
         color: 'gray',
         periodKey: 'purchaseInvoicePeriod',
         hasData: false,
-        barWidth: 60
-      }
+        barWidth: 60,
+      },
     ],
     salesInvoicePeriod: 'This Year',
-    purchaseInvoicePeriod: 'This Year'
+    purchaseInvoicePeriod: 'This Year',
   }),
   watch: {
     salesInvoicePeriod: 'calculateInvoiceTotals',
-    purchaseInvoicePeriod: 'calculateInvoiceTotals'
+    purchaseInvoicePeriod: 'calculateInvoiceTotals',
   },
   activated() {
     this.calculateInvoiceTotals();
   },
   methods: {
     async calculateInvoiceTotals() {
-      let promises = this.invoices.map(async d => {
+      let promises = this.invoices.map(async (d) => {
         let { fromDate, toDate } = await getDatesAndPeriodicity(
           this.$data[d.periodKey]
         );
@@ -133,11 +133,11 @@ export default {
           .first();
 
         let { total, outstanding } = result;
-        d.total = total;
-        d.unpaid = outstanding;
+        d.total = total ?? 0;
+        d.unpaid = outstanding ?? 0;
         d.paid = total - outstanding;
-        d.hasData = (d.total || 0) !== 0;
-        d.barWidth = (d.paid / d.total) * 100;
+        d.hasData = d.total !== 0;
+        d.barWidth = (d.paid / (d.total || 1)) * 100;
         return d;
       });
 
@@ -146,7 +146,7 @@ export default {
     async newInvoice(invoice) {
       let doc = await frappe.getNewDoc(invoice.doctype);
       routeTo(`/edit/${invoice.doctype}/${doc.name}`);
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/pages/GetStarted.vue
+++ b/src/pages/GetStarted.vue
@@ -134,7 +134,7 @@ export default {
               label: _('System'),
               icon: 'system',
               description:
-                'Setup system defaults like date format and currency precision',
+                'Setup system defaults like date format and display precision',
               fieldname: 'systemSetup',
               action() {
                 openSettings('System');

--- a/src/pages/SetupWizard/setupCompany.js
+++ b/src/pages/SetupWizard/setupCompany.js
@@ -63,7 +63,6 @@ async function setupGlobalCurrencies(countries) {
       currency_fraction_units: fractionUnits,
       smallest_currency_fraction_value: smallestValue,
       currency_symbol: symbol,
-      number_format: numberFormat,
     } = country;
 
     if (!currency || queue.includes(currency)) {
@@ -77,7 +76,6 @@ async function setupGlobalCurrencies(countries) {
       fractionUnits,
       smallestValue,
       symbol,
-      numberFormat: numberFormat || '#,###.##',
     };
 
     const doc = checkAndCreateDoc(docObject);

--- a/src/pages/SetupWizard/setupCompany.js
+++ b/src/pages/SetupWizard/setupCompany.js
@@ -3,6 +3,7 @@ import frappe from 'frappejs';
 import countryList from '~/fixtures/countryInfo.json';
 import generateTaxes from '../../../models/doctype/Tax/RegionalEntries';
 import regionalModelUpdates from '../../../models/regionalModelUpdates';
+import { callInitializeMoneyMaker } from '../../utils';
 
 export default async function setupCompany(setupWizardValues) {
   const {
@@ -17,6 +18,9 @@ export default async function setupCompany(setupWizardValues) {
   } = setupWizardValues;
 
   const accountingSettings = frappe.AccountingSettings;
+  const currency = countryList[country]['currency'];
+  await callInitializeMoneyMaker(currency);
+
   await accountingSettings.update({
     companyName,
     country,
@@ -25,7 +29,7 @@ export default async function setupCompany(setupWizardValues) {
     bankName,
     fiscalYearStart,
     fiscalYearEnd,
-    currency: countryList[country]['currency'],
+    currency,
   });
 
   const printSettings = await frappe.getSingle('PrintSettings');

--- a/src/pages/SetupWizard/setupCompany.js
+++ b/src/pages/SetupWizard/setupCompany.js
@@ -1,5 +1,6 @@
 import config from '@/config';
 import frappe from 'frappejs';
+import { DEFAULT_LOCALE } from 'frappejs/utils/consts';
 import countryList from '~/fixtures/countryInfo.json';
 import generateTaxes from '../../../models/doctype/Tax/RegionalEntries';
 import regionalModelUpdates from '../../../models/regionalModelUpdates';
@@ -19,6 +20,7 @@ export default async function setupCompany(setupWizardValues) {
 
   const accountingSettings = frappe.AccountingSettings;
   const currency = countryList[country]['currency'];
+  const locale = countryList[country]['locale'] ?? DEFAULT_LOCALE;
   await callInitializeMoneyMaker(currency);
 
   await accountingSettings.update({
@@ -47,6 +49,8 @@ export default async function setupCompany(setupWizardValues) {
 
   await accountingSettings.update({ setupComplete: 1 });
   frappe.AccountingSettings = accountingSettings;
+
+  (await frappe.getSingle('SystemSettings')).update({ locale });
 }
 
 async function setupGlobalCurrencies(countries) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -351,3 +351,39 @@ export function titleCase(phrase) {
     })
     .join(' ');
 }
+
+export async function getIsSetupComplete() {
+  try {
+    const { setupComplete } = await frappe.getSingle('AccountingSettings');
+    return !!setupComplete;
+  } catch {
+    return false;
+  }
+}
+
+export async function getCurrency() {
+  let currency = frappe?.AccoutingSettings?.currency ?? undefined;
+
+  if (!currency) {
+    try {
+      currency = (
+        await frappe.db.getSingleValues({
+          fieldname: 'currency',
+          parent: 'AccountingSettings',
+        })
+      )[0].value;
+    } catch (err) {
+      currency = undefined;
+    }
+  }
+
+  return currency;
+}
+
+export async function callInitializeMoneyMaker(currency) {
+  currency ??= await getCurrency();
+  if (!currency && frappe.pesa) {
+    return;
+  }
+  await frappe.initializeMoneyMaker(currency);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ import Toast from '@/components/Toast';
 import router from '@/router';
 import { ipcRenderer } from 'electron';
 import frappe from 'frappejs';
-import { _ } from 'frappejs/utils';
+import { isPesa, _ } from 'frappejs/utils';
 import lodash from 'lodash';
 import Vue from 'vue';
 import { IPC_ACTIONS, IPC_MESSAGES } from './messages';
@@ -386,4 +386,12 @@ export async function callInitializeMoneyMaker(currency) {
     return;
   }
   await frappe.initializeMoneyMaker(currency);
+}
+
+export function convertPesaValuesToFloat(obj) {
+  Object.keys(obj).forEach((key) => {
+    if (!isPesa(obj[key])) return;
+
+    obj[key] = obj[key].float;
+  });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -362,7 +362,7 @@ export async function getIsSetupComplete() {
 }
 
 export async function getCurrency() {
-  let currency = frappe?.AccoutingSettings?.currency ?? undefined;
+  let currency = frappe?.AccountingSettings?.currency ?? undefined;
 
   if (!currency) {
     try {
@@ -383,6 +383,10 @@ export async function getCurrency() {
 export async function callInitializeMoneyMaker(currency) {
   currency ??= await getCurrency();
   if (!currency && frappe.pesa) {
+    return;
+  }
+
+  if (currency && frappe.pesa().options.currency === currency) {
     return;
   }
   await frappe.initializeMoneyMaker(currency);

--- a/src/utils.js
+++ b/src/utils.js
@@ -258,7 +258,7 @@ export function getInvoiceStatus(doc) {
   if (!doc.submitted) {
     status = 'Draft';
   }
-  if (doc.submitted === 1 && doc.outstandingAmount === 0.0) {
+  if (doc.submitted === 1 && doc.outstandingAmount.isZero()) {
     status = 'Paid';
   }
   if (doc.cancelled === 1) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -152,7 +152,7 @@ export function openQuickEdit({ doctype, name, hideFields, defaults = {} }) {
 }
 
 export function getErrorMessage(e, doc) {
-  let errorMessage = e.message || _('An error occurred');
+  let errorMessage = e.message || _('An error occurred.');
   const { doctype, name } = doc;
   const canElaborate = doctype && name;
   if (e.type === frappe.errors.LinkValidationError && canElaborate) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,6 +53,9 @@ module.exports = {
         lg: '0.5rem', // 8px
         xl: '0.75rem', // 12px
       },
+      gridColumn: {
+        'span-full': '1 / -1',
+      },
       colors: {
         brand: '#2490EF',
         'brand-100': '#f4f9ff',


### PR DESCRIPTION
### Currency Refactor
PR pertains to refactoring books to use [`pesa`](https://github.com/frappe/pesa) to handle monetary calculations.

#### Pesa initialization
1. Initialized immediately after db connect.
2. If setup is incomplete currency is not available; ∴ initialized with default `"XXX"` code for no currency.
3. if setup incomplete, on submit with the entered currency.

#### Todo List
- [x] All javascript calculations should take place through `pesa` methods.
- [x] All sql queries should cast the values to number first.
- [x] Deprecate earlier handling of precision.
- [x] Setting display should change the number of significant digits displayed.
- [x] On storing the values in the db, use string type and use `Money#store`
    which will get a precision adjusted decimal string.
- [x] When a doc is being fetched the currency values should be converted to the
    Money object.
- [x] Patch that converts values to store strings.
- [x] After db init when `currency` and `internalPrecision` are available set `pesa` on
    the global object.

#### Other Changes
- ~`Model#field#validate(value, doc)` will be called before update in `Base.vue` on `blur`ring of the input field~. Validations will be inline, previous change has been removed cause they are called on `doc.set`.

https://user-images.githubusercontent.com/29507195/148735790-eb3cca97-a146-4354-9a55-47760c030eda.mov


- This function should throw an error if invalid, this will be show in a message box.
- `Int` and `Float` types now have number inputs, `Model#field#minValue` and `Model#field#maxValue` can be used to restrict the range.
- Added **Locale** in _System Settings_ to set `Intl.NumberFormat`


FrappeJS: https://github.com/frappe/frappejs/pull/153