### PR TITLE
fix(ux): use native Date, Datetime input elements

### DIFF
--- a/src/components/Controls/Currency.vue
+++ b/src/components/Controls/Currency.vue
@@ -20,7 +20,7 @@
     <div
       v-show="!showInput"
       class="whitespace-nowrap overflow-x-auto no-scrollbar"
-      :class="[inputClasses, containerClasses, ,]"
+      :class="[inputClasses, containerClasses]"
       @click="activateInput"
       @focus="activateInput"
       tabindex="0"

--- a/src/components/Controls/Date.vue
+++ b/src/components/Controls/Date.vue
@@ -1,11 +1,139 @@
+<template>
+  <div>
+    <div :class="labelClasses" v-if="showLabel">
+      {{ df.label }}
+    </div>
+    <input
+      v-show="showInput"
+      ref="input"
+      :class="[inputClasses, containerClasses]"
+      :type="inputType"
+      :value="inputValue"
+      :placeholder="inputPlaceholder"
+      :readonly="isReadOnly"
+      :tabindex="isReadOnly ? '-1' : '0'"
+      @blur="onBlur"
+      @focus="onFocus"
+      @input="(e) => $emit('input', e)"
+    />
+    <div
+      v-show="!showInput"
+      class="flex"
+      :class="[containerClasses, sizeClasses]"
+      @click="activateInput"
+      @focus="activateInput"
+      tabindex="0"
+    >
+      <p
+        :class="[baseInputClasses]"
+        class="overflow-auto no-scrollbar whitespace-nowrap"
+        v-if="!isEmpty"
+      >
+        {{ formattedValue }}
+      </p>
+      <p v-else-if="inputPlaceholder" class="text-base text-gray-500 w-full">
+        {{ inputPlaceholder }}
+      </p>
+
+      <button v-if="!isReadOnly" class="-me-0.5 ms-1">
+        <FeatherIcon
+          name="calendar"
+          class="w-4 h-4"
+          :class="showMandatory ? 'text-red-600' : 'text-gray-600'"
+        />
+      </button>
+    </div>
+  </div>
+</template>
 <script lang="ts">
-import { defineComponent } from 'vue';
-import Datetime from './Datetime.vue';
+import { fyo } from 'src/initFyo';
+import { defineComponent, nextTick } from 'vue';
+import Base from './Base.vue';
 
 export default defineComponent({
+  extends: Base,
+  emits: ['input', 'focus'],
   data() {
-    return { selectTime: false };
+    return {
+      showInput: false,
+    };
   },
-  extends: Datetime,
+  methods: {
+    onFocus(e: FocusEvent) {
+      const target = e.target;
+      if (!(target instanceof HTMLInputElement)) {
+        return;
+      }
+
+      target.select();
+      this.showInput = true;
+      this.$emit('focus', e);
+    },
+    onBlur(e: FocusEvent) {
+      const target = e.target;
+      if (!(target instanceof HTMLInputElement)) {
+        return;
+      }
+
+      this.showInput = false;
+      let value: Date | null = new Date(target.value);
+      if (Number.isNaN(value.valueOf())) {
+        value = null;
+      }
+
+      this.triggerChange(value);
+    },
+    activateInput() {
+      if (this.isReadOnly) {
+        return;
+      }
+
+      this.showInput = true;
+      nextTick(() => {
+        this.focus();
+
+        // @ts-ignore
+        this.$refs.input.showPicker();
+      });
+    },
+  },
+  computed: {
+    inputValue(): string {
+      let value = this.value;
+      if (typeof value === 'string') {
+        value = new Date(value);
+      }
+
+      if (value instanceof Date && !Number.isNaN(value.valueOf())) {
+        return value.toISOString().split('T')[0];
+      }
+
+      return '';
+    },
+    inputType() {
+      return 'date';
+    },
+    formattedValue() {
+      const value = this.parse(this.value);
+      return fyo.format(value, this.df, this.doc);
+    },
+    borderClasses(): string {
+      if (!this.border) {
+        return '';
+      }
+
+      const border = 'border border-gray-200';
+      let background = 'bg-gray-25';
+      if (this.isReadOnly) {
+        background = 'bg-gray-50';
+      }
+
+      if (this.showInput) {
+        return background;
+      }
+
+      return border + ' ' + background;
+    },
+  },
 });
 </script>

--- a/src/components/Controls/Datetime.vue
+++ b/src/components/Controls/Datetime.vue
@@ -1,93 +1,25 @@
-<template>
-  <Popover>
-    <!-- Datetime Selected Display -->
-    <template #target="{ togglePopover }">
-      <div :class="labelClasses" v-if="showLabel">
-        {{ df?.label }}
-      </div>
-      <div
-        :class="[containerClasses, sizeClasses]"
-        class="flex"
-        @click="() => !isReadOnly && togglePopover()"
-      >
-        <p
-          :class="[baseInputClasses]"
-          class="overflow-auto no-scrollbar whitespace-nowrap"
-          v-if="!isEmpty"
-        >
-          {{ formattedValue }}
-        </p>
-        <p v-else-if="inputPlaceholder" class="text-base text-gray-500 w-full">
-          {{ inputPlaceholder }}
-        </p>
-
-        <button v-if="!isReadOnly" class="p-0.5 rounded -me-1 ms-1">
-          <FeatherIcon
-            name="calendar"
-            class="w-4 h-4"
-            :class="showMandatory ? 'text-red-600' : 'text-gray-600'"
-          />
-        </button>
-      </div>
-    </template>
-
-    <!-- Datetime Input Popover -->
-    <template #content>
-      <DatetimePicker
-        :show-clear="!isRequired"
-        :select-time="selectTime"
-        :model-value="internalValue"
-        :format-value="formatValue"
-        @update:model-value="(value) => triggerChange(value)"
-      />
-    </template>
-  </Popover>
-</template>
-
 <script lang="ts">
