### PR TITLE
CD: add yml to publish build artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,139 @@
+name: Publish
+
+on: workflow_dispatch
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.4.0'
+
+      - name: Change yarn version
+        run: yarn set version 1.22.17
+
+      - name: Checkout Books
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Checkout FrappeJS
+        uses: actions/checkout@v2
+        with:
+          repository: 'frappe/frappejs'
+          path: framework
+
+      - name: Setup FrappeJS
+        run: |
+          cd $GITHUB_WORKSPACE/framework
+          yarn
+          yarn link
+
+      - name: Setup Books
+        run: |
+          cd $GITHUB_WORKSPACE/main
+          yarn
+          yarn link frappejs
+
+      - name: Run build
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_IDENTITY_AUTO_DISCOVERY: true
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          APPLE_NOTARIZE: 1
+        run: |
+          cd $GITHUB_WORKSPACE/main
+          yarn electron:build --mac --publish always
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.4.0'
+
+      - name: Change yarn version
+        run: yarn set version 1.22.17
+
+      - name: Checkout Books
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Checkout FrappeJS
+        uses: actions/checkout@v2
+        with:
+          repository: 'frappe/frappejs'
+          path: framework
+
+      - name: Setup FrappeJS
+        run: |
+          cd $GITHUB_WORKSPACE/framework
+          yarn
+          yarn link
+
+      - name: Setup Books
+        run: |
+          cd $GITHUB_WORKSPACE/main
+          yarn
+          yarn link frappejs
+
+      - name: Install RPM
+        run: apt install rpm
+
+      - name: Run build
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          cd $GITHUB_WORKSPACE/main
+          yarn electron:build --linux --publish always
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.4.0'
+
+      - name: Change yarn version
+        run: yarn set version 1.22.17
+
+      - name: Checkout Books
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Checkout FrappeJS
+        uses: actions/checkout@v2
+        with:
+          repository: 'frappe/frappejs'
+          path: framework
+
+      - name: Setup FrappeJS
+        run: |
+          cd $GITHUB_WORKSPACE/framework
+          yarn
+          yarn link
+
+      - name: Setup Books
+        run: |
+          cd $GITHUB_WORKSPACE/main
+          yarn
+          yarn link frappejs
+
+      - name: Run build
+        env:
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          cd $GITHUB_WORKSPACE/main
+          yarn electron:build --win --publish always


### PR DESCRIPTION
### Description
- Added a workflow for publishing, `publish.yml`.
- For now the publish script runs only when manually triggered.

### Steps to Publish
If things work right, to [publish](https://www.electron.build/configuration/publish#recommended-github-releases-workflow) a new release:
1. Create a **Release** draft with the tag matching the package.json version.
2. Run the **Publish** workflow from the **Actions** tab on the `master` branch.
3. The build artifacts should be uploaded to the release.
4. Click **Publish** on the release page.

_Note: if a Draft Release isn't present, it'll create one on it's own._
### Some questions
> Why is publishing not automated?

This is because the unnecessary spooling up of servers to build for [three different platforms](https://www.electron.build/multi-platform-build) and also upload to Apple servers to notarize seems wasteful when not publishing, weighs a bit too heavily on my conscience. Although on `tag` push this script can be run.

<br>

> Why does `build.yml` require only `macos-latest` but publish is done separately for each platform?

The code signing of Windows requires Windows, else the uninstaller doesn't get code signed.
Linux can be built on macOS but I suspect there is something weird going on there too hence it being better to build on Ubuntu.
And macOS can't be built anywhere else other than macOS.