### PR TITLE
feat: start setting up error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 
 #Electron-builder output
 /dist_electron
+err_log_creds.txt

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,12 @@
 productName: Frappe Books
 appId: io.frappe.books
 afterSign: build/notarize.js
+extraResources: [
+  { 
+    from: 'err_log_creds.txt',
+    to: '../creds/err_log_creds.txt',  
+  }
+]
 mac:
   type: distribution
   category: public.app-category.finance

--- a/frappe/models/doctype/SystemSettings/SystemSettings.js
+++ b/frappe/models/doctype/SystemSettings/SystemSettings.js
@@ -99,11 +99,11 @@ module.exports = {
     },
     {
       fieldname: 'autoReportErrors',
-      label: 'Auto Report Errors',
+      label: 'Hide & Auto Report Errors',
       fieldtype: 'Check',
       default: 0,
       description: t(
-        'Automatically report all errors. User will still be notified when an error pops up.'
+        'Prevent errors from showing and automatically report all errors.'
       ),
     },
   ],

--- a/src/App.vue
+++ b/src/App.vue
@@ -35,8 +35,9 @@ import { ipcRenderer } from 'electron';
 import config from '@/config';
 import { IPC_MESSAGES, IPC_ACTIONS } from '@/messages';
 import { connectToLocalDatabase, purgeCache } from '@/initialization';
-import { routeTo, showErrorDialog } from './utils';
+import { routeTo } from './utils';
 import fs from 'fs/promises';
