### PR TITLE
feat: #755 taxes on payments

### DIFF
--- a/models/baseModels/Payment/Payment.ts
+++ b/models/baseModels/Payment/Payment.ts
@@ -28,10 +28,12 @@ import { Invoice } from '../Invoice/Invoice';
 import { Party } from '../Party/Party';
 import { PaymentFor } from '../PaymentFor/PaymentFor';
 import { PaymentMethod, PaymentType } from './types';
+import { TaxSummary } from '../TaxSummary/TaxSummary';
 
 type AccountTypeMap = Record<AccountTypeEnum, string[] | undefined>;
 
 export class Payment extends Transactional {
+  taxes?: TaxSummary[];
   party?: string;
   amount?: Money;
   writeoff?: Money;
@@ -221,6 +223,80 @@ export class Payment extends Transactional {
     );
   }
 
+  async getTaxSummary() {
+    const taxes: Record<
+      string,
+      Record<
+        string,
+        {
+          account: string;
+          from_account: string;
+          rate: number;
+          amount: Money;
+        }
+      >
+    > = {};
+
+    for (const childDoc of this.for ?? []) {
+      const referenceName = childDoc.referenceName;
+      const referenceType = childDoc.referenceType;
+
+      const refDoc = (await this.fyo.doc.getDoc(
+        childDoc.referenceType!,
+        childDoc.referenceName
+      )) as Invoice;
+
+      if (referenceName && referenceType && !refDoc) {
+        throw new ValidationError(
+          t`${referenceType} of type ${
+            this.fyo.schemaMap?.[referenceType]?.label ?? referenceType
+          } does not exist`
+        );
+      }
+
+      if (!refDoc) {
+        continue;
+      }
+
+      for(const {details, taxAmount, exchangeRate} of await refDoc.getTaxItems()) {
+        const { account, payment_account } = details
+        if (!payment_account) {
+          continue
+        }
+
+        taxes[payment_account] ??= {}
+        taxes[payment_account][account] ??= {
+          account: payment_account,
+          from_account: account,
+          rate: details.rate,
+          amount: this.fyo.pesa(0),
+        }
+
+        taxes[payment_account][account].amount = taxes[payment_account][account].amount.add(taxAmount.mul(exchangeRate ?? 1));
+      }
+    }
+
+    type Summary = typeof taxes[string][string] & { idx: number };
+    const taxArr: Summary[] = [];
+    let idx = 0;
+    for (const payment_account in taxes) {
+      for (const account in taxes[payment_account]) {
+        const tax = taxes[payment_account][account];
+        if (tax.amount.isZero()) {
+          continue;
+        }
+
+        taxArr.push({
+          ...tax,
+          idx,
+        });
+        idx += 1;
+      }
+    }
+
+    return taxArr;
+  }
+
   async getPosting() {
     /**
      * account        : From Account
@@ -243,6 +319,20 @@ export class Payment extends Transactional {
 
     await posting.debit(paymentAccount, amount);
     await posting.credit(account, amount);
+
+    if (this.taxes) {
+      if (this.paymentType === 'Receive') {
+        for (const tax of this.taxes) {
+          await posting.debit(tax.from_account!, tax.amount!)
+          await posting.credit(tax.account!, tax.amount!)
+        }
+      } else if  (this.paymentType === 'Pay') {
+        for (const tax of this.taxes) {
+          await posting.credit(tax.from_account!, tax.amount!)
+          await posting.debit(tax.account!, tax.amount!)
+        }
+      }
+    }
 
     await this.applyWriteOffPosting(posting);
     return posting;
@@ -546,6 +636,7 @@ export class Payment extends Transactional {
         return this.for![0].referenceType;
       },
     },
+    taxes: { formula: async () => await this.getTaxSummary() },
   };
 
   validations: ValidationMap = {
@@ -588,6 +679,7 @@ export class Payment extends Transactional {
     attachment: () =>
       !(this.attachment || !(this.isSubmitted || this.isCancelled)),
     for: () => !!((this.isSubmitted || this.isCancelled) && !this.for?.length),
+    taxes: () => !this.taxes?.length,
   };
 
   static filters: FiltersMap = {

--- a/models/baseModels/TaxSummary/TaxSummary.ts
+++ b/models/baseModels/TaxSummary/TaxSummary.ts
@@ -9,6 +9,7 @@ import { Invoice } from '../Invoice/Invoice';
 
 export class TaxSummary extends Doc {
   account?: string;
+  from_account?: string;
   rate?: number;
   amount?: Money;
   parentdoc?: Invoice;

--- a/schemas/app/Payment.json
+++ b/schemas/app/Payment.json
@@ -142,6 +142,14 @@
       "section": "Amounts"
     },
     {
+      "fieldname": "taxes",
+      "label": "Taxes",
+      "fieldtype": "Table",
+      "target": "TaxSummary",
+      "readOnly": true,
+      "section": "Amounts"
+    },
+    {
       "fieldname": "for",
       "label": "Payment Reference",
       "fieldtype": "Table",

--- a/schemas/app/TaxDetail.json
+++ b/schemas/app/TaxDetail.json
@@ -6,11 +6,19 @@
   "fields": [
     {
       "fieldname": "account",
-      "label": "Tax Account",
+      "label": "Tax Invoice Account",
       "fieldtype": "Link",
       "target": "Account",
       "create": true,
       "required": true
+    },
+    {
+      "fieldname": "payment_account",
+      "label": "Tax Payment Account",
+      "fieldtype": "Link",
+      "target": "Account",
+      "create": true,
+      "required": false
     },
     {
       "fieldname": "rate",
@@ -20,5 +28,5 @@
       "placeholder": "0%"
     }
   ],
-  "tableFields": ["account", "rate"]
+  "tableFields": ["account", "payment_account", "rate"]
 }

--- a/schemas/app/TaxSummary.json
+++ b/schemas/app/TaxSummary.json
@@ -11,6 +11,14 @@
       "required": true
     },
     {
+      "fieldname": "from_account",
+      "label": "Tax Invoice Account",
+      "fieldtype": "Link",
+      "target": "Account",
+      "required": false,
+      "hidden": true
+    },
+    {
       "fieldname": "rate",
       "label": "Tax Rate",
       "fieldtype": "Float",


### PR DESCRIPTION
When defining taxes, it is possible to define an additional payment    account that will be used during payments to move taxes from the    original tax account to this new payment tax account. This allows to    account for taxes only when payment is received.
    
Now payments can reference tax summary objects that will reference the    two accounts to move funds between when the payment is committed. Reuse   some of the Invoice code to generate these tax summary objects.
