### PR TITLE
fix(ux): inline fieldtype, handle Address like a regular entry

### DIFF
--- a/models/baseModels/AccountingLedgerEntry/AccountingLedgerEntry.ts
+++ b/models/baseModels/AccountingLedgerEntry/AccountingLedgerEntry.ts
@@ -41,12 +41,12 @@ export class AccountingLedgerEntry extends Doc {
   static getListViewSettings(): ListViewSettings {
     return {
       columns: [
+        'date',
         'account',
         'party',
         'debit',
         'credit',
         'referenceName',
-        'reverted',
       ],
     };
   }

--- a/models/baseModels/Address/Address.ts
+++ b/models/baseModels/Address/Address.ts
@@ -1,6 +1,11 @@
-import { t } from 'fyo';
+import { Fyo, t } from 'fyo';
 import { Doc } from 'fyo/model/doc';
-import { EmptyMessageMap, FormulaMap, ListsMap } from 'fyo/model/types';
+import {
+  EmptyMessageMap,
+  FormulaMap,
+  ListsMap,
+  ListViewSettings,
+} from 'fyo/model/types';
 import { codeStateMap } from 'regional/in';
 import { getCountryInfo } from 'utils/misc';
 
@@ -54,4 +59,10 @@ export class Address extends Doc {
       return t`Enter Country to load States`;
     },
   };
+
+  static override getListViewSettings(): ListViewSettings {
+    return {
+      columns: ['name', 'addressLine1', 'city', 'state', 'country'],
+    };
+  }
 }

--- a/models/inventory/StockLedgerEntry.ts
+++ b/models/inventory/StockLedgerEntry.ts
@@ -1,6 +1,6 @@
 import { Doc } from 'fyo/model/doc';
+import { ListViewSettings } from 'fyo/model/types';
 import { Money } from 'pesa';
-
 
 export class StockLedgerEntry extends Doc {
   date?: Date;
@@ -11,4 +11,17 @@ export class StockLedgerEntry extends Doc {
   referenceName?: string;
   referenceType?: string;
   batch?: string;
+
+  static override getListViewSettings(): ListViewSettings {
+    return {
+      columns: [
+        'date',
+        'item',
+        'location',
+        'rate',
+        'quantity',
+        'referenceName',
+      ],
+    };
+  }
 }

--- a/schemas/app/Address.json
+++ b/schemas/app/Address.json
@@ -84,5 +84,5 @@
     "country",
     "postalCode"
   ],
-  "inlineEditDisplayField": "addressDisplay"
+  "linkDisplayField": "addressDisplay"
 }

--- a/schemas/app/Address.json
+++ b/schemas/app/Address.json
@@ -1,8 +1,15 @@
 {
   "name": "Address",
   "label": "Address",
+  "naming": "manual",
   "isSingle": false,
   "fields": [
+    {
+      "fieldname": "name",
+      "label": "Address Name",
+      "fieldtype": "Data",
+      "required": true
+    },
     {
       "fieldname": "addressLine1",
       "label": "Address Line 1",
@@ -69,6 +76,7 @@
     }
   ],
   "quickEditFields": [
+    "name",
     "addressLine1",
     "addressLine2",
     "city",

--- a/schemas/app/Party.json
+++ b/schemas/app/Party.json
@@ -74,7 +74,7 @@
       "label": "Address",
       "fieldtype": "Link",
       "target": "Address",
-      "inline": true
+      "create": true
     },
     {
       "fieldname": "taxId",

--- a/schemas/app/PrintSettings.json
+++ b/schemas/app/PrintSettings.json
@@ -35,6 +35,7 @@
       "fieldtype": "Link",
       "target": "Address",
       "inline": true,
+      "create": true,
       "section": "Contacts"
     },
     {

--- a/schemas/app/PrintSettings.json
+++ b/schemas/app/PrintSettings.json
@@ -34,7 +34,6 @@
       "label": "Address",
       "fieldtype": "Link",
       "target": "Address",
-      "inline": true,
       "create": true,
       "section": "Contacts"
     },

--- a/schemas/app/inventory/Location.json
+++ b/schemas/app/inventory/Location.json
@@ -16,7 +16,7 @@
       "label": "Address",
       "fieldtype": "Link",
       "target": "Address",
-      "inline": true
+      "create": true
     }
   ],
   "quickEditFields": ["item", "address"]

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -50,8 +50,8 @@ function removeFields(schemaMap: SchemaMap): SchemaMap {
         (fn) => fn !== fieldname
       );
 
-      if (schema.inlineEditDisplayField === fieldname) {
-        delete schema.inlineEditDisplayField;
+      if (schema.linkDisplayField === fieldname) {
+        delete schema.linkDisplayField;
       }
     }
 

