### PR TITLE
fix: add failsafes along db connection paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "frappe-books",
   "description": "Simple book-keeping app for everyone",
   "homepage": "https://frappebooks.com",
-  "version": "0.0.4-beta.0",
+  "version": "0.0.4-beta.1",
   "author": {
     "name": "Frappe Technologies Pvt. Ltd.",
     "email": "hello@frappe.io"

--- a/src/background.js
+++ b/src/background.js
@@ -185,6 +185,10 @@ ipcMain.handle(IPC_ACTIONS.GET_DIALOG_RESPONSE, async (event, options) => {
   return await dialog.showMessageBox(window, options);
 });
 
+ipcMain.handle(IPC_ACTIONS.SHOW_ERROR, async (event, { title, content }) => {
+  return await dialog.showErrorBox(title, content);
+});
+
 ipcMain.handle(IPC_ACTIONS.SAVE_HTML_AS_PDF, async (event, html, savePath) => {
   return await saveHtmlAsPdf(html, savePath);
 });

--- a/src/messages.js
+++ b/src/messages.js
@@ -15,5 +15,12 @@ export const IPC_ACTIONS = {
   GET_SAVE_FILEPATH: 'save-dialog',
   GET_DIALOG_RESPONSE: 'show-message-box',
   GET_PRIMARY_DISPLAY_SIZE: 'get-primary-display-size',
-  SAVE_HTML_AS_PDF: 'save-html-as-pdf'
+  SAVE_HTML_AS_PDF: 'save-html-as-pdf',
+  SHOW_ERROR: 'show-error',
+};
+
+export const DB_CONN_FAILURE = {
+  INVALID_FILE: 'invalid-file',
+  CANT_OPEN: 'cant-open',
+  CANT_CONNECT: 'cant-connect',
 };

--- a/src/pages/SetupWizard/SetupWizard.vue
+++ b/src/pages/SetupWizard/SetupWizard.vue
@@ -78,6 +78,7 @@ import {
   getErrorMessage,
   handleErrorWithDialog,
   showMessageDialog,
+  showErrorDialog,
 } from '@/utils';
 
 export default {
@@ -151,10 +152,18 @@ export default {
 
       purgeCache();
 
-      const connectionSuccess = await connectToLocalDatabase(filePath);
+      const { connectionSuccess, reason } = await connectToLocalDatabase(
+        filePath
+      );
+
       if (connectionSuccess) {
         await setupCompany(this.doc);
         this.$emit('setup-complete');
+      } else {
+        await showErrorDialog({
+          title: 'DB Connection Error',
+          content: `reason: ${reason}, filePath: ${filePath}`,
+        });
       }
     },
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,16 @@ export async function showMessageDialog({
   }
 }
 
+export async function showErrorDialog({ title, content }) {
+  // To be used for  show stopper errors
+  title = title ?? 'Error';
+  content =
+    content ??
+    'Something has gone terribly wrong. Please check the console and raise an issue.';
+
+  await ipcRenderer.invoke(IPC_ACTIONS.SHOW_ERROR, { title, content });
+}
+
 export function deleteDocWithPrompt(doc) {
   return new Promise((resolve) => {
     showMessageDialog({


### PR DESCRIPTION
On DB connection failure, used to show a blank screen. Now almost all DB connection paths on failure will show a sensible error dialogue.

<img width="547" alt="Screen Shot 2021-12-10 at 13 39 21" src="https://user-images.githubusercontent.com/29507195/145539651-b52f35d6-81be-456c-a048-51600f8bd6b6.png">

Alleviates this: https://github.com/frappe/books/issues/273