### PR TITLE
Add provisions for settings sync

### DIFF
--- a/src/pages/Settings/TabGeneral.vue
+++ b/src/pages/Settings/TabGeneral.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
-    <TwoColumnForm v-if="doc" :doc="doc" :fields="fields" :autosave="true" />
+    <TwoColumnForm
+      v-if="doc"
+      :doc="doc"
+      :fields="fields"
+      :autosave="true"
+      :emit-change="true"
+      @change="forwardChangeEvent"
+    />
   </div>
 </template>
 
@@ -11,16 +18,16 @@ import TwoColumnForm from '@/components/TwoColumnForm';
 export default {
   name: 'TabGeneral',
   components: {
-    TwoColumnForm
+    TwoColumnForm,
   },
   data() {
     return {
-      doc: null
+      doc: null,
     };
   },
   async mounted() {
     this.doc = await frappe.getDoc('AccountingSettings', 'AccountingSettings', {
-      skipDocumentCache: true
+      skipDocumentCache: true,
     });
   },
   computed: {
@@ -36,8 +43,13 @@ export default {
         'fiscalYearStart',
         'fiscalYearEnd',
         'gstin',
-      ].map(fieldname => meta.getField(fieldname));
-    }
-  }
+      ].map((fieldname) => meta.getField(fieldname));
+    },
+  },
+  methods: {
+    forwardChangeEvent(...args) {
+      this.$emit('change', ...args);
+    },
+  },
 };
 </script>

--- a/src/pages/Settings/TabInvoice.vue
+++ b/src/pages/Settings/TabInvoice.vue
@@ -8,6 +8,7 @@
           (value) => {
             doc.set('logo', value);
             doc.update();
+            forwardChangeEvent(meta.getField('logo'));
           }
         "
       />
@@ -27,13 +28,21 @@
             (value) => {
               doc.set('displayLogo', value);
               doc.update();
+              forwardChangeEvent(meta.getField('displayLogo'));
             }
           "
           size="small"
         />
       </div>
     </div>
-    <TwoColumnForm class="mt-6" :doc="doc" :fields="fields" :autosave="true" />
+    <TwoColumnForm
+      class="mt-6"
+      :doc="doc"
+      :fields="fields"
+      :autosave="true"
+      :emit-change="true"
+      @change="forwardChangeEvent"
+    />
   </div>
 </template>
 <script>
@@ -73,14 +82,9 @@ export default {
       return frappe.getMeta('PrintSettings');
     },
     fields() {
-      return [
-        'template',
-        'color',
-        'font',
-        'email',
-        'phone',
-        'address',
-      ].map((field) => this.meta.getField(field));
+      return ['template', 'color', 'font', 'email', 'phone', 'address'].map(
+        (field) => this.meta.getField(field)
+      );
     },
   },
   methods: {
@@ -90,11 +94,17 @@ export default {
         properties: ['openFile'],
         filters: [{ name: 'Invoice Logo', extensions: ['png', 'jpg', 'svg'] }],
       };
-      const { filePaths } = await ipcRenderer.invoke(IPC_ACTIONS.GET_OPEN_FILEPATH, options);
+      const { filePaths } = await ipcRenderer.invoke(
+        IPC_ACTIONS.GET_OPEN_FILEPATH,
+        options
+      );
       if (filePaths[0] !== undefined) {
         this.doc.set('logo', `file://${files[0]}`);
         this.doc.update;
       }
+    },
+    forwardChangeEvent(...args) {
+      this.$emit('change', ...args);
     },
   },
 };

--- a/src/pages/Settings/TabSystem.vue
+++ b/src/pages/Settings/TabSystem.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
-    <TwoColumnForm v-if="doc" :doc="doc" :fields="fields" :autosave="true" />
+    <TwoColumnForm
+      v-if="doc"
+      :doc="doc"
+      :fields="fields"
+      :autosave="true"
+      :emit-change="true"
+      @change="forwardChangeEvent"
+    />
   </div>
 </template>
 
@@ -26,6 +33,11 @@ export default {
     fields() {
       let meta = frappe.getMeta('SystemSettings');
       return meta.getQuickEditFields();
+    },
+  },
+  methods: {
+    forwardChangeEvent(...args) {
+      this.$emit('change', ...args);
     },
   },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -380,13 +380,13 @@ export async function getCurrency() {
   return currency;
 }
 
-export async function callInitializeMoneyMaker(currency) {
+export async function callInitializeMoneyMaker(currency, force = false) {
   currency ??= await getCurrency();
-  if (!currency && frappe.pesa) {
+  if (!force && !currency && frappe.pesa) {
     return;
   }
 
-  if (currency && frappe.pesa().options.currency === currency) {
+  if (!force && currency && frappe.pesa().options.currency === currency) {
     return;
   }
   await frappe.initializeMoneyMaker(currency);


### PR DESCRIPTION
- Added some provisioning for syncing settings and updating cache in case the settings are fetched from the cache.
- Here changes in `displayPrecision` require a reload to be visible (because of keep-alive components) so a toast is displayed with the Reload action.
- Afaik only `displayPrecision` has an issue will add other syncing mechanisms if required.