### PR TITLE
feat: add entry duplication

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -227,7 +227,40 @@ export function getActionsForDocument(doc) {
     },
   };
 
-  let actions = [...(doc.meta.actions || []), deleteAction, cancelAction]
+  const isSubmittable = !!doc.meta.isSubmittable;
+  const duplicateAction = {
+    label: frappe.t`Duplicate`,
+    condition: (doc) =>
+      ((isSubmittable && doc && doc.submitted) || !isSubmittable) &&
+      !doc._notInserted &&
+      !(doc.cancelled || false),
+    action: () => {
+      showMessageDialog({
+        message: t`Duplicate ${doc.doctype} ${doc.name}?`,
+        buttons: [
+          {
+            label: t`Yes`,
+            async action() {
+              doc.duplicate();
+            },
+          },
+          {
+            label: t`No`,
+            action() {
+              resolve(false);
+            },
+          },
+        ],
+      });
+    },
+  };
+
+  let actions = [
+    ...(doc.meta.actions || []),
+    duplicateAction,
+    deleteAction,
+    cancelAction,
+  ]
     .filter((d) => (d.condition ? d.condition(doc) : true))
     .map((d) => {
       return {


### PR DESCRIPTION
![Screen Shot 2022-03-17 at 11 56 22](https://user-images.githubusercontent.com/29507195/158749714-b7f7f5fb-12a3-4977-876c-9d6e0b710c08.png)

Adds a duplicate option that creates a copy of the entry being viewed.