### PR TITLE
fix date (hopefully)

### DIFF
--- a/fyo/core/converter.ts
+++ b/fyo/core/converter.ts
@@ -345,12 +345,23 @@ function toRawFloat(value: DocValue, field: Field): number {
 }
 
 function toRawDate(value: DocValue, field: Field): string | null {
-  const dateTime = toRawDateTime(value, field);
-  if (dateTime === null) {
+  if (value === null) {
     return null;
   }
 
-  return dateTime.split('T')[0];
+  if (typeof value === 'string' || typeof value === 'number') {
+    value = new Date(value);
+  }
+
+  if (value instanceof DateTime) {
+    return value.toISODate();
+  }
+
+  if (value instanceof Date) {
+    return DateTime.fromJSDate(value).toISODate();
+  }
+
+  throwError(value, field, 'raw');
 }
 
 function toRawDateTime(value: DocValue, field: Field): string | null {
@@ -367,7 +378,7 @@ function toRawDateTime(value: DocValue, field: Field): string | null {
   }
 
   if (value instanceof DateTime) {
-    return (value as DateTime).toISO();
+    return value.toJSDate().toISOString();
   }
 
   throwError(value, field, 'raw');

--- a/src/components/Controls/Date.vue
+++ b/src/components/Controls/Date.vue
@@ -46,6 +46,7 @@
   </div>
 </template>
 <script lang="ts">
+import { DateTime } from 'luxon';
 import { fyo } from 'src/initFyo';
 import { defineComponent, nextTick } from 'vue';
 import Base from './Base.vue';
@@ -66,7 +67,7 @@ export default defineComponent({
       }
 
       if (value instanceof Date && !Number.isNaN(value.valueOf())) {
-        return value.toISOString().split('T')[0];
+        return DateTime.fromJSDate(value).toISODate();
       }
 
       return '';
@@ -115,8 +116,6 @@ export default defineComponent({
       this.showInput = false;
 
       let value: Date | null = new Date(target.value);
-      value.setHours(0, 0, 0, 0);
-
       if (Number.isNaN(value.valueOf())) {
         value = null;
       }


### PR DESCRIPTION
- fix: return local date for display
- fix: store as local date in ISO format - datetime is stored in UTC

In Date.vue local date was being converted to UTC before using only the date
component.

Due to this depending on the timezone the date portion was a day ahead or behind
local date, for example:

```
local datetime gmt-0400 = 2023-07-19 00:00:00
  utc datetime gmt+0000 = 2023-07-18 20:00:00
```

hopefully this PR corrects it.

closes #689 
