### PR TITLE
fix: stock return PR (#682)

### DIFF
--- a/models/inventory/StockTransfer.ts
+++ b/models/inventory/StockTransfer.ts
@@ -274,7 +274,7 @@ export abstract class StockTransfer extends Transfer {
   }
 
   async _updateItemsReturned() {
-    if (this.isSyncing || !this.returnAgainst) {
+    if (!this.returnAgainst) {
       return;
     }
 

--- a/models/inventory/StockTransfer.ts
+++ b/models/inventory/StockTransfer.ts
@@ -45,7 +45,7 @@ export abstract class StockTransfer extends Transfer {
   }
 
   get isReturn(): boolean {
-    return !!this.returnAgainst && this.returnAgainst.length > 1;
+    return !!this.returnAgainst;
   }
 
   get invoiceSchemaName() {

--- a/models/inventory/StockTransfer.ts
+++ b/models/inventory/StockTransfer.ts
@@ -68,7 +68,8 @@ export abstract class StockTransfer extends Transfer {
     terms: () => !(this.terms || !(this.isSubmitted || this.isCancelled)),
     attachment: () =>
       !(this.attachment || !(this.isSubmitted || this.isCancelled)),
-    returnAgainst: () => this.isSubmitted && !this.returnAgainst,
+    returnAgainst: () =>
+      (this.isSubmitted || this.isCancelled) && !this.returnAgainst,
   };
 
   static defaults: DefaultMap = {

--- a/models/inventory/StockTransfer.ts
+++ b/models/inventory/StockTransfer.ts
@@ -198,6 +198,7 @@ export abstract class StockTransfer extends Transfer {
     await validateBatch(this);
     await validateSerialNumber(this);
     await validateSerialNumberStatus(this);
+    await this._validateHasReturnDocs();
   }
 
   async afterSubmit() {
@@ -205,11 +206,6 @@ export abstract class StockTransfer extends Transfer {
     await updateSerialNumbers(this, false, this.isReturn);
     await this._updateBackReference();
     await this._updateItemsReturned();
-  }
-
-  async beforeCancel(): Promise<void> {
-    await super.beforeCancel();
-    await this._validateHasReturnDocs();
   }
 
   async afterCancel(): Promise<void> {
@@ -293,7 +289,7 @@ export abstract class StockTransfer extends Transfer {
   }
 
   async _validateHasReturnDocs() {
-    if (!this.name) {
+    if (!this.name || !this.isCancelled) {
       return;
     }
 


### PR DESCRIPTION
**Fixes mentioned issues with PR #682**

## 

- [x] [Extra condition](https://github.com/frappe/books/pull/682#discussion_r1298210966) to check `isReturn` in `StockTransfer` .
- [x]  `returnAgainst` [hiding rule](https://github.com/frappe/books/pull/682#discussion_r1298214124).
- [x] [redundant exit condition](https://github.com/frappe/books/pull/682#discussion_r1298217374) for `_updateItemsReturned` .
- [x]  [move](https://github.com/frappe/books/pull/682#discussion_r1298229117) `validateHasReturnDocs` to `validate`.