### PR TITLE
ci(build): add upgrade frappejs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Books
         run: |
           cd $GITHUB_WORKSPACE/main
-          yarn
+          yarn upgrade frappejs
           yarn link frappejs
 
       - name: Install RPM

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Books
         run: |
           cd $GITHUB_WORKSPACE/main
-          yarn
+          yarn upgrade frappejs
           yarn link frappejs
 
       - name: Run build
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Books
         run: |
           cd $GITHUB_WORKSPACE/main
-          yarn
+          yarn upgrade frappejs
           yarn link frappejs
 
       - name: Run build
@@ -121,7 +121,7 @@ jobs:
       - name: Setup Books
         run: |
           cd $GITHUB_WORKSPACE/main
-          yarn
+          yarn upgrade frappejs
           yarn link frappejs
 
       - name: Run build


### PR DESCRIPTION
Need to run `yarn upgrade frappejs` before linking. Not adding this line throws this error:
```bash
Error: Rule can only have one resource source (provided resource and test + include + exclude) in {
  "type": "javascript/auto",
  "include": [
    {}
  ],
  "use": []
}
```

This makes no sense to me cause:
1. The diff remains the same.
2. Linking removes the resolved `frappejs` and sets it to the cloned one.

But it works. I'll check what's actually up later when revamping the build, depending on so many build tools and their millions of moving parts causes an ever-present sense of trepidation.