--- a/schemas/regional/in/Address.json
+++ b/schemas/regional/in/Address.json
@@ -9,6 +9,7 @@
     }
   ],
   "quickEditFields": [
+    "name",
     "addressLine1",
     "addressLine2",
     "city",

--- a/schemas/tests/Party.json
+++ b/schemas/tests/Party.json
@@ -72,8 +72,7 @@
       "fieldname": "address",
       "label": "Address",
       "fieldtype": "Link",
-      "target": "Address",
-      "inline": true
+      "target": "Address"
     }
   ],
   "quickEditFields": [

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -61,7 +61,6 @@ export interface BaseField {
   placeholder?: string;          // UI Facing config, form field placeholder
   groupBy?: string;              // UI Facing used in dropdowns fields
   meta?: boolean;                // Field is a meta field, i.e. only for the db, not UI
-  inline?: boolean;              // UI Facing config, whether to display doc inline.
   filter?: boolean;               // UI Facing config, whether to be used to filter the List.
   computed?: boolean;            // Computed values are not stored in the database.
   section?: string;              // UI Facing config, for grouping by sections
@@ -118,7 +117,7 @@ export interface Schema {
   isSubmittable?: boolean;       // For transactional types, values considered only after submit
   keywordFields?: string[];      // Used to get fields that are to be used for search.
   quickEditFields?: string[];    // Used to get fields for the quickEditForm
-  inlineEditDisplayField?:string;// Display field if inline editable
+  linkDisplayField?:string;// Display field if inline editable
   naming?: Naming;               // Used for assigning name, default is 'random' else 'numberSeries' if present
   titleField?: string;           // Main display field
   removeFields?: string[];       // Used by the builder to remove fields.

--- a/src/components/Controls/AutoComplete.vue
+++ b/src/components/Controls/AutoComplete.vue
@@ -25,6 +25,7 @@
           :placeholder="inputPlaceholder"
           :readonly="isReadOnly"
           @focus="(e) => !isReadOnly && onFocus(e, toggleDropdown)"
+          @click="(e) => !isReadOnly && onFocus(e, toggleDropdown)"
           @blur="(e) => !isReadOnly && onBlur(e.target.value)"
           @input="onInput"
           @keydown.up="highlightItemUp"
@@ -55,7 +56,6 @@
     </template>
   </Dropdown>
 </template>
-
 <script>
 import { getOptionList } from 'fyo/utils';
 import Dropdown from 'src/components/Dropdown.vue';
@@ -81,7 +81,7 @@ export default {
     value: {
       immediate: true,
       handler(newValue) {
-        this.linkValue = this.getLinkValue(newValue);
+        this.setLinkValue(this.getLinkValue(newValue));
       },
     },
   },
@@ -89,7 +89,8 @@ export default {
     doc: { default: null },
   },
   mounted() {
-    this.linkValue = this.getLinkValue(this.linkValue || this.value);
+    const value = this.linkValue || this.value;
+    this.setLinkValue(this.getLinkValue(value));
   },
   computed: {
     options() {
@@ -101,6 +102,9 @@ export default {
     },
   },
   methods: {
+    setLinkValue(value) {
+      this.linkValue = value;
+    },
     getLinkValue(value) {
       const oldValue = this.linkValue;
       let option = this.options.find((o) => o.value === value);
@@ -116,7 +120,7 @@ export default {
     },
     async updateSuggestions(keyword) {
       if (typeof keyword === 'string') {
-        this.linkValue = keyword;
+        this.setLinkValue(keyword, true);
       }
 
       this.isLoading = true;
@@ -152,12 +156,12 @@ export default {
     },
     setSuggestion(suggestion) {
       if (suggestion?.actionOnly) {
-        this.linkValue = this.value;
+        this.setLinkValue(this.value);
         return;
       }
 
       if (suggestion) {
-        this.linkValue = suggestion.label;
+        this.setLinkValue(suggestion.label);
         this.triggerChange(suggestion.value);
       }
 

--- a/src/components/Controls/FormControl.vue
+++ b/src/components/Controls/FormControl.vue
@@ -48,6 +48,12 @@ export default {
     });
   },
   methods: {
+    clear() {
+      const input = this.$refs.control.$refs.input;
+      if (input instanceof HTMLInputElement) {
+        input.value = '';
+      }
+    },
     focus() {
       this.$refs.control.focus();
     },

--- a/src/components/Controls/Link.vue
+++ b/src/components/Controls/Link.vue
@@ -35,7 +35,7 @@ export default {
 
       const value = newValue ?? this.value;
       const { fieldname, target } = this.df ?? {};
-      const displayField = fyo.schemaMap[target ?? '']?.inlineEditDisplayField;
+      const displayField = fyo.schemaMap[target ?? '']?.linkDisplayField;
 
       if (!displayField) {
         return (this.linkValue = value);

--- a/src/components/Controls/Link.vue
+++ b/src/components/Controls/Link.vue
@@ -16,18 +16,42 @@ export default {
   },
   mounted() {
     if (this.value) {
-      this.linkValue = this.value;
+      this.setLinkValue();
     }
   },
   watch: {
     value: {
       immediate: true,
       handler(newValue) {
-        this.linkValue = newValue;
+        this.setLinkValue(newValue);
       },
     },
   },
   methods: {
+    async setLinkValue(newValue, isInput) {
+      if (isInput) {
+        return (this.linkValue = newValue || '');
+      }
+
+      const value = newValue ?? this.value;
+      const { fieldname, target } = this.df ?? {};
+      const displayField = fyo.schemaMap[target ?? '']?.inlineEditDisplayField;
+
+      if (!displayField) {
+        return (this.linkValue = value);
+      }
+
+      let displayValue = this.docs?.links?.[fieldname]?.get(displayField);
+      if (!displayValue) {
+        displayValue = await fyo.getValue(
+          target,
+          this.value ?? '',
+          displayField
+        );
+      }
+
+      this.linkValue = displayValue;
+    },
     getTargetSchemaName() {
       return this.df.target;
     },
@@ -104,10 +128,11 @@ export default {
             '<Badge color="blue" class="ms-2" v-if="isNewValue">{{ linkValue }}</Badge>' +
             '</div>',
           computed: {
+            value: () => this.value,
             linkValue: () => this.linkValue,
             isNewValue: () => {
               let values = this.suggestions.map((d) => d.value);
-              return this.linkValue && !values.includes(this.linkValue);
+              return this.value && !values.includes(this.value);
             },
           },
           components: { Badge },
@@ -134,6 +159,7 @@ export default {
         this.$emit('new-doc', doc);
         this.$router.back();
         this.results = [];
+        this.triggerChange(doc.name);
       });
     },
     async getCreateFilters() {

--- a/src/components/Controls/Select.vue
+++ b/src/components/Controls/Select.vue
@@ -23,7 +23,12 @@
         @change="(e) => triggerChange(e.target.value)"
         @focus="(e) => $emit('focus', e)"
       >
-        <option value="" disabled selected v-if="inputPlaceholder">
+        <option
+          value=""
+          disabled
+          selected
+          v-if="inputPlaceholder && !showLabel"
+        >
           {{ inputPlaceholder }}
         </option>
         <option

--- a/src/components/FilterDropdown.vue
+++ b/src/components/FilterDropdown.vue
@@ -165,7 +165,11 @@ export default {
   methods: {
     getRandomString,
     addNewFilter() {
-      let df = this.fields[0];
+      const df = this.fields[0];
+      if (!df) {
+        return;
+      }
+
       this.addFilter(df.fieldname, 'like', '', false);
     },
     addFilter(fieldname, condition, value, implicit) {

--- a/src/pages/CommonForm/CommonFormSection.vue
+++ b/src/pages/CommonForm/CommonFormSection.vue
@@ -66,15 +66,19 @@ export default defineComponent({
   methods: {
     focusOnNameField() {
       const naming = this.fyo.schemaMap[this.doc.schemaName]?.naming;
-      if (naming !== 'manual') {
+      if (naming !== 'manual' || this.doc.inserted) {
         return;
       }
 
-      const nameField = (this.$refs.nameField as { focus: Function }[])?.[0];
+      const nameField = (
+        this.$refs.nameField as { focus: Function; clear: Function }[]
+      )?.[0];
+
       if (!nameField) {
         return;
       }
 
+      nameField.clear();
       nameField.focus();
     },
   },

--- a/src/utils/doc.ts
+++ b/src/utils/doc.ts
@@ -2,7 +2,14 @@ import { Doc } from 'fyo/model/doc';
 import { Field } from 'schemas/types';
 
 export function evaluateReadOnly(field: Field, doc?: Doc) {
-  if (field.fieldname === 'numberSeries' && !doc?.notInserted) {
+  if (doc?.inserted && field.fieldname === 'numberSeries') {
+    return true;
+  }
+
+  if (
+    field.fieldname === 'name' &&
+    (doc?.inserted || doc?.schema.naming !== 'manual')
+  ) {
     return true;
   }
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -223,6 +223,10 @@ function getListViewList(fyo: Fyo): SearchItem[] {
     ModelNameEnum.PurchaseInvoice,
     ModelNameEnum.SalesInvoice,
     ModelNameEnum.Tax,
+    ModelNameEnum.UOM,
+    ModelNameEnum.Address,
+    ModelNameEnum.AccountingLedgerEntry,
+    ModelNameEnum.Currency,
   ];
 
   const hasInventory = fyo.doc.singles.AccountingSettings?.enableInventory;
@@ -231,7 +235,8 @@ function getListViewList(fyo: Fyo): SearchItem[] {
       ModelNameEnum.StockMovement,
       ModelNameEnum.Shipment,
       ModelNameEnum.PurchaseReceipt,
-      ModelNameEnum.Location
+      ModelNameEnum.Location,
+      ModelNameEnum.StockLedgerEntry
     );
   }
 


### PR DESCRIPTION
- Fixes the use of `"inline"` field property by removing it.
- Link Fields with targets such as Address can instead have a `linkDisplayField` which is used to set the display value of link fields.