### PR TITLE
feat: POS: add items by barcode scan and input

### DIFF
--- a/src/pages/POS/POS.vue
+++ b/src/pages/POS/POS.vue
@@ -35,10 +35,10 @@
     >
       <div class="bg-white border col-span-5 rounded-md">
         <div class="rounded-md p-4 col-span-5">
-          <div class="flex justify-between">
+          <div class="flex gap-x-2">
             <!-- Item Search -->
             <Link
-              class="w-2/3 border-r flex-shrink-0"
+              class="flex-shrink-0 w-2/3"
               :df="{
                 label: t`Search an Item`,
                 fieldtype: 'Link',
@@ -54,6 +54,7 @@
             />
 
             <Barcode
+              class="w-1/3"
               @item-selected="
                 async (name: string) => {
                   await addItem(await getItem(name));

--- a/src/pages/POS/POS.vue
+++ b/src/pages/POS/POS.vue
@@ -38,7 +38,7 @@
           <div class="flex justify-between">
             <!-- Item Search -->
             <Link
-              class="border-r flex-shrink-0 w-2/3"
+              class="w-2/3 border-r flex-shrink-0"
               :df="{
                 label: t`Search an Item`,
                 fieldtype: 'Link',

--- a/src/pages/POS/POS.vue
+++ b/src/pages/POS/POS.vue
@@ -35,22 +35,33 @@
     >
       <div class="bg-white border col-span-5 rounded-md">
         <div class="rounded-md p-4 col-span-5">
-          <!-- Item Search -->
-          <Link
-            class="border-r flex-shrink-0 w-full"
-            :df="{
-              label: t`Search an Item`,
-              fieldtype: 'Link',
-              fieldname: 'item',
-              target: 'Item',
-            }"
-            :border="true"
-            :value="itemSearchTerm"
-            @keyup.enter="
-              async () => await addItem(await getItem(itemSearchTerm))
-            "
-            @change="(item: string) =>itemSearchTerm= item"
-          />
+          <div class="flex justify-between">
+            <!-- Item Search -->
+            <Link
+              class="border-r flex-shrink-0 w-2/3"
+              :df="{
+                label: t`Search an Item`,
+                fieldtype: 'Link',
+                fieldname: 'item',
+                target: 'Item',
+              }"
+              :border="true"
+              :value="itemSearchTerm"
+              @keyup.enter="
+                async () => await addItem(await getItem(itemSearchTerm))
+              "
+              @change="(item: string) =>itemSearchTerm= item"
+            />
+
+            <Barcode
+              @item-selected="
+                async (name: string) => {
+                  await addItem(await getItem(name));
+                }
+              "
+            />
+          </div>
+
           <ItemsTable @add-item="addItem" />
         </div>
       </div>
@@ -199,6 +210,7 @@ import {
   validateShipment,
   validateSinv,
 } from 'src/utils/pos';
+import Barcode from 'src/components/Controls/Barcode.vue';
 
 export default defineComponent({
   name: 'POS',
@@ -213,6 +225,7 @@ export default defineComponent({
     PageHeader,
     PaymentModal,
     SelectedItemTable,
+    Barcode,
   },
   provide() {
     return {


### PR DESCRIPTION
This PR adds the functionality to add items by scanning Barcode or by manually entering the barcode number in the POS.

### Screenshot
![image](https://github.com/frappe/books/assets/60477442/55ae86f3-b03b-4cc3-b7af-125131a2bfdc)

