### PR TITLE
feat: add custom UOM support

### DIFF
--- a/backend/patches/addUOMs.ts
+++ b/backend/patches/addUOMs.ts
@@ -1,0 +1,13 @@
+import { ModelNameEnum } from '../../models/types';
+import { defaultUOMs } from '../../utils/defaults';
+import { DatabaseManager } from '../database/manager';
+import { getDefaultMetaFieldValueMap } from '../helpers';
+
+async function execute(dm: DatabaseManager) {
+  for (const uom of defaultUOMs) {
+    const defaults = getDefaultMetaFieldValueMap();
+    await dm.db?.insert(ModelNameEnum.UOM, { ...uom, ...defaults });
+  }
+}
+
+export default { execute };

--- a/backend/patches/index.ts
+++ b/backend/patches/index.ts
@@ -1,4 +1,5 @@
 import { Patch } from '../database/types';
+import addUOMs from './addUOMs';
 import testPatch from './testPatch';
 import updateSchemas from './updateSchemas';
 
@@ -9,5 +10,10 @@ export default [
     version: '0.5.0-beta.0',
     patch: updateSchemas,
     priority: 100,
+  },
+  {
+    name: 'addUOMs',
+    version: '0.6.0-beta.0',
+    patch: addUOMs,
   },
 ] as Patch[];

--- a/fyo/model/doc.ts
+++ b/fyo/model/doc.ts
@@ -457,8 +457,11 @@ export class Doc extends Observable<DocValue | Doc[]> {
 
   async loadLinks() {
     this._links = {};
-    const inlineLinks = this.schema.fields.filter((f) => f.inline);
-    for (const f of inlineLinks) {
+    const linkFields = this.schema.fields.filter(
+      (f) => f.fieldtype === FieldTypeEnum.Link || f.inline
+    );
+
+    for (const f of linkFields) {
       await this.loadLink(f.fieldname);
     }
   }

--- a/models/types.ts
+++ b/models/types.ts
@@ -9,6 +9,7 @@ export enum ModelNameEnum {
   Currency = 'Currency',
   GetStarted = 'GetStarted',
   Item = 'Item',
+  UOM = 'UOM',
   JournalEntry = 'JournalEntry',
   JournalEntryAccount = 'JournalEntryAccount',
   NumberSeries = 'NumberSeries',

--- a/schemas/app/Item.json
+++ b/schemas/app/Item.json
@@ -25,35 +25,10 @@
     {
       "fieldname": "unit",
       "label": "Unit Type",
-      "fieldtype": "Select",
-      "placeholder": "Unit Type",
-      "default": "Unit",
-      "options": [
-        {
-          "value": "Unit",
-          "label": "Unit"
-        },
-        {
-          "value": "Kg",
-          "label": "Kg"
-        },
-        {
-          "value": "Gram",
-          "label": "Gram"
-        },
-        {
-          "value": "Meter",
-          "label": "Meter"
-        },
-        {
-          "value": "Hour",
-          "label": "Hour"
-        },
-        {
-          "value": "Day",
-          "label": "Day"
-        }
-      ]
+      "fieldtype": "Link",
+      "target": "UOM",
+      "create": true,
+      "placeholder": "Unit Type"
     },
     {
       "fieldname": "itemType",

--- a/schemas/app/UOM.json
+++ b/schemas/app/UOM.json
@@ -1,0 +1,22 @@
+{
+  "name": "UOM",
+  "label": "UOM",
+  "isSingle": false,
+  "naming": "manual",
+  "fields": [
+    {
+      "fieldname": "name",
+      "label": "UOM",
+      "fieldtype": "Data",
+      "placeholder": "Item Name",
+      "required": true
+    },
+    {
+      "fieldname": "isWhole",
+      "label": "Is Whole",
+      "fieldtype": "Check",
+      "default": false
+    }
+  ],
+  "quickEditFields": ["isWhole"]
+}

--- a/schemas/schemas.ts
+++ b/schemas/schemas.ts
@@ -22,6 +22,7 @@ import SetupWizard from './app/SetupWizard.json';
 import Tax from './app/Tax.json';
 import TaxDetail from './app/TaxDetail.json';
 import TaxSummary from './app/TaxSummary.json';
+import UOM from './app/UOM.json';
 import PatchRun from './core/PatchRun.json';
 import SingleValue from './core/SingleValue.json';
 import SystemSettings from './core/SystemSettings.json';
@@ -62,6 +63,7 @@ export const appSchemas: Schema[] | SchemaStub[] = [
   Party as Schema,
   Address as Schema,
   Item as Schema,
+  UOM as Schema,
 
   Payment as Schema,
   PaymentFor as Schema,

--- a/src/setup/setupInstance.ts
+++ b/src/setup/setupInstance.ts
@@ -12,6 +12,7 @@ import { ModelNameEnum } from 'models/types';
 import { initializeInstance } from 'src/initFyo';
 import { createRegionalRecords } from 'src/regional';
 import { getRandomString } from 'utils';
+import { defaultUOMs } from 'utils/defaults';
 import { getCountryCodeFromCountry, getCountryInfo } from 'utils/misc';
 import { CountryInfo } from 'utils/types';
 import { CreateCOA } from './createCOA';
@@ -33,9 +34,19 @@ export default async function setupInstance(
   await createCurrencyRecords(fyo);
   await createAccountRecords(bankName, country, chartOfAccounts, fyo);
   await createRegionalRecords(country, fyo);
+  await createDefaultEntries(fyo);
   await createDefaultNumberSeries(fyo);
 
   await completeSetup(companyName, fyo);
+}
+
+async function createDefaultEntries(fyo: Fyo) {
+  /**
+   * Create default UOM entries
+   */
+  for (const uom of defaultUOMs) {
+    await checkAndCreateDoc(ModelNameEnum.UOM, uom, fyo);
+  }
 }
 
 async function initializeDatabase(dbPath: string, country: string, fyo: Fyo) {

--- a/utils/defaults.ts
+++ b/utils/defaults.ts
@@ -1,0 +1,26 @@
+export const defaultUOMs = [
+  {
+    name: 'Unit',
+    isWhole: true,
+  },
+  {
+    name: 'Kg',
+    isWhole: false,
+  },
+  {
+    name: 'Gram',
+    isWhole: false,
+  },
+  {
+    name: 'Meter',
+    isWhole: false,
+  },
+  {
+    name: 'Hour',
+    isWhole: false,
+  },
+  {
+    name: 'Day',
+    isWhole: false,
+  },
+];


### PR DESCRIPTION
Changes Item Unit Type from Select to a Link type with a _Create_ option. This allows for custom UOMs.


closes #408