### PR TITLE
ci: test yml to check win build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
           path: dist-linux.tar
 
   build-windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
`node-gyp` doesn't detect VS properly and causes building of `sqlite3` to fail, switching to 2019 seems to work for now.