### PR TITLE
chore: typo in StockMovementItem validations

### DIFF
--- a/models/inventory/StockMovementItem.ts
+++ b/models/inventory/StockMovementItem.ts
@@ -99,7 +99,7 @@ export class StockMovementItem extends Doc {
 
       if (value && this.toLocation) {
         throw new ValidationError(
-          this.fyo.t`Only From or To can be set for Manucature`
+          this.fyo.t`Only From or To can be set for Manufacture`
         );
       }
     },


### PR DESCRIPTION
### Before
https://github.com/frappe/books/blob/362e10c94874ce9e3660472dbe76d593119177cf/models/inventory/StockMovementItem.ts#L102

### After
https://github.com/frappe/books/blob/449a23939ebad5b5f39973ce72d0ded54d281b9d/models/inventory/StockMovementItem.ts#L102