### PR TITLE
fix(ui): temporarily disable maximize

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,7 +62,8 @@ export default {
         DatabaseSelector: [600, 600],
         SetupWizard: [600, 600],
       }[value];
-      let resizable = value === 'Desk';
+      // let resizable = value === 'Desk';
+      const resizable = false;
 
       if (size.length) {
         ipcRenderer.send(IPC_MESSAGES.RESIZE_MAIN_WINDOW, size, resizable);

--- a/src/components/WindowControls.vue
+++ b/src/components/WindowControls.vue
@@ -20,7 +20,6 @@
 
 <script>
 import { runWindowAction } from '@/utils';
-import { ipcRenderer } from 'electron';
 
 export default {
   name: 'WindowControls',
@@ -32,6 +31,10 @@ export default {
   },
   methods: {
     async action(name) {
+      if (name === 'maximize') {
+        return;
+      }
+
       if (this.buttons.includes(name)) {
         const actionRan = await runWindowAction(name);
         this.$emit(actionRan);
@@ -41,8 +44,9 @@ export default {
       let classes = {
         close: 'bg-red-500 hover:bg-red-700',
         minimize: 'bg-yellow-500 hover:bg-yellow-700',
-        maximize: 'bg-green-500 hover:bg-green-700',
+        maximize: 'bg-gray-500',
       }[name];
+      // maximize: 'bg-green-500 hover:bg-green-700',
 
       if (this.buttons.includes(name)) {
         return classes;

--- a/src/components/WindowsTitleBar.vue
+++ b/src/components/WindowsTitleBar.vue
@@ -14,7 +14,7 @@
         <feather-icon name="minus" class="w-4 h-4" />
       </div>
       <div
-        class="flex-center py-1 px-2 hover:bg-gray-100 cursor-pointer"
+        class="flex-center py-1 px-2 text-gray-500"
         @click="action('maximize')"
       >
         <feather-icon name="square" class="w-3 h-3" />
@@ -38,6 +38,10 @@ export default {
   name: 'WindowsTitleBar',
   methods: {
     async action(name) {
+      if (name === 'maximize') {
+        return;
+      }
+
       const actionRan = await runWindowAction(name);
       this.$emit(actionRan);
     },


### PR DESCRIPTION
Removing maximize and window resize temporarily.

Rationale for this:
- The dashboard wasn't designed with resizing in mind, hence it doesn't maximize (or resize gracefully).
- This makes the dashboard a bit buggy.
- Not removing it permanently, will add it back in later.