### PR TITLE
feat: Manufacture stock movement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'arrow-body-style': 'off',
     'prefer-arrow-callback': 'off',
+    'vue/no-mutating-props': 'off',
     'vue/multi-word-component-names': 'off',
     'vue/no-useless-template-attributes': 'off',
   },

--- a/backend/patches/createInventoryNumberSeries.ts
+++ b/backend/patches/createInventoryNumberSeries.ts
@@ -2,9 +2,19 @@ import { getDefaultMetaFieldValueMap } from '../../backend/helpers';
 import { DatabaseManager } from '../database/manager';
 
 async function execute(dm: DatabaseManager) {
+  const s = (await dm.db?.getAll('SingleValue', {
+    fields: ['value'],
+    filters: { fieldname: 'setupComplete' },
+  })) as { value: string }[];
+
+  if (!Number(s?.[0]?.value ?? '0')) {
+    return;
+  }
+
   const names: Record<string, string> = {
     StockMovement: 'SMOV-',
-    Shipment: 'SHP-',
+    PurchaseReceipt: 'PREC-',
+    Shipment: 'SHPM-',
   };
 
   for (const referenceType in names) {

--- a/models/inventory/StockMovementItem.ts
+++ b/models/inventory/StockMovementItem.ts
@@ -4,7 +4,9 @@ import {
   FormulaMap,
   ReadOnlyMap,
   RequiredMap,
+  ValidationMap,
 } from 'fyo/model/types';
+import { ValidationError } from 'fyo/utils/errors';
 import { ModelNameEnum } from 'models/types';
 import { Money } from 'pesa';
 import { StockMovement } from './StockMovement';
@@ -32,6 +34,10 @@ export class StockMovementItem extends Doc {
     return this.parentdoc?.movementType === MovementType.MaterialTransfer;
   }
 
+  get isManufacture() {
+    return this.parentdoc?.movementType === MovementType.Manufacture;
+  }
+
   static filters: FiltersMap = {
     item: () => ({ trackItem: true }),
   };
@@ -52,14 +58,14 @@ export class StockMovementItem extends Doc {
       dependsOn: ['item', 'rate', 'quantity'],
     },
     fromLocation: {
-      formula: (fn) => {
-        if (this.isReceipt || this.isTransfer) {
+      formula: () => {
+        if (this.isReceipt || this.isTransfer || this.isManufacture) {
           return null;
         }
 
         const defaultLocation = this.fyo.singles.InventorySettings
           ?.defaultLocation as string | undefined;
-        if (defaultLocation && !this.location && this.isIssue) {
+        if (defaultLocation && !this.fromLocation && this.isIssue) {
           return defaultLocation;
         }
 
@@ -68,20 +74,45 @@ export class StockMovementItem extends Doc {
       dependsOn: ['movementType'],
     },
     toLocation: {
-      formula: (fn) => {
-        if (this.isIssue || this.isTransfer) {
+      formula: () => {
+        if (this.isIssue || this.isTransfer || this.isManufacture) {
           return null;
         }
 
         const defaultLocation = this.fyo.singles.InventorySettings
           ?.defaultLocation as string | undefined;
-        if (defaultLocation && !this.location && this.isReceipt) {
+        if (defaultLocation && !this.toLocation && this.isReceipt) {
           return defaultLocation;
         }
 
         return this.toLocation;
       },
       dependsOn: ['movementType'],
+    },
+  };
+
+  validations: ValidationMap = {
+    fromLocation: (value) => {
+      if (!this.isManufacture) {
+        return;
+      }
+
+      if (value && this.toLocation) {
+        throw new ValidationError(
+          this.fyo.t`Only From or To can be set for Manucature`
+        );
+      }
+    },
+    toLocation: (value) => {
+      if (!this.isManufacture) {
+        return;
+      }
+
+      if (value && this.fromLocation) {
+        throw new ValidationError(
+          this.fyo.t`Only From or To can be set for Manufacture`
+        );
+      }
     },
   };
 

--- a/models/inventory/tests/testStockMovement.spec.ts
+++ b/models/inventory/tests/testStockMovement.spec.ts
@@ -1,0 +1,136 @@
+import { ModelNameEnum } from 'models/types';
+import test from 'tape';
+import { getItem } from './helpers';
+import { closeTestFyo, getTestFyo, setupTestFyo } from 'tests/helpers';
+import { MovementType } from '../types';
+import {
+  assertDoesNotThrow,
+  assertThrows,
+} from 'backend/database/tests/helpers';
+import { StockMovement } from '../StockMovement';
+
+const fyo = getTestFyo();
+setupTestFyo(fyo, __filename);
+
+test('check store and create test items', async (t) => {
+  const e = await fyo.db.exists(ModelNameEnum.Location, 'Stores');
+  t.equals(e, true, 'location Stores exist');
+
+  const items = [
+    getItem('RawOne', 100),
+    getItem('RawTwo', 100),
+    getItem('Final', 200),
+  ];
+
+  const exists: boolean[] = [];
+  for (const item of items) {
+    await fyo.doc.getNewDoc('Item', item).sync();
+    exists.push(await fyo.db.exists('Item', item.name));
+  }
+
+  t.ok(exists.every(Boolean), 'items created');
+});
+
+test('Stock Movement, Material Receipt', async (t) => {
+  const sm = fyo.doc.getNewDoc(ModelNameEnum.StockMovement);
+
+  await sm.set({
+    date: new Date('2022-01-01'),
+    movementType: MovementType.MaterialReceipt,
+  });
+
+  await sm.append('items', {
+    item: 'RawOne',
+    quantity: 1,
+    rate: 100,
+    toLocation: 'Stores',
+  });
+
+  await sm.append('items', {
+    item: 'RawTwo',
+    quantity: 1,
+    rate: 100,
+    toLocation: 'Stores',
+  });
+
+  await assertDoesNotThrow(async () => await sm.sync());
+  await assertDoesNotThrow(async () => await sm.submit());
+
+  t.equal(
+    await fyo.db.getStockQuantity('RawOne', 'Stores'),
+    1,
+    'item RawOne added'
+  );
+  t.equal(
+    await fyo.db.getStockQuantity('RawTwo', 'Stores'),
+    1,
+    'item RawTwo added'
+  );
+  t.equal(
+    await fyo.db.getStockQuantity('Final', 'Stores'),
+    null,
+    'item Final not yet added'
+  );
+});
+
+test('Stock Movement, Manufacture', async (t) => {
+  const sm = fyo.doc.getNewDoc(ModelNameEnum.StockMovement) as StockMovement;
+
+  await sm.set({
+    date: new Date('2022-01-02'),
+    movementType: MovementType.Manufacture,
+  });
+
+  await sm.append('items', {
+    item: 'RawOne',
+    quantity: 1,
+    rate: 100,
+  });
+
+  await assertDoesNotThrow(
+    async () => await sm.items?.[0].set('fromLocation', 'Stores')
+  );
+  await assertThrows(
+    async () => await sm.items?.[0].set('toLocation', 'Stores')
+  );
+  t.notOk(sm.items?.[0].to, 'to location not set');
+
+  await sm.append('items', {
+    item: 'RawTwo',
+    quantity: 1,
+    rate: 100,
+    fromLocation: 'Stores',
+  });
+
+  await assertThrows(async () => await sm.sync());
+
+  await sm.append('items', {
+    item: 'Final',
+    quantity: 1,
+    rate: 100,
+    toLocation: 'Stores',
+  });
+
+  await assertDoesNotThrow(async () => await sm.sync());
+  await assertDoesNotThrow(async () => await sm.submit());
+
+  t.equal(
+    await fyo.db.getStockQuantity('RawOne', 'Stores'),
+    0,
+    'item RawOne removed'
+  );
+
+  t.equal(
+    await fyo.db.getStockQuantity('RawTwo', 'Stores'),
+    0,
+    'item RawTwo removed'
+  );
+
+  t.equal(
+    await fyo.db.getStockQuantity('Final', 'Stores'),
+    1,
+    'item Final added'
+  );
+});
+
+closeTestFyo(fyo, __filename);

--- a/models/inventory/types.ts
+++ b/models/inventory/types.ts
@@ -9,6 +9,7 @@ export enum MovementType {
   'MaterialIssue' = 'MaterialIssue',
   'MaterialReceipt' = 'MaterialReceipt',
   'MaterialTransfer' = 'MaterialTransfer',
+  'Manufacture' = 'Manufacture',
 }
 
 export interface SMDetails {

--- a/schemas/app/inventory/StockMovement.json
+++ b/schemas/app/inventory/StockMovement.json
@@ -35,6 +35,10 @@
         {
           "value": "MaterialTransfer",
           "label": "Material Transfer"
+        },
+        {
+          "value": "Manufacture",
+          "label": "Manufacture"
         }
       ],
       "required": true

--- a/src/components/Controls/TableRow.vue
+++ b/src/components/Controls/TableRow.vue
@@ -62,6 +62,7 @@
 import { Doc } from 'fyo/model/doc';
 import Row from 'src/components/Row.vue';
 import { getErrorMessage } from 'src/utils';
+import { nextTick } from 'vue';
 import Button from '../Button.vue';
 import FormControl from './FormControl.vue';
 
@@ -102,15 +103,18 @@ export default {
     },
   },
   methods: {
-    onChange(df, value) {
-      if (value == null) {
-        return;
-      }
+    async onChange(df, value) {
+      const fieldname = df.fieldname;
+      this.errors[fieldname] = null;
+      const oldValue = this.row[fieldname];
 
-      this.errors[df.fieldname] = null;
-      this.row.set(df.fieldname, value).catch((e) => {
-        this.errors[df.fieldname] = getErrorMessage(e, this.row);
-      });
+      try {
+        await this.row.set(fieldname, value);
+      } catch (e) {
+        this.errors[fieldname] = getErrorMessage(e, this.row);
+        this.row[fieldname] = '';
+        nextTick(() => (this.row[fieldname] = oldValue));
+      }
     },
     getErrorString() {
       return Object.values(this.errors).filter(Boolean).join(' ');


### PR DESCRIPTION
Adds a new Movement Type to Stock Movement: Manufacture. This allows the recording of the conversion of one or a group of items into another single or a group of items.

- [x] Add Manufacture type
- [x] Add tests
- [x] Add docs ([link](https://github.com/frappe/books_docs/commit/fa5e1381efb1384dfa63fa2f342f915b7ef63319))