### PR TITLE
feat: #755 Accounting for taxes on payments

### DIFF
--- a/models/baseModels/Invoice/Invoice.ts
+++ b/models/baseModels/Invoice/Invoice.ts
@@ -28,6 +28,19 @@ import { TaxSummary } from '../TaxSummary/TaxSummary';
 import { ReturnDocItem } from 'models/inventory/types';
 import { AccountFieldEnum, PaymentTypeEnum } from '../Payment/types';
 
+export type TaxDetail = {
+  account: string;
+  payment_account?: string;
+  rate: number;
+};
+
+export type InvoiceTaxItem = {
+  details: TaxDetail;
+  exchangeRate?: number;
+  fullAmount: Money;
+  taxAmount: Money;
+};
+
 export abstract class Invoice extends Transactional {
   _taxes: Record<string, Tax> = {};
   taxes?: TaxSummary[];
@@ -242,6 +255,38 @@ export abstract class Invoice extends Transactional {
     return safeParseFloat(exchangeRate.toFixed(2));
   }
 
+  async getTaxItems(): Promise<InvoiceTaxItem[]> {
+    const taxItems: InvoiceTaxItem[] = [];
+    for (const item of this.items ?? []) {
+      if (!item.tax) {
+        continue;
+      }
+
+      const tax = await this.getTax(item.tax);
+      for (const details of (tax.details ?? []) as TaxDetail[]) {
+        let amount = item.amount!;
+        if (
+          this.enableDiscounting &&
+          !this.discountAfterTax &&
+          !item.itemDiscountedTotal?.isZero()
+        ) {
+          amount = item.itemDiscountedTotal!;
+        }
+
+        const taxItem: InvoiceTaxItem = {
+          details,
+          exchangeRate: this.exchangeRate ?? 1,
+          fullAmount: amount,
+          taxAmount: amount.mul(details.rate / 100),
+        };
+
+        taxItems.push(taxItem);
+      }
+    }
+
+    return taxItems;
+  }
+
   async getTaxSummary() {
     const taxes: Record<
       string,
@@ -252,33 +297,16 @@ export abstract class Invoice extends Transactional {
       }
     > = {};
 
-    type TaxDetail = { account: string; rate: number };
+    for (const { details, taxAmount } of await this.getTaxItems()) {
+      const account = details.account;
 
-    for (const item of this.items ?? []) {
-      if (!item.tax) {
-        continue;
-      }
+      taxes[account] ??= {
+        account,
+        rate: details.rate,
+        amount: this.fyo.pesa(0),
+      };
 
-      const tax = await this.getTax(item.tax);
-      for (const { account, rate } of (tax.details ?? []) as TaxDetail[]) {
-        taxes[account] ??= {
-          account,
-          rate,
-          amount: this.fyo.pesa(0),
-        };
-
-        let amount = item.amount!;
-        if (
-          this.enableDiscounting &&
-          !this.discountAfterTax &&
-          !item.itemDiscountedTotal?.isZero()
-        ) {
-          amount = item.itemDiscountedTotal!;
-        }
-
-        const taxAmount = amount.mul(rate / 100);
-        taxes[account].amount = taxes[account].amount.add(taxAmount);
-      }
+      taxes[account].amount = taxes[account].amount.add(taxAmount);
     }
 
     type Summary = typeof taxes[string] & { idx: number };

--- a/models/baseModels/TaxSummary/TaxSummary.ts
+++ b/models/baseModels/TaxSummary/TaxSummary.ts
@@ -9,6 +9,7 @@ import { Invoice } from '../Invoice/Invoice';
 
 export class TaxSummary extends Doc {
   account?: string;
+  from_account?: string;
   rate?: number;
   amount?: Money;
   parentdoc?: Invoice;

--- a/schemas/app/Payment.json
+++ b/schemas/app/Payment.json
@@ -142,6 +142,14 @@
       "section": "Amounts"
     },
     {
+      "fieldname": "taxes",
+      "label": "Taxes",
+      "fieldtype": "Table",
+      "target": "TaxSummary",
+      "readOnly": true,
+      "section": "Amounts"
+    },
+    {
       "fieldname": "for",
       "label": "Payment Reference",
       "fieldtype": "Table",

--- a/schemas/app/TaxDetail.json
+++ b/schemas/app/TaxDetail.json
@@ -6,11 +6,19 @@
   "fields": [
     {
       "fieldname": "account",
-      "label": "Tax Account",
+      "label": "Tax Invoice Account",
       "fieldtype": "Link",
       "target": "Account",
       "create": true,
       "required": true
+    },
+    {
+      "fieldname": "payment_account",
+      "label": "Tax Payment Account",
+      "fieldtype": "Link",
+      "target": "Account",
+      "create": true,
+      "required": false
     },
     {
       "fieldname": "rate",
@@ -20,5 +28,5 @@
       "placeholder": "0%"
     }
   ],
-  "tableFields": ["account", "rate"]
+  "tableFields": ["account", "payment_account", "rate"]
 }

--- a/schemas/app/TaxSummary.json
+++ b/schemas/app/TaxSummary.json
@@ -11,6 +11,14 @@
       "required": true
     },
     {
+      "fieldname": "from_account",
+      "label": "Tax Invoice Account",
+      "fieldtype": "Link",
+      "target": "Account",
+      "required": false,
+      "hidden": true
+    },
+    {
       "fieldname": "rate",
       "label": "Tax Rate",
       "fieldtype": "Float",


### PR DESCRIPTION
When defining taxes, it is possible to define an additional payment account that will be used during payments to move taxes from the original tax account to this new payment tax account. This allows to account for taxes only when payment is received.

Now payments can reference tax summary objects that will reference the two accounts to move funds between when the payment is committed. Reuse some of the Invoice code to generate these tax summary objects.

implements #755