### PR TITLE
chore: bump yarn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '16.13.1'
 
       - name: Set yarn version
-        run: yarn set version 1.22.17
+        run: yarn set version 1.22.18
 
       - name: Checkout Books
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
           node-version: '16.13.1'
 
       - name: Change yarn version
-        run: yarn set version 1.22.17
+        run: yarn set version 1.22.18
 
       - name: Checkout Books
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "engineStrict": true,
   "engines": {
     "node": ">=16.13.1 <17",
-    "yarn": "1.22.17"
+    "yarn": "1.22.18"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/src/utils.js
+++ b/src/utils.js
@@ -391,6 +391,10 @@ export async function getSavePath(name, extention) {
 function replaceAndAppendMount(app, replaceId) {
   const fragment = document.createDocumentFragment();
   const target = document.getElementById(replaceId);
+  if (target === null) {
+    return;
+  }
+
   const parent = target.parentElement;
   const clone = target.cloneNode();
 


### PR DESCRIPTION
- prevent error on pre mounted toast

This is to prevent breaking `build.yml`