### PR TITLE
Colored toasts

### DIFF
--- a/models/doctype/Transaction/Transaction.js
+++ b/models/doctype/Transaction/Transaction.js
@@ -1,7 +1,8 @@
+import Badge from '@/components/Badge';
+import { getInvoiceStatus, openQuickEdit, routeTo } from '@/utils';
 import frappe from 'frappejs';
 import utils from '../../../accounting/utils';
-import { openQuickEdit, getInvoiceStatus, statusColor, routeTo } from '@/utils';
-import Badge from '@/components/Badge';
+import { statusColor } from '../../../src/colors';
 
 export function getStatusColumn() {
   return {

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,0 +1,26 @@
+export const statusColor = {
+  Draft: 'gray',
+  Unpaid: 'orange',
+  Paid: 'green',
+  Cancelled: 'red',
+};
+
+const getValidColor = (color) => {
+  const isValid = ['gray', 'orange', 'green', 'red', 'yellow', 'blue'].includes(
+    color
+  );
+  return isValid ? color : 'gray';
+};
+
+export function getBgColorClass(color) {
+  return `bg-${getValidColor(color)}-100`;
+}
+export function getTextColorClass(color) {
+  return `text-${getValidColor(color)}-600`;
+}
+
+export function getColorClass(color) {
+  const bg = getBgColorClass(color);
+  const text = getTextColorClass(color);
+  return [bg, text].join(' ');
+}

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -1,31 +1,23 @@
 <template>
-  <div
-    class="inline-block rounded-md px-2 py-1 truncate"
-    :class="getColorClass"
-  >
+  <div class="inline-block rounded-md px-2 py-1 truncate" :class="colorClass">
     <slot></slot>
   </div>
 </template>
 
 <script>
+import { getColorClass } from '../colors';
+
 export default {
   name: 'Badge',
   props: {
     color: {
-      default: 'gray'
-    }
+      default: 'gray',
+    },
   },
   computed: {
-    getColorClass() {
-      return {
-        gray: 'bg-gray-100 text-gray-600',
-        red: 'bg-red-100 text-red-600',
-        yellow: 'bg-yellow-100 text-yellow-600',
-        orange: 'bg-orange-100 text-orange-600',
-        blue: 'bg-blue-100 text-blue-600',
-        green: 'bg-green-100 text-green-600'
-      }[this.color];
-    }
-  }
+    colorClass() {
+      return getColorClass(this.color);
+    },
+  },
 };
 </script>

--- a/src/components/StatusBadge.vue
+++ b/src/components/StatusBadge.vue
@@ -4,7 +4,7 @@
   }}</Badge>
 </template>
 <script>
-import { statusColor } from '@/utils';
+import { statusColor } from '../colors';
 import Badge from '@/components/Badge';
 
 export default {

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -2,7 +2,6 @@
   <div
     class="
       text-gray-900
-      bg-white
       shadow-md
       px-3
       py-2
@@ -12,20 +11,31 @@
       mb-3
       w-60
     "
+    :class="bgColor"
     style="transition: opacity 150ms ease-in"
     :style="{ opacity }"
     v-if="show"
   >
-    <feather-icon name="alert-circle" class="w-8 h-8 mr-3 text-gray-800" />
+    <feather-icon
+      :name="iconName"
+      class="w-8 h-8 mr-3 text-gray-800"
+      :class="iconColor"
+    />
     <div>
       <p class="text-base">{{ message }}</p>
-      <button v-if="actionText" @click="action" class="text-sm text-gray-700 hover:text-gray-800">
+      <button
+        v-if="actionText"
+        @click="action"
+        class="text-sm text-gray-700 hover:text-gray-800"
+      >
         {{ actionText }}
       </button>
     </div>
   </div>
 </template>
 <script>
+import { getBgColorClass, getTextColorClass } from '../colors';
+
 export default {
   data() {
     return { opacity: 0, show: true };
@@ -34,7 +44,34 @@ export default {
     message: String,
     action: Function,
     actionText: String,
+    type: { type: String, default: 'info' },
     duration: { type: Number, default: 5000 },
+  },
+  computed: {
+    iconName() {
+      switch (this.type) {
+        case 'warning':
+          return 'alert-triangle';
+        case 'success':
+          return 'check-circle';
+        default:
+          return 'alert-circle';
+      }
+    },
+    color() {
+      return {
+        info: 'blue',
+        warning: 'orange',
+        error: 'red',
+        success: 'green',
+      }[this.type];
+    },
+    bgColor() {
+      return getBgColorClass(this.color);
+    },
+    iconColor() {
+      return getTextColorClass(this.color);
+    },
   },
   mounted() {
     const mountTarget = document.createElement('div');

--- a/src/pages/Settings/Settings.vue
+++ b/src/pages/Settings/Settings.vue
@@ -114,8 +114,9 @@ export default {
   methods: {
     showReloadToast() {
       showToast({
-        message: _('Changes will be visible on reload'),
+        message: _('Changes require reload'),
         actionText: frappe._('Reload'),
+        type: 'info',
         action: async () => {
           frappe.events.trigger('reload-main-window');
         },

--- a/src/utils.js
+++ b/src/utils.js
@@ -257,13 +257,6 @@ export async function runWindowAction(name) {
   return name;
 }
 
-export const statusColor = {
-  Draft: 'gray',
-  Unpaid: 'orange',
-  Paid: 'green',
-  Cancelled: 'red',
-};
-
 export function getInvoiceStatus(doc) {
   let status = 'Unpaid';
   if (!doc.submitted) {
@@ -349,6 +342,7 @@ export function showToast(props) {
     },
   });
 }
+window.showToast = showToast;
 
 export function titleCase(phrase) {
   return phrase

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,6 +181,7 @@ export function showExportInFolder(message, filePath) {
   showToast({
     message,
     actionText: frappe._('Open Folder'),
+    type: 'success',
     action: async () => {
       await showItemInFolder(filePath);
     },
@@ -342,7 +343,6 @@ export function showToast(props) {
     },
   });
 }
-window.showToast = showToast;
 
 export function titleCase(phrase) {
   return phrase


### PR DESCRIPTION
Added types to toasts:
![Screen Shot 2022-01-19 at 15 53 30](https://user-images.githubusercontent.com/29507195/150111825-da08f643-d848-4e80-8a6d-6b83ded55b9f.png)


```typescript
type type = 'info' | 'warning' | 'error' | 'success'
```

Default type is `info`