### PR TITLE
refactor: recode and replace the bar chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "csvjson-csv2json": "^5.0.6",
     "electron-store": "^8.0.1",
     "feather-icons": "^4.28.0",
-    "frappe-charts": "1.6.1",
     "knex": "^0.95.12",
     "lodash": "^4.17.21",
     "luxon": "^2.0.2",

--- a/src/components/Charts/BarChart.vue
+++ b/src/components/Charts/BarChart.vue
@@ -50,7 +50,7 @@
           :x="xs[i - 1]"
           text-anchor="middle"
         >
-          {{ xLabels[i - 1] || '' }}
+          {{ j % skipXLabel === 0 ? formatX(xLabels[i - 1] || '') : '' }}
         </text>
       </template>
 
@@ -121,7 +121,7 @@
       class="text-sm shadow-md px-2 py-1 bg-white text-gray-900 border-l-2"
       :style="{ borderColor: activeColor }"
     >
-      {{ xi > -1 ? xLabels[xi] : '' }}
+      {{ xi > -1 ? xLabels[xi] : '' }} – 
       {{ yi > -1 ? format(points[yi][xi]) : '' }}
     </Tooltip>
   </div>
@@ -132,6 +132,7 @@ import Tooltip from '../Tooltip.vue';
 
 export default {
   props: {
+    skipXLabel: { type: Number, default: 2 },
     colors: { type: Array, default: () => [] },
     xLabels: { type: Array, default: () => [] },
     yLabelDivisions: { type: Number, default: 4 },
@@ -139,27 +140,27 @@ export default {
     drawAxis: { type: Boolean, default: false },
     drawXGrid: { type: Boolean, default: true },
     viewBoxHeight: { type: Number, default: 500 },
-    aspectRatio: { type: Number, default: 1.75 },
+    aspectRatio: { type: Number, default: 2.1 },
     axisPadding: { type: Number, default: 30 },
-    pointsPadding: { type: Number, default: 24 },
-    xLabelOffset: { type: Number, default: 5 },
-    yLabelOffset: { type: Number, default: 5 },
+    pointsPadding: { type: Number, default: 40 },
+    xLabelOffset: { type: Number, default: 20 },
+    yLabelOffset: { type: Number, default: 0 },
     gridColor: { type: String, default: 'rgba(0, 0, 0, 0.2)' },
     zeroLineColor: { type: String, default: 'rgba(0, 0, 0, 0.2)' },
     axisColor: { type: String, default: 'rgba(0, 0, 0, 0.5)' },
-    thickness: { type: Number, default: 5 },
     axisThickness: { type: Number, default: 1 },
     gridThickness: { type: Number, default: 0.5 },
     yMin: { type: Number, default: null },
     yMax: { type: Number, default: null },
     format: { type: Function, default: (n) => n.toFixed(1) },
     formatY: { type: Function, default: prefixFormat },
-    fontSize: { type: Number, default: 18 },
+    formatX: { type: Function, default: (v) => v },
+    fontSize: { type: Number, default: 25 },
     fontColor: { type: String, default: '#415668' },
     bottom: { type: Number, default: 0 },
-    width: { type: Number, default: 30 },
-    left: { type: Number, default: 55 },
-    radius: { type: Number, default: 15 },
+    width: { type: Number, default: 34 },
+    left: { type: Number, default: 65 },
+    radius: { type: Number, default: 17 },
     extendGridX: { type: Number, default: -20 },
     tooltipDispDistThreshold: { type: Number, default: 20 },
     drawZeroLine: { type: Boolean, default: true },

--- a/src/components/Charts/BarChart.vue
+++ b/src/components/Charts/BarChart.vue
@@ -1,0 +1,345 @@
+<template>
+  <div>
+    <svg
+      ref="chartSvg"
+      :viewBox="`0 0 ${viewBoxWidth} ${viewBoxHeight}`"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <!-- x Grid Lines -->
+      <path
+        v-if="drawXGrid"
+        :d="xGrid"
+        :stroke="gridColor"
+        :stroke-width="gridThickness"
+        stroke-linecap="round"
+        fill="transparent"
+      />
+
+      <!-- zero line -->
+      <path
+        v-if="drawZeroLine"
+        :d="zLine"
+        :stroke="zeroLineColor"
+        :stroke-width="gridThickness"
+        stroke-linecap="round"
+        fill="transparent"
+      />
+
+      <!-- Axis -->
+      <path
+        v-if="drawAxis"
+        :d="axis"
+        :stroke-width="axisThickness"
+        :stroke="axisColor"
+        fill="transparent"
+      />
+
+      <!-- x Labels -->
+      <template v-if="xLabels.length > 0">
+        <text
+          :style="fontStyle"
+          v-for="(i, j) in count"
+          :key="j + '-xlabels'"
+          :y="
+            viewBoxHeight -
+            axisPadding +
+            yLabelOffset +
+            fontStyle.fontSize / 2 -
+            bottom
+          "
+          :x="xs[i - 1]"
+          text-anchor="middle"
+        >
+          {{ xLabels[i - 1] || '' }}
+        </text>
+      </template>
+
+      <!-- y Labels -->
+      <template v-if="yLabelDivisions > 0">
+        <text
+          :style="fontStyle"
+          v-for="(i, j) in yLabelDivisions + 1"
+          :key="j + '-ylabels'"
+          :y="yScalerLocation(i - 1)"
+          :x="axisPadding - xLabelOffset + left"
+          text-anchor="end"
+        >
+          {{ yScalerValue(i - 1) }}
+        </text>
+      </template>
+
+      <defs>
+        <clipPath id="positive-rect-clip">
+          <rect x="0" y="0" :width="viewBoxWidth" :height="z" />
+        </clipPath>
+        <clipPath id="negative-rect-clip">
+          <rect
+            x="0"
+            :y="z"
+            :width="viewBoxWidth"
+            :height="viewBoxHeight - z"
+          />
+        </clipPath>
+      </defs>
+
+      <rect
+        v-for="(rec, i) in positiveRects"
+        :key="i + 'prec'"
+        :rx="radius"
+        :ry="radius"
+        :x="rec.x"
+        :y="rec.y"
+        :width="width"
+        :height="rec.height"
+        :fill="rec.color"
+        @mouseenter="() => create(rec.xi, rec.yi)"
+        @mousemove="update"
+        @mouseleave="destroy"
+        clip-path="url(#positive-rect-clip)"
+      />
+
+      <rect
+        v-for="(rec, i) in negativeRects"
+        :key="i + 'nrec'"
+        :rx="radius"
+        :ry="radius"
+        :x="rec.x"
+        :y="rec.y"
+        :width="width"
+        :height="rec.height"
+        :fill="rec.color"
+        @mouseenter="() => create(rec.xi, rec.yi)"
+        @mousemove="update"
+        @mouseleave="destroy"
+        clip-path="url(#negative-rect-clip)"
+      />
+    </svg>
+    <Tooltip
+      ref="tooltip"
+      :offset="15"
+      placement="top"
+      class="text-sm shadow-md px-2 py-1 bg-white text-gray-900 border-l-2"
+      :style="{ borderColor: activeColor }"
+    >
+      {{ xi > -1 ? xLabels[xi] : '' }}
+      {{ yi > -1 ? format(points[yi][xi]) : '' }}
+    </Tooltip>
+  </div>
+</template>
+<script>
+import { prefixFormat } from './chartUtils';
+import Tooltip from '../Tooltip.vue';
+
+export default {
+  props: {
+    colors: { type: Array, default: () => [] },
+    xLabels: { type: Array, default: () => [] },
+    yLabelDivisions: { type: Number, default: 4 },
+    points: { type: Array, default: () => [[]] },
+    drawAxis: { type: Boolean, default: false },
+    drawXGrid: { type: Boolean, default: true },
+    viewBoxHeight: { type: Number, default: 500 },
+    aspectRatio: { type: Number, default: 1.75 },
+    axisPadding: { type: Number, default: 30 },
+    pointsPadding: { type: Number, default: 24 },
+    xLabelOffset: { type: Number, default: 5 },
+    yLabelOffset: { type: Number, default: 5 },
+    gridColor: { type: String, default: 'rgba(0, 0, 0, 0.2)' },
+    zeroLineColor: { type: String, default: 'rgba(0, 0, 0, 0.2)' },
+    axisColor: { type: String, default: 'rgba(0, 0, 0, 0.5)' },
+    thickness: { type: Number, default: 5 },
+    axisThickness: { type: Number, default: 1 },
+    gridThickness: { type: Number, default: 0.5 },
+    yMin: { type: Number, default: null },
+    yMax: { type: Number, default: null },
+    format: { type: Function, default: (n) => n.toFixed(1) },
+    formatY: { type: Function, default: prefixFormat },
+    fontSize: { type: Number, default: 18 },
+    fontColor: { type: String, default: '#415668' },
+    bottom: { type: Number, default: 0 },
+    width: { type: Number, default: 30 },
+    left: { type: Number, default: 55 },
+    radius: { type: Number, default: 15 },
+    extendGridX: { type: Number, default: -20 },
+    tooltipDispDistThreshold: { type: Number, default: 20 },
+    drawZeroLine: { type: Boolean, default: true },
+  },
+  computed: {
+    inverseMatrix() {
+      return this.$refs.chartSvg.getScreenCTM().inverse();
+    },
+    fontStyle() {
+      return { fontSize: this.fontSize, fill: this.fontColor };
+    },
+    viewBoxWidth() {
+      return this.aspectRatio * this.viewBoxHeight;
+    },
+    num() {
+      return this.points.length;
+    },
+    count() {
+      return Math.max(...this.points.map((p) => p.length));
+    },
+    xs() {
+      return Array(this.count)
+        .fill()
+        .map(
+          (_, i) =>
+            this.padding +
+            this.left +
+            (i * (this.viewBoxWidth - this.left - 2 * this.padding)) /
+              (this.count - 1)
+        );
+    },
+    z() {
+      return this.getViewBoxY(0);
+    },
+    ys() {
+      return this.points.map((pp) => pp.map(this.getViewBoxY));
+    },
+    xy() {
+      return this.xs.map((x, i) => [x, this.ys.map((y) => y[i])]);
+    },
+    min() {
+      return Math.min(...this.points.flat());
+    },
+    max() {
+      return Math.max(...this.points.flat());
+    },
+    axis() {
+      return `M ${this.axisPadding + this.left} ${this.axisPadding} V ${
+        this.viewBoxHeight - this.axisPadding - this.bottom
+      } H ${this.viewBoxWidth - this.axisPadding}`;
+    },
+    padding() {
+      return this.axisPadding + this.pointsPadding;
+    },
+    xGrid() {
+      const { l, r } = this.xLims;
+      const lo = l + this.extendGridX;
+      const ro = r - this.extendGridX;
+      const ys = Array(this.yLabelDivisions + 1)
+        .fill()
+        .map((_, i) => this.yScalerLocation(i));
+      return ys.map((y) => `M ${lo} ${y} H ${ro}`).join(' ');
+    },
+    yGrid() {
+      return [];
+    },
+    zLine() {
+      const { l, r } = this.xLims;
+      const lo = l + this.extendGridX;
+      const ro = r - this.extendGridX;
+      return `M ${lo} ${this.z} H ${ro}`;
+    },
+    xLims() {
+      const l = this.padding + this.left;
+      const r = this.viewBoxWidth - this.padding;
+      return { l, r };
+    },
+    positiveRects() {
+      return this.rects.flat().filter(({ isPositive }) => isPositive);
+    },
+    negativeRects() {
+      return this.rects.flat().filter(({ isPositive }) => !isPositive);
+    },
+    rects() {
+      return this.xy.map(([x, ys], i) =>
+        ys.map((y, j) => this.getRect(x, y, i, j))
+      );
+    },
+  },
+  data() {
+    return { xi: -1, yi: -1, activeColor: 'rgba(0, 0, 0, 0.2)' };
+  },
+  methods: {
+    gradY(i) {
+      return Math.min(...this.ys[i]).toFixed();
+    },
+    getViewBoxY(value) {
+      const min = this.yMin ?? this.min;
+      const max = this.yMax ?? this.max;
+      return (
+        this.padding +
+        (1 - (value - min) / (max - min)) *
+          (this.viewBoxHeight - 2 * this.padding - this.bottom)
+      );
+    },
+    getRect(px, py, i, j) {
+      const isPositive = py <= this.z;
+      const x = px - (this.width * this.num) / 2 + j * this.width;
+      const y = isPositive ? py : this.z - this.radius;
+      const h = Math.abs(py - this.z);
+      const height = h + this.radius;
+      const color = this.getColor(j, isPositive);
+      return { x, y, height, color, isPositive, xi: i, yi: j };
+    },
+    getColor(j, isPositive) {
+      if (this.colors.length > 0) {
+        const c = this.colors[j];
+        return typeof c === 'string'
+          ? c
+          : c[isPositive ? 'positive' : 'negative'];
+      }
+      return this.getRandomColor();
+    },
+    yScalerLocation(i) {
+      return (
+        ((this.yLabelDivisions - i) *
+          (this.viewBoxHeight - this.padding * 2 - this.bottom)) /
+          this.yLabelDivisions +
+        this.padding
+      );
+    },
+    yScalerValue(i) {
+      const max = this.yMax ?? this.max;
+      const min = this.yMin ?? this.min;
+      return this.formatY((i * (max - min)) / this.yLabelDivisions + min);
+    },
+    getLine(i) {
+      const [x, y] = this.xy[0];
+      let d = `M ${x} ${y[i]} `;
+      this.xy.slice(1).forEach(([x, y]) => {
+        d += `L ${x} ${y[i]} `;
+      });
+      return d;
+    },
+    getGradLine(i) {
+      let bo = this.viewBoxHeight - this.padding - this.bottom;
+      let d = `M ${this.padding + this.left} ${bo}`;
+      this.xy.forEach(([x, y]) => {
+        d += `L ${x} ${y[i]} `;
+      });
+      return d + ` V ${bo} Z`;
+    },
+    getRandomColor() {
+      const rgb = Array(3)
+        .fill()
+        .map(() => parseInt(Math.random() * 255))
+        .join(',');
+      return `rgb(${rgb})`;
+    },
+    create(xi, yi) {
+      this.xi = xi;
+      this.yi = yi;
+      this.activeColor = this.getColor(yi, this.points[yi][xi] > 0);
+      this.$refs.tooltip.create();
+    },
+    update(event) {
+      this.$refs.tooltip.update(event);
+    },
+    destroy() {
+      this.xi = -1;
+      this.yi = -1;
+      this.$refs.tooltip.destroy();
+    },
+  },
+  components: { Tooltip },
+};
+</script>
+
+<style scoped>
+rect:hover {
+  filter: brightness(115%);
+}
+</style>

--- a/src/components/Charts/LineChart.vue
+++ b/src/components/Charts/LineChart.vue
@@ -41,7 +41,7 @@
           :x="xs[i - 1]"
           text-anchor="middle"
         >
-          {{ xLabels[i - 1] || '' }}
+          {{ formatX(xLabels[i - 1] || '') }}
         </text>
       </template>
 
@@ -119,7 +119,7 @@
       class="text-sm shadow-md px-2 py-1 bg-white text-gray-900 border-l-2"
       :style="{ borderColor: colors[yi] }"
     >
-      {{ xi > -1 ? xLabels[xi] : '' }}
+      {{ xi > -1 ? xLabels[xi] : '' }} –
       {{ yi > -1 ? format(points[yi][xi]) : '' }}
     </Tooltip>
   </div>
@@ -140,7 +140,7 @@ export default {
     aspectRatio: { type: Number, default: 3.5 },
     axisPadding: { type: Number, default: 30 },
     pointsPadding: { type: Number, default: 24 },
-    xLabelOffset: { type: Number, default: 5 },
+    xLabelOffset: { type: Number, default: 20 },
     yLabelOffset: { type: Number, default: 5 },
     gridColor: { type: String, default: 'rgba(0, 0, 0, 0.2)' },
     axisColor: { type: String, default: 'rgba(0, 0, 0, 0.5)' },
@@ -151,6 +151,7 @@ export default {
     yMax: { type: Number, default: null },
     format: { type: Function, default: (n) => n.toFixed(1) },
     formatY: { type: Function, default: prefixFormat },
+    formatX: { type: Function, default: (v) => v },
     fontSize: { type: Number, default: 18 },
     fontColor: { type: String, default: '#415668' },
     bottom: { type: Number, default: 0 },

--- a/src/components/Charts/chartUtils.ts
+++ b/src/components/Charts/chartUtils.ts
@@ -31,6 +31,10 @@ export function euclideanDistance(
 
 export function getYMax(points: Array<Array<number>>): number {
   const maxVal = Math.max(...points.flat());
+  if (maxVal === 0) {
+    return 0;
+  }
+
   const sign = maxVal >= 0 ? 1 : -1;
   const texp = 10 ** Math.floor(Math.log10(Math.abs(maxVal)));
   if (sign === 1) {
@@ -41,6 +45,10 @@ export function getYMax(points: Array<Array<number>>): number {
 
 export function getYMin(points: Array<Array<number>>): number {
   const minVal = Math.min(...points.flat());
+  if (minVal === 0) {
+    return minVal;
+  }
+
   const sign = minVal >= 0 ? 1 : -1;
   const texp = 10 ** Math.floor(Math.log10(Math.abs(minVal)));
   if (sign === 1) {

--- a/src/components/Charts/chartUtils.ts
+++ b/src/components/Charts/chartUtils.ts
@@ -28,3 +28,23 @@ export function euclideanDistance(
   const dsq = Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2);
   return Math.sqrt(dsq);
 }
+
+export function getYMax(points: Array<Array<number>>): number {
+  const maxVal = Math.max(...points.flat());
+  const sign = maxVal >= 0 ? 1 : -1;
+  const texp = 10 ** Math.floor(Math.log10(Math.abs(maxVal)));
+  if (sign === 1) {
+    return Math.ceil(maxVal / texp) * texp;
+  }
+  return Math.floor(maxVal / texp) * texp;
+}
+
+export function getYMin(points: Array<Array<number>>): number {
+  const minVal = Math.min(...points.flat());
+  const sign = minVal >= 0 ? 1 : -1;
+  const texp = 10 ** Math.floor(Math.log10(Math.abs(minVal)));
+  if (sign === 1) {
+    return Math.ceil(minVal / texp) * texp;
+  }
+  return Math.floor(minVal / texp) * texp;
+}

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -43,7 +43,7 @@ export default {
 
       this.$refs.tooltip.setAttribute('data-show', '');
       this.virtualElement = {
-        getBoundingClientRect: generateGetBoundingClientRect(),
+        getBoundingClientRect: generateGetBoundingClientRect(-1000,-1000),
       };
       this.popper = createPopper(this.virtualElement, this.$refs.tooltip, {
         placement: this.placement,

--- a/src/pages/Dashboard/Cashflow.vue
+++ b/src/pages/Dashboard/Cashflow.vue
@@ -13,7 +13,11 @@
             <span class="ml-2 text-gray-900">{{ t('Outflow') }}</span>
           </div>
         </div>
-        <PeriodSelector :value="period" @change="(value) => (period = value)" />
+        <PeriodSelector
+          :value="period"
+          @change="(value) => (period = value)"
+          :options="['This Year', 'This Quarter']"
+        />
       </div>
       <LineChart
         v-if="hasData"
@@ -136,7 +140,7 @@ export default {
       const colors = ['#2490EF', '#B7BFC6'];
       const format = (value) => frappe.format(value ?? 0, 'Currency');
       const yMax = getYMax(points);
-      return { points, xLabels, colors, format, yMax, formatX:formatXLabels };
+      return { points, xLabels, colors, format, yMax, formatX: formatXLabels };
     },
   },
   methods: {

--- a/src/pages/Dashboard/Cashflow.vue
+++ b/src/pages/Dashboard/Cashflow.vue
@@ -101,6 +101,7 @@ import PeriodSelector from './PeriodSelector';
 import Cashflow from '../../../reports/Cashflow/Cashflow';
 import { getDatesAndPeriodicity } from './getDatesAndPeriodicity';
 import LineChart from '@/components/Charts/LineChart.vue';
+import { getYMax } from '@/components/Charts/chartUtils';
 
 export default {
   name: 'Cashflow',
@@ -126,17 +127,13 @@ export default {
       return !(totalInflow === 0 && totalOutflow === 0);
     },
     chartData() {
-      const xLabels = this.periodList.map((l) => l.split(' ')[0]);
+      const xLabels = this.periodList;
       const points = ['inflow', 'outflow'].map((k) =>
         this.data.map((d) => d[k])
       );
       const colors = ['#2490EF', '#B7BFC6'];
       const format = (value) => frappe.format(value ?? 0, 'Currency');
-
-      const maxVal = Math.max(...points.flat());
-      const texp = 10 ** Math.floor(Math.log10(maxVal));
-      const yMax = Math.ceil(maxVal / texp) * texp;
-
+      const yMax = getYMax(points);
       return { points, xLabels, colors, format, yMax };
     },
   },

--- a/src/pages/Dashboard/Cashflow.vue
+++ b/src/pages/Dashboard/Cashflow.vue
@@ -22,6 +22,7 @@
         :points="chartData.points"
         :x-labels="chartData.xLabels"
         :format="chartData.format"
+        :format-x="chartData.formatX"
         :y-max="chartData.yMax"
       />
     </template>
@@ -102,6 +103,7 @@ import Cashflow from '../../../reports/Cashflow/Cashflow';
 import { getDatesAndPeriodicity } from './getDatesAndPeriodicity';
 import LineChart from '@/components/Charts/LineChart.vue';
 import { getYMax } from '@/components/Charts/chartUtils';
+import { formatXLabels } from '@/utils';
 
 export default {
   name: 'Cashflow',
@@ -134,7 +136,7 @@ export default {
       const colors = ['#2490EF', '#B7BFC6'];
       const format = (value) => frappe.format(value ?? 0, 'Currency');
       const yMax = getYMax(points);
-      return { points, xLabels, colors, format, yMax };
+      return { points, xLabels, colors, format, yMax, formatX:formatXLabels };
     },
   },
   methods: {

--- a/src/pages/Dashboard/PeriodSelector.vue
+++ b/src/pages/Dashboard/PeriodSelector.vue
@@ -39,14 +39,20 @@
 import Dropdown from '@/components/Dropdown';
 export default {
   name: 'PeriodSelector',
-  props: ['value'],
+  props: {
+    value: String,
+    options: {
+      type: Array,
+      default: () => ['This Year', 'This Quarter', 'This Month'],
+    },
+  },
+
   components: {
     Dropdown,
   },
   data() {
-    let options = ['This Year', 'This Quarter', 'This Month'];
     return {
-      periodOptions: options.map((option) => {
+      periodOptions: this.options.map((option) => {
         return {
           label: option,
           action: () => this.selectOption(option),

--- a/src/pages/Dashboard/ProfitAndLoss.vue
+++ b/src/pages/Dashboard/ProfitAndLoss.vue
@@ -57,9 +57,6 @@ export default {
   computed: {
     chartData() {
       const points = [this.periodList.map((p) => this.data[p])];
-      console.log(this.period);
-      console.log(this.data, this.periodList);
-      console.log(points);
       const colors = [{ positive: '#2490EF', negative: '#B7BFC6' }];
       const format = (value) => frappe.format(value ?? 0, 'Currency');
       const yMax = getYMax(points);

--- a/src/pages/Dashboard/ProfitAndLoss.vue
+++ b/src/pages/Dashboard/ProfitAndLoss.vue
@@ -5,6 +5,7 @@
       <PeriodSelector
         slot="action"
         :value="period"
+        :options="['This Year', 'This Quarter']"
         @change="(value) => (period = value)"
       />
     </SectionHeader>

--- a/src/pages/Dashboard/ProfitAndLoss.vue
+++ b/src/pages/Dashboard/ProfitAndLoss.vue
@@ -15,6 +15,7 @@
       :points="chartData.points"
       :x-labels="chartData.xLabels"
       :format="chartData.format"
+      :format-x="chartData.formatX"
       :y-max="chartData.yMax"
       :y-min="chartData.yMin"
     />
@@ -33,6 +34,7 @@ import ProfitAndLoss from '../../../reports/ProfitAndLoss/ProfitAndLoss';
 import { getDatesAndPeriodicity } from './getDatesAndPeriodicity';
 import BarChart from '@/components/Charts/BarChart.vue';
 import { getYMax, getYMin } from '@/components/Charts/chartUtils';
+import { formatXLabels } from '@/utils';
 
 export default {
   name: 'ProfitAndLoss',
@@ -50,22 +52,26 @@ export default {
     this.setData();
   },
   watch: {
-    period: 'render',
+    period: 'setData',
   },
   computed: {
     chartData() {
       const points = [this.periodList.map((p) => this.data[p])];
+      console.log(this.period);
+      console.log(this.data, this.periodList);
+      console.log(points);
       const colors = [{ positive: '#2490EF', negative: '#B7BFC6' }];
       const format = (value) => frappe.format(value ?? 0, 'Currency');
       const yMax = getYMax(points);
       const yMin = getYMin(points);
       return {
-        xLabels: this.periodList.map((p) => p.split(' ')[0]),
+        xLabels: this.periodList,
         points,
         format,
         colors,
         yMax,
         yMin,
+        formatX: formatXLabels,
       };
     },
     hasData() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -404,3 +404,11 @@ export function convertPesaValuesToFloat(obj) {
     obj[key] = obj[key].float;
   });
 }
+
+export function formatXLabels(label) {
+  // Format: Mmm YYYY -> Mm YY
+  let [month, year] = label.split(' ');
+  year = year.slice(2);
+
+  return `${month} ${year}`;
+}

--- a/vue.config.js
+++ b/vue.config.js
@@ -37,7 +37,6 @@ module.exports = {
   configureWebpack(config) {
     Object.assign(config.resolve.alias, {
       frappe: path.resolve(__dirname, './frappe'),
-      'frappe-charts$': 'frappe-charts/dist/frappe-charts.esm.js',
       '~': path.resolve('.'),
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5504,11 +5504,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-frappe-charts@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.6.1.tgz#2162cec05f4524b10cf232df8787a3ac20218384"
-  integrity sha512-Fteae/oqv4XdxP4ALoqTmUBBvXt8ECtghziqabp1ZA4yLqY8a3haafNqluwUCxnBOvrV+EdpvhZu0H+VEebX1Q==
-
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"


### PR DESCRIPTION
Same as: https://github.com/frappe/books/pull/325 but for the Profit and Loss bar chart.
This also marks the removal of `frappe-charts` from Frappe Books.