### PR TITLE
fix: minor fixes: account write-off, zero rates, display outstanding

### DIFF
--- a/models/doctype/Item/Item.js
+++ b/models/doctype/Item/Item.js
@@ -105,10 +105,8 @@ export default {
       label: t`Rate`,
       fieldtype: 'Currency',
       validate(value) {
-        if (value.lte(0)) {
-          throw new frappe.errors.ValidationError(
-            'Rate must be greater than 0'
-          );
+        if (value.isNegative()) {
+          throw new frappe.errors.ValidationError(t`Rate can't be negative.`);
         }
       },
     },

--- a/models/doctype/Party/PartyWidget.vue
+++ b/models/doctype/Party/PartyWidget.vue
@@ -36,8 +36,8 @@
             <span class="text-gray-600" v-if="!fullyPaid(invoice)">
               ({{
                 frappe.format(
-                  invoice.baseGrandTotal,
-                  invoiceMeta.getField('baseGrandTotal')
+                  invoice.outstandingAmount,
+                  invoiceMeta.getField('outstandingAmount')
                 )
               }})
             </span>
@@ -49,9 +49,9 @@
 </template>
 
 <script>
+import { routeTo } from '@/utils';
 import frappe from 'frappe';
 import { getStatusColumn } from '../Transaction/Transaction';
-import { routeTo } from '@/utils';
 
 export default {
   name: 'PartyWidget',

--- a/models/doctype/PurchaseInvoiceItem/PurchaseInvoiceItem.js
+++ b/models/doctype/PurchaseInvoiceItem/PurchaseInvoiceItem.js
@@ -46,6 +46,18 @@ export default {
         return baseRate.div(doc.exchangeRate);
       },
       getCurrency: (row, doc) => doc.currency,
+      validate(value) {
+        if (value.gte(0)) {
+          return;
+        }
+
+        throw new frappe.errors.ValidationError(
+          frappe.t`Rate (${frappe.format(
+            value,
+            'Currency'
+          )}) cannot be less zero.`
+        );
+      },
     },
     {
       fieldname: 'baseRate',


### PR DESCRIPTION
Minor fixes
- Account write-off amount: if write-off is set then the Ledger entry made is for **Amount** - **Write Off**. Write Off is booked separately.
- Zero Rates: allows for zero rate Item masters and Bill, Invoice entries.
- Display Outstanding: shows the outstanding amount in the Payment Widget instead of the grand total.