+import { showErrorDialog } from './errorHandling';
 
 export default {
   name: 'App',

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,10 +83,10 @@ export default {
     }
 
     if (lastSelectedFilePath) {
-      await showErrorDialog({
-        title: 'DB Connection Error',
-        content: `reason: ${reason}, filePath: ${lastSelectedFilePath}`,
-      });
+      const title = this.t`DB Connection Error`;
+      const content = `reason: ${reason}, filePath: ${lastSelectedFilePath}`;
+
+      await showErrorDialog(title, content);
     }
 
     this.activeScreen = 'DatabaseSelector';

--- a/src/background.js
+++ b/src/background.js
@@ -15,6 +15,7 @@ import { autoUpdater } from 'electron-updater';
 import fs from 'fs/promises';
 import path from 'path';
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib';
+import { sendError } from './contactMothership';
 import { IPC_ACTIONS, IPC_MESSAGES } from './messages';
 import saveHtmlAsPdf from './saveHtmlAsPdf';
 
@@ -200,6 +201,10 @@ ipcMain.handle(IPC_ACTIONS.SAVE_HTML_AS_PDF, async (event, html, savePath) => {
 
 ipcMain.handle(IPC_ACTIONS.SAVE_DATA, async (event, data, savePath) => {
   return await fs.writeFile(savePath, data, { encoding: 'utf-8' });
+});
+
+ipcMain.handle(IPC_ACTIONS.SEND_ERROR, (event, bodyJson) => {
+  sendError(bodyJson);
 });
 
 /* ------------------------------

--- a/src/components/Controls/TableRow.vue
+++ b/src/components/Controls/TableRow.vue
@@ -33,8 +33,8 @@
 </template>
 <script>
 import FormControl from './FormControl';
-import { getErrorMessage } from '../../utils';
 import Row from '@/components/Row';
+import { getErrorMessage } from '../../errorHandling';
 
 export default {
   name: 'TableRow',

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,26 +1,37 @@
 <template>
   <div
-    class="
-      pt-6
-      pb-2
-      px-2
-      h-full
-      block
-      flex
-      justify-between
-      flex-col
-      bg-gray-100
-    "
+    class="pt-6 pb-2 px-2 h-full flex justify-between flex-col bg-gray-100"
     :class="{
       'window-drag': platform !== 'Windows',
     }"
   >
     <div class="window-no-drag">
       <WindowControls v-if="platform === 'Mac'" class="px-3 mb-6" />
-      <div class="px-3">
-        <h6 class="text-lg font-semibold" @click="routeTo('/')">
+      <div class="px-3 flex flex-row items-center">
+        <h6
+          class="
+            text-xl
+            font-semibold
+            whitespace-nowrap
+            overflow-scroll
+            no-scrollbar
+          "
+        >
           {{ companyName }}
         </h6>
+        <feather-icon
+          class="
+            w-5
+            h-5
+            ml-1
+            stroke-2
+            cursor-pointer
+            text-gray-600
+            hover:text-gray-800
+          "
+          name="chevron-down"
+          @click="$emit('change-db-file')"
+        />
       </div>
       <div class="mt-3">
         <div class="mt-1 first:mt-0" v-for="group in groups" :key="group.title">
@@ -74,16 +85,17 @@
     </div>
     <div class="px-5 window-no-drag">
       <button
-        class="pb-1 text-sm text-gray-600 hover:text-gray-800 w-full whitespace-nowrap overflow-scroll no-scrollbar text-left"
-        @click="$emit('change-db-file')"
+        class="pb-1 text-sm text-gray-600 hover:text-gray-800 w-full text-left"
+        @click="() => reportIssue()"
       >
-        {{ dbPath }}
+        Report Issue
       </button>
       <p class="pb-3 text-sm text-gray-600">v{{ appVersion }}</p>
     </div>
   </div>
 </template>
 <script>
+import { reportIssue } from '@/errorHandling';
 import sidebarConfig from '../sidebarConfig';
 import Button from '@/components/Button';
 import WindowControls from './WindowControls';
@@ -145,7 +157,6 @@ export default {
       }
     }
 
-
     this.groups = groups;
 
     this.setActiveGroup();
@@ -155,6 +166,7 @@ export default {
   },
   methods: {
     routeTo,
+    reportIssue,
     setActiveGroup() {
       const { fullPath } = this.$router.currentRoute;
       const fallBackGroup = this.activeGroup;

--- a/src/components/TwoColumnForm.vue
+++ b/src/components/TwoColumnForm.vue
@@ -93,7 +93,7 @@
 import frappe from 'frappe';
 import FormControl from '@/components/Controls/FormControl';
 import Button from '@/components/Button';
-import { getErrorMessage, handleErrorWithDialog } from '@/utils';
+import { handleErrorWithDialog, getErrorMessage } from '../errorHandling';
 
 let TwoColumnForm = {
   name: 'TwoColumnForm',

--- a/src/contactMothership.js
+++ b/src/contactMothership.js
@@ -6,7 +6,18 @@ import path from 'path';
 
 function getUrlAndTokenString() {
   const inProduction = app.isPackaged;
-  const errLogCredsPath = path.join(__dirname, '../err_log_creds.txt');
+  let errLogCredsPath = path.join(
+    process.resourcesPath,
+    '../creds/err_log_creds.txt'
+  );
+  if (!fs.existsSync(errLogCredsPath)) {
+    errLogCredsPath = path.join(__dirname, '../err_log_creds.txt');
+  }
+
+  if (!fs.existsSync(errLogCredsPath)) {
+    !inProduction && console.log(`${errLogCredsPath} doesn't exist, can't log`);
+    return;
+  }
 
   let apiKey, apiSecret, url;
   try {
@@ -16,13 +27,12 @@ function getUrlAndTokenString() {
       .filter((f) => f.length);
   } catch (err) {
     if (!inProduction) {
-      console.log('error logging failed');
+      console.log(`logging error using creds at: ${errLogCredsPath} failed`);
       console.log(err);
     }
     return;
   }
 
-  !inProduction && console.log(apiKey, apiSecret, url);
   return { url: encodeURI(url), tokenString: `token ${apiKey}:${apiSecret}` };
 }
 

--- a/src/contactMothership.js
+++ b/src/contactMothership.js
@@ -1,0 +1,69 @@
+import { app } from 'electron';
+import fs from 'fs';
+import http from 'http';
+import https from 'https';
+import path from 'path';
+
+function getUrlAndTokenString() {
+  const inProduction = app.isPackaged;
+  const errLogCredsPath = path.join(__dirname, '../err_log_creds.txt');
+
+  let apiKey, apiSecret, url;
+  try {
+    [apiKey, apiSecret, url] = fs
+      .readFileSync(errLogCredsPath, 'utf-8')
+      .split('\n')
+      .filter((f) => f.length);
+  } catch (err) {
+    if (!inProduction) {
+      console.log('error logging failed');
+      console.log(err);
+    }
+    return;
+  }
+
+  !inProduction && console.log(apiKey, apiSecret, url);
+  return { url: encodeURI(url), tokenString: `token ${apiKey}:${apiSecret}` };
+}
+
+function post(bodyJson) {
+  const inProduction = app.isPackaged;
+  const { url, tokenString } = getUrlAndTokenString();
+  const isHttps = url.split(':')[0].toLowerCase() === 'https';
+  const headers = {
+    Authorization: tokenString,
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  const req = (isHttps ? https : http).request(
+    url,
+    {
+      method: 'POST',
+      headers,
+    },
+    (res) => {
+      if (inProduction) {
+        return;
+      }
+
+      console.log(`STATUS: ${res.statusCode}`);
+      console.log(`HEADERS: ${JSON.stringify(res.headers)}`);
+
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        console.log(`BODY: ${chunk}`);
+      });
+    }
+  );
+
+  req.write(bodyJson);
+  req.end();
+}
+
+export function sendError(bodyJson) {
+  post(bodyJson);
+}
+
+// Nothing nefarious going on here.
+// Just regular old user mandated error logging.

--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -22,3 +22,33 @@ export function handleError(shouldLog, error, more = {}) {
 
   // Do something cool
 }
+
+export function getErrorHandled(func) {
+  return async function errorHandled(...args) {
+    try {
+      return await func(...args);
+    } catch (error) {
+      handleError(false, error, {
+        functionName: func.name,
+        functionArgs: args,
+      });
+
+      throw error;
+    }
+  };
+}
+
+export function getErrorHandledSync(func) {
+  return function errorHandledSync(...args) {
+    try {
+      return func(...args);
+    } catch (error) {
+      handleError(false, error, {
+        functionName: func.name,
+        functionArgs: args,
+      });
+
+      throw error;
+    }
+  };
+}

--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -1,5 +1,8 @@
+import { ipcRenderer } from 'electron';
 import frappe from 'frappejs';
 import { MandatoryError, ValidationError } from 'frappejs/common/errors';
+import { IPC_ACTIONS } from './messages';
+import { showMessageDialog } from './utils';
 
 function shouldNotStore(error) {
   return [MandatoryError, ValidationError].some(
@@ -22,6 +25,41 @@ export function handleError(shouldLog, error, more = {}) {
 
   // Do something cool
 }
+
+export function getErrorMessage(e, doc) {
+  let errorMessage = e.message || _('An error occurred.');
+  const { doctype, name } = doc;
+  const canElaborate = doctype && name;
+  if (e.type === frappe.errors.LinkValidationError && canElaborate) {
+    errorMessage = _('{0} {1} is linked with existing records.', [
+      doctype,
+      name,
+    ]);
+  } else if (e.type === frappe.errors.DuplicateEntryError && canElaborate) {
+    errorMessage = _('{0} {1} already exists.', [doctype, name]);
+  }
+  return errorMessage;
+}
+
+export function handleErrorWithDialog(error, doc = {}) {
+  let errorMessage = getErrorMessage(error, doc);
+  handleError(false, error, { errorMessage, doc });
+
+  showMessageDialog({ message: errorMessage });
+  throw error;
+}
+
+export async function showErrorDialog({ title, content }) {
+  // To be used for  show stopper errors
+  title ??= frappe._('Error');
+  content ??= frappe._(
+    'Something has gone terribly wrong. Please check the console and raise an issue.'
+  );
+
+  await ipcRenderer.invoke(IPC_ACTIONS.SHOW_ERROR, { title, content });
+}
+
+// Wrapper Functions
 
 export function getErrorHandled(func) {
   return async function errorHandled(...args) {

--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -15,6 +15,24 @@ function reportError(errorLogObj) {
   console.log(errorLogObj);
 }
 
+function getToastProps(errorLogObj) {
+  const props = {
+    message: _(`Error: `) + errorLogObj.name,
+    type: 'error',
+  };
+
+  if (!frappe.SystemSettings.autoReportErrors) {
+    Object.assign(props, {
+      actionText: frappe._('Report Error'),
+      action: () => {
+        reportError(errorLogObj);
+      },
+    });
+  }
+
+  return props;
+}
+
 export function handleError(shouldLog, error, more = {}) {
   if (shouldLog) {
     console.error(error);
@@ -26,17 +44,13 @@ export function handleError(shouldLog, error, more = {}) {
 
   const { name, stack, message } = error;
   const errorLogObj = { name, stack, message, more };
+
   frappe.errorLog.push(errorLogObj);
 
-  // Do something cool
-  showToast({
-    message: _(`Error: `) + name,
-    actionText: frappe._('Report Error'),
-    type: 'error',
-    action: () => {
-      reportError(errorLogObj);
-    },
-  });
+  showToast(getToastProps(errorLogObj));
+  if (frappe.SystemSettings.autoReportErrors) {
+    reportError(errorLogObj);
+  }
 }
 
 export function getErrorMessage(e, doc) {

--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -1,6 +1,6 @@
 import { ipcRenderer } from 'electron';
-import frappe from 'frappejs';
-import { MandatoryError, ValidationError } from 'frappejs/common/errors';
+import frappe, { t } from 'frappe';
+import { MandatoryError, ValidationError } from 'frappe/common/errors';
 import { IPC_ACTIONS } from './messages';
 import { showMessageDialog, showToast } from './utils';
 
@@ -17,13 +17,13 @@ function reportError(errorLogObj) {
 
 function getToastProps(errorLogObj) {
   const props = {
-    message: _(`Error: `) + errorLogObj.name,
+    message: t`Error: ` + errorLogObj.name,
     type: 'error',
   };
 
   if (!frappe.SystemSettings.autoReportErrors) {
     Object.assign(props, {
-      actionText: frappe._('Report Error'),
+      actionText: t`Report Error`,
       action: () => {
         reportError(errorLogObj);
       },
@@ -54,16 +54,13 @@ export function handleError(shouldLog, error, more = {}) {
 }
 
 export function getErrorMessage(e, doc) {
-  let errorMessage = e.message || _('An error occurred.');
+  let errorMessage = e.message || t`An error occurred.`;
   const { doctype, name } = doc;
   const canElaborate = doctype && name;
   if (e.type === frappe.errors.LinkValidationError && canElaborate) {
-    errorMessage = _('{0} {1} is linked with existing records.', [
-      doctype,
-      name,
-    ]);
+    errorMessage = t`${doctype} ${name} is linked with existing records.`;
   } else if (e.type === frappe.errors.DuplicateEntryError && canElaborate) {
-    errorMessage = _('{0} {1} already exists.', [doctype, name]);
+    errorMessage = t`${doctype} ${name} already exists.`;
   }
   return errorMessage;
 }
@@ -78,10 +75,8 @@ export function handleErrorWithDialog(error, doc = {}) {
 
 export async function showErrorDialog({ title, content }) {
   // To be used for  show stopper errors
-  title ??= frappe._('Error');
-  content ??= frappe._(
-    'Something has gone terribly wrong. Please check the console and raise an issue.'
-  );
+  title ??= t`Error`;
+  content ??= t`Something has gone terribly wrong. Please check the console and raise an issue.`;
 
   await ipcRenderer.invoke(IPC_ACTIONS.SHOW_ERROR, { title, content });
 }

--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -2,12 +2,17 @@ import { ipcRenderer } from 'electron';
 import frappe from 'frappejs';
 import { MandatoryError, ValidationError } from 'frappejs/common/errors';
 import { IPC_ACTIONS } from './messages';
-import { showMessageDialog } from './utils';
+import { showMessageDialog, showToast } from './utils';
 
 function shouldNotStore(error) {
   return [MandatoryError, ValidationError].some(
     (errorClass) => error instanceof errorClass
   );
+}
+
+function reportError(errorLogObj) {
+  // push errorlog to frappebooks.com
+  console.log(errorLogObj);
 }
 
 export function handleError(shouldLog, error, more = {}) {
@@ -24,6 +29,14 @@ export function handleError(shouldLog, error, more = {}) {
   frappe.errorLog.push(errorLogObj);
 
   // Do something cool
+  showToast({
+    message: _(`Error: `) + name,
+    actionText: frappe._('Report Error'),
+    type: 'error',
+    action: () => {
+      reportError(errorLogObj);
+    },
+  });
 }
 
 export function getErrorMessage(e, doc) {

--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -1,0 +1,24 @@
+import frappe from 'frappejs';
+import { MandatoryError, ValidationError } from 'frappejs/common/errors';
+
+function shouldNotStore(error) {
+  return [MandatoryError, ValidationError].some(
+    (errorClass) => error instanceof errorClass
+  );
+}
+
+export function handleError(shouldLog, error, more = {}) {
+  if (shouldLog) {
+    console.error(error);
+  }
+
+  if (shouldNotStore(error)) {
+    return;
+  }
+
+  const { name, stack, message } = error;
+  const errorLogObj = { name, stack, message, more };
+  frappe.errorLog.push(errorLogObj);
+
+  // Do something cool
+}

--- a/src/errorHandling.ts
+++ b/src/errorHandling.ts
@@ -40,7 +40,7 @@ function getToastProps(errorLogObj: ErrorLog) {
       actionText: t`Report Error`,
       action: () => {
         reportError(errorLogObj);
-        createIssue(errorLogObj);
+        reportIssue(errorLogObj);
       },
     });
   }
@@ -137,24 +137,25 @@ export function getErrorHandledSync(func: Function) {
   };
 }
 
-function getIssueUrlQuery(errorLogObj: ErrorLog): string {
+function getIssueUrlQuery(errorLogObj?: ErrorLog): string {
   const baseUrl = 'https://github.com/frappe/books/issues/new?labels=bug';
 
-  const body = [
-    '<h2>Description</h2>',
-    'Add some description...',
-    '',
-    '<h2>Error Info</h2>',
-    '',
-    `**Error**: _${errorLogObj.name}: ${errorLogObj.message}_`,
-    '',
-  ];
+  const body = ['<h2>Description</h2>', 'Add some description...', ''];
 
-  if (errorLogObj.stack) {
+  if (errorLogObj) {
+    body.push(
+      '<h2>Error Info</h2>',
+      '',
+      `**Error**: _${errorLogObj.name}: ${errorLogObj.message}_`,
+      ''
+    );
+  }
+
+  if (errorLogObj?.stack) {
     body.push('**Stack**:', '```', errorLogObj.stack, '```', '');
   }
 
-  const { fullPath } = errorLogObj.more as { fullPath?: string };
+  const { fullPath } = (errorLogObj?.more as { fullPath?: string }) ?? {};
   if (fullPath) {
     body.push(`**Path**: \`${fullPath}\``);
   }
@@ -163,7 +164,7 @@ function getIssueUrlQuery(errorLogObj: ErrorLog): string {
   return encodeURI(url);
 }
 
-function createIssue(errorLogObj: ErrorLog) {
+export function reportIssue(errorLogObj?: ErrorLog) {
   const urlQuery = getIssueUrlQuery(errorLogObj);
   ipcRenderer.send(IPC_MESSAGES.OPEN_EXTERNAL, urlQuery);
 }

--- a/src/errorHandling.ts
+++ b/src/errorHandling.ts
@@ -76,10 +76,11 @@ export function handleError(
   // @ts-ignore
   frappe.errorLog.push(errorLogObj);
 
-  showToast(getToastProps(errorLogObj));
   // @ts-ignore
   if (frappe.SystemSettings.autoReportErrors) {
     reportError(errorLogObj);
+  } else {
+    showToast(getToastProps(errorLogObj));
   }
 }
 

--- a/src/errorHandling.ts
+++ b/src/errorHandling.ts
@@ -23,9 +23,18 @@ function shouldNotStore(error: Error) {
   );
 }
 
-function reportError(errorLogObj: ErrorLog) {
-  // push errorlog to frappebooks.com
-  console.log(errorLogObj);
+async function reportError(errorLogObj: ErrorLog) {
+  if (!errorLogObj.stack) {
+    return;
+  }
+
+  const body = {
+    error_name: errorLogObj.name,
+    message: errorLogObj.message,
+    stack: errorLogObj.stack,
+    more: JSON.stringify(errorLogObj.more ?? {}),
+  };
+  ipcRenderer.invoke(IPC_ACTIONS.SEND_ERROR, JSON.stringify(body));
 }
 
 function getToastProps(errorLogObj: ErrorLog) {

--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,11 @@ import Vue from 'vue';
 import models from '../models';
 import App from './App';
 import FeatherIcon from './components/FeatherIcon';
+import { handleError } from './errorHandling';
 import { IPC_MESSAGES } from './messages';
 import router from './router';
 import { outsideClickDirective } from './ui';
+import { stringifyCircular } from './utils';
 
 (async () => {
   frappe.isServer = true;
@@ -55,11 +57,22 @@ import { outsideClickDirective } from './ui';
   });
 
   Vue.config.errorHandler = (err, vm, info) => {
+    const { fullPath, params } = vm.$route;
+    const data = stringifyCircular(vm.$data, true, true);
+    const props = stringifyCircular(vm.$props, true, true);
+
+    handleError(false, err, {
+      fullPath,
+      params: stringifyCircular(params),
+      data,
+      props,
+      info,
+    });
     console.error(err, vm, info);
   };
 
   process.on('unhandledRejection', (error) => {
-    console.error(error);
+    handleError(true, error);
   });
 
   /* eslint-disable no-new */

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import Vue from 'vue';
 import models from '../models';
 import App from './App';
 import FeatherIcon from './components/FeatherIcon';
-import { handleError } from './errorHandling';
+import { getErrorHandled, handleError } from './errorHandling';
 import { IPC_MESSAGES } from './messages';
 import router from './router';
 import { outsideClickDirective } from './ui';
@@ -15,6 +15,9 @@ import { stringifyCircular } from './utils';
   frappe.isElectron = true;
   frappe.initializeAndRegister(models);
   frappe.fetch = window.fetch.bind();
+
+  ipcRenderer.send = getErrorHandled(ipcRenderer.send);
+  ipcRenderer.invoke = getErrorHandled(ipcRenderer.invoke);
 
   frappe.events.on('reload-main-window', () => {
     ipcRenderer.send(IPC_MESSAGES.RELOAD_MAIN_WINDOW);

--- a/src/messages.js
+++ b/src/messages.js
@@ -19,6 +19,7 @@ export const IPC_ACTIONS = {
   SAVE_HTML_AS_PDF: 'save-html-as-pdf',
   SAVE_DATA: 'save-data',
   SHOW_ERROR: 'show-error',
+  SEND_ERROR: 'send-error',
 };
 
 export const DB_CONN_FAILURE = {

--- a/src/pages/ChartOfAccounts.vue
+++ b/src/pages/ChartOfAccounts.vue
@@ -12,10 +12,18 @@
       <div class="flex-1" v-if="root">
         <template v-for="account in allAccounts">
           <div
-            class="mt-2 px-4 py-2 cursor-pointer hover:bg-gray-100 rounded-md group"
+            class="
+              mt-2
+              px-4
+              py-2
+              cursor-pointer
+              hover:bg-gray-100
+              rounded-md
+              group
+            "
             :class="[
               account.level !== 0 ? 'text-base' : 'text-lg',
-              isQuickEditOpen(account) ? 'bg-gray-200' : ''
+              isQuickEditOpen(account) ? 'bg-gray-200' : '',
             ]"
             :key="account.name"
             @click="onClick(account)"
@@ -34,13 +42,22 @@
                   class="ml-6 hidden group-hover:block"
                 >
                   <button
-                    class="text-xs text-gray-800 hover:text-gray-900 focus:outline-none"
+                    class="
+                      text-xs text-gray-800
+                      hover:text-gray-900
+                      focus:outline-none
+                    "
                     @click.stop="addAccount(account, 'addingAccount')"
                   >
                     {{ t('Add Account') }}
                   </button>
                   <button
-                    class="ml-3 text-xs text-gray-800 hover:text-gray-900 focus:outline-none"
+                    class="
+                      ml-3
+                      text-xs text-gray-800
+                      hover:text-gray-900
+                      focus:outline-none
+                    "
                     @click.stop="addAccount(account, 'addingGroupAccount')"
                   >
                     {{ t('Add Group') }}
@@ -51,7 +68,15 @@
           </div>
           <div
             v-if="account.addingAccount || account.addingGroupAccount"
-            class="mt-2 px-4 py-2 cursor-pointer hover:bg-gray-100 rounded-md group"
+            class="
+              mt-2
+              px-4
+              py-2
+              cursor-pointer
+              hover:bg-gray-100
+              rounded-md
+              group
+            "
             :class="[account.level !== 0 ? 'text-base' : 'text-lg']"
             :key="account.name + '-adding-account'"
           >
@@ -71,7 +96,7 @@
                     :ref="account.name"
                     @keydown.esc="cancelAddingAccount(account)"
                     @keydown.enter="
-                      e =>
+                      (e) =>
                         createNewAccount(
                           e.target.value,
                           account,
@@ -83,7 +108,12 @@
                   />
                   <button
                     v-if="!insertingAccount"
-                    class="ml-4 text-xs text-gray-800 hover:text-gray-900 focus:outline-none"
+                    class="
+                      ml-4
+                      text-xs text-gray-800
+                      hover:text-gray-900
+                      focus:outline-none
+                    "
                     @click="cancelAddingAccount(account)"
                   >
                     {{ t('Cancel') }}
@@ -101,19 +131,20 @@
 import frappe from 'frappe';
 import PageHeader from '@/components/PageHeader';
 import SearchBar from '@/components/SearchBar';
-import { openQuickEdit, handleErrorWithDialog } from '@/utils';
+import { openQuickEdit } from '@/utils';
+import { handleErrorWithDialog } from '../errorHandling';
 
 export default {
   components: {
     PageHeader,
-    SearchBar
+    SearchBar,
   },
   data() {
     return {
       root: null,
       accounts: [],
       doctype: 'Account',
-      insertingAccount: false
+      insertingAccount: false,
     };
   },
   mounted() {
@@ -130,7 +161,7 @@ export default {
       this.root = {
         label: await this.settings.getRootLabel(),
         balance: 0,
-        currency
+        currency,
       };
       this.accounts = await this.getChildren();
     },
@@ -138,7 +169,7 @@ export default {
       if (account.isGroup === 0) {
         openQuickEdit({
           doctype: 'Account',
-          name: account.name
+          name: account.name,
         });
       } else {
         this.toggleChildren(account);
@@ -180,7 +211,7 @@ export default {
               <path d="M7.332 11.36l4.666-3.734 2 1.6V.666A.667.667 0 0013.332 0h-12a.667.667 0 00-.667.667v14.666c0 .369.298.667.667.667h6v-4.64zm-4-7.36H11.3v1.333H3.332V4zm2.666 8H3.332v-1.333h2.666V12zM3.332 8.667V7.333h5.333v1.334H3.332z" fill="#415668"/>
               <path d="M15.332 12l-3.334-2.667L8.665 12v3.333c0 .369.298.667.667.667h2v-2h1.333v2h2a.667.667 0 00.667-.667V12z" fill="#A1ABB4"/>
             </g>
-          </svg>`
+          </svg>`,
       };
 
       let leaf = `<svg class="w-2 h-2" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
@@ -194,7 +225,7 @@ export default {
       let icon = account.isGroup ? folder : leaf;
 
       let c = {
-        template: icons[account.name] || icon
+        template: icons[account.name] || icon,
       };
 
       return c;
@@ -203,7 +234,7 @@ export default {
       const children = await frappe.db.getAll({
         doctype: this.doctype,
         filters: {
-          parentAccount: parent
+          parentAccount: parent,
         },
         fields: [
           'name',
@@ -211,13 +242,13 @@ export default {
           'isGroup',
           'balance',
           'rootType',
-          'accountType'
+          'accountType',
         ],
         orderBy: 'name',
-        order: 'asc'
+        order: 'asc',
       });
 
-      return children.map(d => {
+      return children.map((d) => {
         d.expanded = 0;
         d.addingAccount = 0;
         d.addingGroupAccount = 0;
@@ -260,7 +291,7 @@ export default {
           parentAccount: name,
           rootType,
           accountType,
-          isGroup
+          isGroup,
         });
         await account.insert();
 
@@ -275,7 +306,7 @@ export default {
         // open quick edit
         openQuickEdit({
           doctype: 'Account',
-          name: account.name
+          name: account.name,
         });
         // unfreeze input
         this.insertingAccount = false;
@@ -291,7 +322,7 @@ export default {
         return true;
       }
       return false;
-    }
+    },
   },
   computed: {
     allAccounts() {
@@ -308,7 +339,7 @@ export default {
           }
         }
       }
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/pages/DatabaseSelector.vue
+++ b/src/pages/DatabaseSelector.vue
@@ -159,7 +159,7 @@ import { ipcRenderer } from 'electron';
 import { DB_CONN_FAILURE, IPC_ACTIONS } from '../messages';
 
 import { createNewDatabase, connectToLocalDatabase } from '@/initialization';
-import { showErrorDialog } from '../utils';
+import { showErrorDialog } from '../errorHandling';
 
 export default {
   name: 'DatabaseSelector',

--- a/src/pages/DatabaseSelector.vue
+++ b/src/pages/DatabaseSelector.vue
@@ -217,21 +217,20 @@ export default {
       );
       this.loadingDatabase = false;
 
-      const title = 'DB Connection Error';
-
       if (connectionSuccess) {
         this.$emit('database-connect');
-      } else if (reason === DB_CONN_FAILURE.CANT_OPEN) {
-        await showErrorDialog({
-          title,
-          content: `Can't open database file: ${filePath}, please create a new file.`,
-        });
-      } else {
-        await showErrorDialog({
-          title,
-          content: `Please select an existing database or create a new one. reason: ${reason}, filePath: ${filePath}`,
-        });
+        return;
       }
+
+      const title = this.t`DB Connection Error`;
+      let content = this
+        .t`Please select an existing database or create a new one. reason: ${reason}, filePath: ${filePath}`;
+      if (reason === DB_CONN_FAILURE.CANT_OPEN) {
+        content = this
+          .t`Can't open database file: ${filePath}, please create a new file.`;
+      }
+
+      await showErrorDialog(title, content);
     },
     getFileLastModified(filePath) {
       let stats = fs.statSync(filePath);

--- a/src/pages/InvoiceForm.vue
+++ b/src/pages/InvoiceForm.vue
@@ -197,12 +197,12 @@ import DropdownWithActions from '@/components/DropdownWithActions';
 import BackLink from '@/components/BackLink';
 import {
   openSettings,
-  handleErrorWithDialog,
   getActionsForDocument,
   getInvoiceStatus,
   showMessageDialog,
-  routeTo
+  routeTo,
 } from '@/utils';
+import { handleErrorWithDialog } from '../errorHandling';
 
 export default {
   name: 'InvoiceForm',
@@ -286,7 +286,7 @@ export default {
       return this.doc.insertOrUpdate().catch(this.handleError);
     },
     onSubmitClick() {
-        let message =
+      let message =
         this.doctype === 'SalesInvoice'
           ? this.t('Are you sure you want to submit this Invoice?')
           : this.t('Are you sure you want to submit this Bill?');

--- a/src/pages/JournalEntryForm.vue
+++ b/src/pages/JournalEntryForm.vue
@@ -124,11 +124,11 @@ import FormControl from '@/components/Controls/FormControl';
 import BackLink from '@/components/BackLink';
 import StatusBadge from '@/components/StatusBadge';
 import {
-  handleErrorWithDialog,
   showMessageDialog,
   getActionsForDocument,
   routeTo,
 } from '@/utils';
+import { handleErrorWithDialog } from '../errorHandling';
 
 export default {
   name: 'JournalEntryForm',

--- a/src/pages/QuickEditForm.vue
+++ b/src/pages/QuickEditForm.vue
@@ -87,7 +87,6 @@ import DropdownWithActions from '@/components/DropdownWithActions';
 import {
   openQuickEdit,
   getActionsForDocument,
-  handleErrorWithDialog,
 } from '@/utils';
 
 export default {

--- a/src/pages/SetupWizard/SetupWizard.vue
+++ b/src/pages/SetupWizard/SetupWizard.vue
@@ -163,10 +163,9 @@ export default {
         await setupCompany(this.doc);
         this.$emit('setup-complete');
       } else {
-        await showErrorDialog({
-          title: 'DB Connection Error',
-          content: `reason: ${reason}, filePath: ${filePath}`,
-        });
+        const title = this.t`DB Connection Error`;
+        const content = this.t`reason: ${reason}, filePath: ${filePath}`;
+        await showErrorDialog(title, content);
       }
     },
   },

--- a/src/pages/SetupWizard/SetupWizard.vue
+++ b/src/pages/SetupWizard/SetupWizard.vue
@@ -52,7 +52,9 @@
       <TwoColumnForm :fields="fields" :doc="doc" />
     </div>
     <div class="flex justify-between px-8 mt-5 window-no-drag">
-      <Button class="text-sm text-grey-900" @click="$emit('setup-canceled')">Cancel</Button>
+      <Button class="text-sm text-grey-900" @click="$emit('setup-canceled')"
+        >Cancel</Button
+      >
       <Button
         @click="submit"
         type="primary"
@@ -75,12 +77,12 @@ import config from '@/config';
 import path from 'path';
 import fs from 'fs';
 import { purgeCache, connectToLocalDatabase } from '@/initialization';
+import { showMessageDialog } from '@/utils';
 import {
-  getErrorMessage,
   handleErrorWithDialog,
-  showMessageDialog,
+  getErrorMessage,
   showErrorDialog,
-} from '@/utils';
+} from '../../errorHandling';
 
 export default {
   name: 'SetupWizard',

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@ import frappe from 'frappe';
 import { isPesa, t } from 'frappe/utils';
 import lodash from 'lodash';
 import Vue from 'vue';
+import { handleErrorWithDialog } from './errorHandling';
 import { IPC_ACTIONS, IPC_MESSAGES } from './messages';
 
 export async function showMessageDialog({
@@ -28,16 +29,6 @@ export async function showMessageDialog({
   if (button && button.action) {
     button.action();
   }
-}
-
-export async function showErrorDialog({ title, content }) {
-  // To be used for  show stopper errors
-  title = title ?? 'Error';
-  content =
-    content ??
-    'Something has gone terribly wrong. Please check the console and raise an issue.';
-
-  await ipcRenderer.invoke(IPC_ACTIONS.SHOW_ERROR, { title, content });
 }
 
 export function deleteDocWithPrompt(doc) {
@@ -149,27 +140,6 @@ export function openQuickEdit({ doctype, name, hideFields, defaults = {} }) {
       lastRoute: currentRoute,
     },
   });
-}
-
-export function getErrorMessage(e, doc) {
-  let errorMessage = e.message || t('An error occurred.');
-  const { doctype, name } = doc;
-  const canElaborate = doctype && name;
-  if (e.type === frappe.errors.LinkValidationError && canElaborate) {
-    errorMessage = t('{0} {1} is linked with existing records.', [
-      doctype,
-      name,
-    ]);
-  } else if (e.type === frappe.errors.DuplicateEntryError && canElaborate) {
-    errorMessage = t('{0} {1} already exists.', [doctype, name]);
-  }
-  return errorMessage;
-}
-
-export function handleErrorWithDialog(e, doc) {
-  let errorMessage = getErrorMessage(e, doc);
-  showMessageDialog({ message: errorMessage });
-  throw e;
 }
 
 export async function makePDF(html, savePath) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -412,3 +412,34 @@ export function formatXLabels(label) {
 
   return `${month} ${year}`;
 }
+
+export function stringifyCircular(
+  obj,
+  ignoreCircular = false,
+  convertBaseDocument = false
+) {
+  const cacheKey = [];
+  const cacheValue = [];
+
+  return JSON.stringify(obj, (key, value) => {
+    if (typeof value !== 'object' || value === null) {
+      cacheKey.push(key);
+      cacheValue.push(value);
+      return value;
+    }
+
+    if (cacheValue.includes(value)) {
+      const circularKey = cacheKey[cacheValue.indexOf(value)] || '{self}';
+      return ignoreCircular ? undefined : `[Circular:${circularKey}]`;
+    }
+
+    cacheKey.push(key);
+    cacheValue.push(value);
+
+    if (convertBaseDocument && value instanceof frappe.BaseDocument) {
+      return value.getValidDict();
+    }
+
+    return value;
+  });
+}


### PR DESCRIPTION
Something to ease the logging of errors. Primarily:
- **Report Issue** button which leads to Github issues.
- Show toast on error.
- On clicking the toast, new issue page with error stack, and since intent is to report, send report to frappebooks.com
- System setting to auto report and hide the errors

closes https://github.com/frappe/books/issues/296