### PR TITLE
Fixed profit loss report half-yearly filter field

### DIFF
--- a/reports/FinancialStatements/FinancialStatements.js
+++ b/reports/FinancialStatements/FinancialStatements.js
@@ -192,10 +192,13 @@ function getPeriodKey(date, periodicity) {
       }[quarter];
     },
     'Half Yearly': () => {
-      return {
-        1: `Apr ${year} - Sep ${year}`,
-        2: `Oct ${year} - Mar ${year}`,
-      }[[2, 3].includes(quarter) ? 1 : 2];
+      if (month > 3) {
+        return {
+          1: `Apr ${year} - Sep ${year}`,
+          2: `Oct ${year} - Mar ${year + 1}`,
+        }[[2, 3].includes(quarter) ? 1 : 2];
+      }
+      return `Oct ${year - 1} - Mar ${year}`;
     },
     Yearly: () => {
       if (month > 3) {

--- a/reports/ProfitAndLoss/viewConfig.js
+++ b/reports/ProfitAndLoss/viewConfig.js
@@ -52,6 +52,7 @@ export default {
         label: name,
         fieldname: name,
         fieldtype: 'Currency',
+        width: 1
       }));
 
       columns.push(...columnDefs);

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -8,7 +8,6 @@
         :placeholder="placeholder"
         readonly
         @focus="!readonly ? togglePopover() : null"
-        @blur="togglePopover(false)"
       />
     </template>
     <template v-slot:content="{ togglePopover }">


### PR DESCRIPTION
Fixed the erroneous behaviour of half-yearly filter field.
cc: @ankitsinghaniyaz @18alantom 

Current behavior -
![image](https://user-images.githubusercontent.com/69912046/149292477-e81ac19f-fead-4ebf-a540-5f73c5bdf61a.png)



Expected behavior -

1 April 2020 to 31 March 2022 should be like broken into -

April 2020 - Sept 2020
Oct 2020 - March 2021
April 2021 - Sept 2021
Oct 2021 - March 2022

![image](https://user-images.githubusercontent.com/69912046/149292509-9cb1b705-0392-4011-a3ee-c802b2b75d1f.png)