-import { Field } from 'schemas/types';
-import { defineComponent, PropType } from 'vue';
-import DatetimePicker from './DatetimePicker.vue';
-import FeatherIcon from '../FeatherIcon.vue';
-import Popover from '../Popover.vue';
-import Base from './Base.vue';
+import { defineComponent } from 'vue';
+import DateVue from './Date.vue';
+import { DateTime } from 'luxon';
 
 export default defineComponent({
-  extends: Base,
-  props: { value: [Date, String], df: Object as PropType<Field> },
-  components: { Popover, FeatherIcon, DatetimePicker },
-  data() {
-    return { selectTime: true };
-  },
+  extends: DateVue,
   computed: {
-    internalValue() {
-      if (this.value == null) {
-        return undefined;
+    inputType() {
+      return 'datetime-local';
+    },
+    inputValue(): string {
+      let value = this.value;
+      if (typeof value === 'string') {
+        value = new Date(value);
       }
 
-      if (typeof this.value === 'string') {
-        return new Date(this.value);
+      if (value instanceof Date && !Number.isNaN(value.valueOf())) {
+        return DateTime.fromJSDate(value).toISO().split('.')[0];
       }
 
-      return this.value;
-    },
-    formattedValue() {
-      return this.formatValue(this.internalValue);
-    },
-  },
-  methods: {
-    triggerChange(value: Date | null) {
-      this.$emit('change', value);
-    },
-    formatValue(value?: Date | null) {
-      if (value == null) {
-        return '';
-      }
-
-      return this.fyo.format(
-        value,
-        this.df ?? (this.selectTime ? 'Datetime' : 'Date')
-      );
+      return '';
     },
   },
 });

--- a/src/components/Controls/Datetime_old.vue
+++ b/src/components/Controls/Datetime_old.vue
@@ -1,0 +1,106 @@
+<template>
+  <Popover>
+    <!-- Datetime Selected Display -->
+    <template #target="{ togglePopover }">
+      <div :class="labelClasses" v-if="showLabel">
+        {{ df?.label }}
+      </div>
+      <div
+        :class="[containerClasses, sizeClasses]"
+        class="flex"
+        @click="() => !isReadOnly && togglePopover()"
+      >
+        <p
+          :class="[baseInputClasses]"
+          class="overflow-auto no-scrollbar whitespace-nowrap"
+          v-if="!isEmpty"
+        >
+          {{ formattedValue }}
+        </p>
+        <p v-else-if="inputPlaceholder" class="text-base text-gray-500 w-full">
+          {{ inputPlaceholder }}
+        </p>
+
+        <button v-if="!isReadOnly" class="p-0.5 rounded -me-1 ms-1">
+          <FeatherIcon
+            name="calendar"
+            class="w-4 h-4"
+            :class="showMandatory ? 'text-red-600' : 'text-gray-600'"
+          />
+        </button>
+      </div>
+    </template>
+
+    <!-- Datetime Input Popover -->
+    <template #content>
+      <DatetimePicker
+        :show-clear="!isRequired"
+        :select-time="selectTime"
+        :model-value="internalValue"
+        :format-value="formatValue"
+        @update:model-value="(value) => triggerChange(value)"
+      />
+    </template>
+  </Popover>
+</template>
+
+<script lang="ts">
+/**
+ * This is a Datetime/Date component that builds
+ * uses a custom DatetimePicker. It is not being used
+ * for now because users are more familiar with their
+ * system's date and datetime picker.
+ *
+ * That provides better UX.
+ *
+ * This component can be used once the underlying
+ * DatetimePicker's UX issues are solved.
+ */
+
+import { Field } from 'schemas/types';
+import { defineComponent, PropType } from 'vue';
+import DatetimePicker from './DatetimePicker.vue';
+import FeatherIcon from '../FeatherIcon.vue';
+import Popover from '../Popover.vue';
+import Base from './Base.vue';
+
+export default defineComponent({
+  extends: Base,
+  props: { value: [Date, String], df: Object as PropType<Field> },
+  components: { Popover, FeatherIcon, DatetimePicker },
+  data() {
+    return { selectTime: true };
+  },
+  computed: {
+    internalValue() {
+      if (this.value == null) {
+        return undefined;
+      }
+
+      if (typeof this.value === 'string') {
+        return new Date(this.value);
+      }
+
+      return this.value;
+    },
+    formattedValue() {
+      return this.formatValue(this.internalValue);
+    },
+  },
+  methods: {
+    triggerChange(value: Date | null) {
+      this.$emit('change', value);
+    },
+    formatValue(value?: Date | null) {
+      if (value == null) {
+        return '';
+      }
+
+      return this.fyo.format(
+        value,
+        this.df ?? (this.selectTime ? 'Datetime' : 'Date')
+      );
+    },
+  },
+});
+</script>


### PR DESCRIPTION
Switches `Date` and `Datetime` components to use native `date` and `datetime-local` input elements from the custom `DatetimePicker` component.

This is cause, users are more familiar with the date and time selector of their OS. Using a custom component leads to inferior UX. Once the UX of `DatetimePicker` is fixed, it can be used instead.