### PR TITLE
fix: use luxon for Date to and from string

### DIFF
--- a/fyo/core/converter.ts
+++ b/fyo/core/converter.ts
@@ -184,11 +184,11 @@ function toDocDate(value: RawValue, field: Field) {
     return null;
   }
 
-  if (typeof value !== 'number' && typeof value !== 'string') {
+  if (typeof value !== 'string') {
     throwError(value, field, 'doc');
   }
 
-  const date = new Date(value);
+  const date = DateTime.fromISO(value).toJSDate();
   if (date.toString() === 'Invalid Date') {
     throwError(value, field, 'doc');
   }
@@ -353,12 +353,12 @@ function toRawDate(value: DocValue, field: Field): string | null {
     value = new Date(value);
   }
 
-  if (value instanceof DateTime) {
-    return value.toISODate();
-  }
-
   if (value instanceof Date) {
     return DateTime.fromJSDate(value).toISODate();
+  }
+
+  if (value instanceof DateTime) {
+    return value.toISODate();
   }
 
   throwError(value, field, 'raw');

--- a/src/components/Controls/Date.vue
+++ b/src/components/Controls/Date.vue
@@ -115,7 +115,7 @@ export default defineComponent({
       }
       this.showInput = false;
 
-      let value: Date | null = new Date(target.value);
+      let value: Date | null = DateTime.fromISO(target.value).toJSDate();
       if (Number.isNaN(value.valueOf())) {
         value = null;
       }


### PR DESCRIPTION
Uses luxon `DateTime.fromJSDate` and `DateTime.fromISO` to convert from JS date to ISO and from ISO to JS date.

When storing dates the time is not stored, so it's local date that's being stored. Blindly stripping the time information from `Date().toISOString()` will cause date to jump around.

- `new Date(isoDate)` sets hours to UTC 00:00:00
- `DateTime.fromISO(isoDate)` sets hours to Local 00:00:00

Mismatch in using different transformations from string to date and vice versa also causes dates to jump around.

Should close #700 