### PR TITLE
Various bug fixes

### DIFF
--- a/reports/AccountReport.ts
+++ b/reports/AccountReport.ts
@@ -64,12 +64,12 @@ export abstract class AccountReport extends LedgerReport {
     this._dateRanges = await this._getDateRanges();
   }
 
-  getRootNode(
+  getRootNodes(
     rootType: AccountRootType,
     accountTree: AccountTree
-  ): AccountTreeNode | undefined {
+  ): AccountTreeNode[] | undefined {
     const rootNodeList = Object.values(accountTree);
-    return rootNodeList.find((n) => n.rootType === rootType);
+    return rootNodeList.filter((n) => n.rootType === rootType);
   }
 
   getEmptyRow(): ReportRow {
@@ -88,8 +88,11 @@ export abstract class AccountReport extends LedgerReport {
     };
   }
 
-  getTotalNode(rootNode: AccountTreeNode, name: string): AccountListNode {
-    const accountTree = { [rootNode.name]: rootNode };
+  getTotalNode(rootNodes: AccountTreeNode[], name: string): AccountListNode {
+    const accountTree: Tree = {};
+    for (const rootNode of rootNodes) {
+      accountTree[rootNode.name] = rootNode;
+    }
     const leafNodes = getListOfLeafNodes(accountTree) as AccountTreeNode[];
 
     const totalMap = leafNodes.reduce((acc, node) => {
@@ -241,9 +244,9 @@ export abstract class AccountReport extends LedgerReport {
   // also the last day.
   _fixMonthsJump(refDate: DateTime, date: DateTime): DateTime {
     if (refDate.day == refDate.daysInMonth && date.day != date.daysInMonth) {
-      return date.set({day: date.daysInMonth})
+      return date.set({ day: date.daysInMonth });
     } else {
-      return date
+      return date;
     }
   }
 
@@ -263,7 +266,10 @@ export abstract class AccountReport extends LedgerReport {
 
     const months: number = monthsMap[this.periodicity];
     const dateRanges: DateRange[] = [
-      { toDate, fromDate: this._fixMonthsJump(toDate, toDate.minus({ months })) },
+      {
+        toDate,
+        fromDate: this._fixMonthsJump(toDate, toDate.minus({ months })),
+      },
     ];
 
     let count = this.count ?? 1;
@@ -275,7 +281,10 @@ export abstract class AccountReport extends LedgerReport {
       const lastRange = dateRanges.at(-1)!;
       dateRanges.push({
         toDate: lastRange.fromDate,
-        fromDate: this._fixMonthsJump(toDate, lastRange.fromDate.minus({ months })),
+        fromDate: this._fixMonthsJump(
+          toDate,
+          lastRange.fromDate.minus({ months })
+        ),
       });
     }
 
@@ -457,13 +466,13 @@ export async function getFiscalEndpoints(
   const fromDate = [
     fromYear,
     (fys.getMonth() + 1).toString().padStart(2, '0'),
-    fys.getDate().toString().padStart(2, '0')
+    fys.getDate().toString().padStart(2, '0'),
   ].join('-');
 
   const toDate = [
     toYear,
     (fye.getMonth() + 1).toString().padStart(2, '0'),
-    fye.getDate().toString().padStart(2, '0')
+    fye.getDate().toString().padStart(2, '0'),
   ].join('-');
 
   return { fromDate, toDate };
@@ -585,15 +594,17 @@ function getPrunedChildren(children: AccountTreeNode[]): AccountTreeNode[] {
   });
 }
 
-export function convertAccountRootNodeToAccountList(
-  rootNode: AccountTreeNode
+export function convertAccountRootNodesToAccountList(
+  rootNodes: AccountTreeNode[]
 ): AccountList {
-  if (!rootNode) {
+  if (!rootNodes || rootNodes.length == 0) {
     return [];
   }
 
   const accountList: AccountList = [];
-  pushToAccountList(rootNode, accountList, 0);
+  for (const rootNode of rootNodes) {
+    pushToAccountList(rootNode, accountList, 0);
+  }
   return accountList;
 }
 

--- a/reports/BalanceSheet/BalanceSheet.ts
+++ b/reports/BalanceSheet/BalanceSheet.ts
@@ -5,7 +5,7 @@ import {
 } from 'models/baseModels/Account/types';
 import {
   AccountReport,
-  convertAccountRootNodeToAccountList,
+  convertAccountRootNodesToAccountList,
 } from 'reports/AccountReport';
 import { ReportData, RootTypeRow } from 'reports/types';
 import { getMapFromList } from 'utils';
@@ -44,15 +44,15 @@ export class BalanceSheet extends AccountReport {
 
     const rootTypeRows: RootTypeRow[] = this.rootTypes
       .map((rootType) => {
-        const rootNode = this.getRootNode(rootType, accountTree)!;
-        const rootList = convertAccountRootNodeToAccountList(rootNode);
+        const rootNodes = this.getRootNodes(rootType, accountTree)!;
+        const rootList = convertAccountRootNodesToAccountList(rootNodes);
         return {
           rootType,
-          rootNode,
+          rootNodes,
           rows: this.getReportRowsFromAccountList(rootList),
         };
       })
-      .filter((row) => !!row.rootNode);
+      .filter((row) => !!row.rootNodes.length);
 
     this.reportData = this.getReportDataFromRows(
       getMapFromList(rootTypeRows, 'rootType')
@@ -88,8 +88,8 @@ export class BalanceSheet extends AccountReport {
 
       reportData.push(...row.rows);
 
-      if (row.rootNode) {
-        const totalNode = this.getTotalNode(row.rootNode, totalName);
+      if (row.rootNodes.length) {
+        const totalNode = this.getTotalNode(row.rootNodes, totalName);
         const totalRow = this.getRowFromAccountListNode(totalNode);
         reportData.push(totalRow);
       }

--- a/reports/TrialBalance/TrialBalance.ts
+++ b/reports/TrialBalance/TrialBalance.ts
@@ -9,7 +9,7 @@ import {
   AccountReport,
   ACC_BAL_WIDTH,
   ACC_NAME_WIDTH,
-  convertAccountRootNodeToAccountList,
+  convertAccountRootNodesToAccountList,
   getFiscalEndpoints,
 } from 'reports/AccountReport';
 import {
@@ -65,15 +65,15 @@ export class TrialBalance extends AccountReport {
 
     const rootTypeRows: RootTypeRow[] = this.rootTypes
       .map((rootType) => {
-        const rootNode = this.getRootNode(rootType, accountTree)!;
-        const rootList = convertAccountRootNodeToAccountList(rootNode);
+        const rootNodes = this.getRootNodes(rootType, accountTree)!;
+        const rootList = convertAccountRootNodesToAccountList(rootNodes);
         return {
           rootType,
-          rootNode,
+          rootNodes,
           rows: this.getReportRowsFromAccountList(rootList),
         };
       })
-      .filter((row) => !!row.rootNode);
+      .filter((row) => !!(row.rootNodes && row.rootNodes.length));
 
     this.reportData = await this.getReportDataFromRows(rootTypeRows);
     this.loading = false;

--- a/reports/types.ts
+++ b/reports/types.ts
@@ -107,6 +107,6 @@ export type Tree = Record<string, TreeNode>;
 
 export type RootTypeRow = {
   rootType: AccountRootType;
-  rootNode: AccountTreeNode;
+  rootNodes: AccountTreeNode[];
   rows: ReportData;
 };


### PR DESCRIPTION
**[AccountReport] Fix date calculation**

fyo.getValue(*, 'fiscalYear{Start,End}') returns a javascript Date object that encodes the filcal year as local time (01-01 and 12-31 at midnight). This date must not be converted to UTC else east timezones will return the day before (12-31 and 12-30). Use locale time values instead.

When computing the monthly/quaterly/half yearly time periods, correct the dates in the particular case where the last day of the month is selected as reference date (yields series 12-31 11-30 10-31 09-30 ...) instead of (12-31 11-30 10-30 09-30 ...).

**[fix reports] Allow multiple root account to have the same type**

In French accounting, multiple root accounts can be of the same type, ensure that reports take all accounts and not only the first one.