### PR TITLE
fix: add pagination to the General Ledger

### DIFF
--- a/models/doctype/Payment/PaymentList.js
+++ b/models/doctype/Payment/PaymentList.js
@@ -14,10 +14,7 @@ export default {
       render(doc) {
         let status = 'Draft';
         let color = 'gray';
-        if (
-          doc.submitted === 1 &&
-          (doc.clearanceDate !== null || doc.paymentMethod === 'Cash')
-        ) {
+        if (doc.submitted === 1) {
           color = 'green';
           status = 'Submitted';
         }


### PR DESCRIPTION
**This doesn't fix the slowness of reports, merely circumvents it** by adding pagination to General Ledger.
I've added it only to GL because the other reports mostly have a known or manageable max len of rows, GL is not so.

Due to the janky front end code (not written by me) used for reports, if one has several transactions (like >200 depending on your CPU) the UI thread get's blocked trying to render the report cells, i.e like 8 ⨉ 200 ⨉ 3 = 4,800 elements.

This causes all sorts of issues, like the database timing out (still haven't figured out how tf does that ends up happening), the frontend crashing, which all get resolved only by restarting and not touching the reports...

A proper solution for this involves rewriting the reports UI from scratch, which I will do, but not until some other day in the near future.