### PR TITLE
Add regional schema for Switzerland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+*.code-workspace
 
 #Electron-builder output
 /dist_electron

--- a/schemas/regional/ch/AccountingSettings.json
+++ b/schemas/regional/ch/AccountingSettings.json
@@ -1,0 +1,21 @@
+{
+  "name": "AccountingSettings",
+  "fields": [
+    {
+      "fieldname": "taxId",
+      "label": "Tax ID",
+      "fieldtype": "Data",
+      "placeholder": "CHE-123.456.789",
+      "section": "Default"
+    }
+  ],
+  "quickEditFields": [
+    "fullname",
+    "email",
+    "companyName",
+    "country",
+    "fiscalYearStart",
+    "fiscalYearEnd",
+    "taxId"
+  ]
+}

--- a/schemas/regional/ch/index.ts
+++ b/schemas/regional/ch/index.ts
@@ -1,0 +1,4 @@
+import { SchemaStub } from '../../types';
+import AccountingSettings from './AccountingSettings.json';
+
+export default [AccountingSettings] as SchemaStub[];

--- a/schemas/regional/index.ts
+++ b/schemas/regional/index.ts
@@ -1,7 +1,11 @@
 import { SchemaStub } from 'schemas/types';
 import IndianSchemas from './in';
+import SwissSchemas from './ch';
 
 /**
  * Regional Schemas are exported by country code.
  */
-export default { in: IndianSchemas } as Record<string, SchemaStub[]>;
+export default { in: IndianSchemas, ch: SwissSchemas } as Record<
+  string,
+  SchemaStub[]
+>;

--- a/src/utils/printTemplates.ts
+++ b/src/utils/printTemplates.ts
@@ -29,7 +29,7 @@ const printSettingsFields = [
   'address',
   'companyName',
 ];
-const accountingSettingsFields = ['gstin'];
+const accountingSettingsFields = ['gstin', 'taxId'];
 
 export async function getPrintTemplatePropValues(
   doc: Doc


### PR DESCRIPTION
Fixes  #768, allowes to specify Tax ID (VAT number) if country is `Switzerland`, propagates the `taxId` attribute to print object to be usable in the print templates.