### PR TITLE
Fix ytd chart issues divide by 0

### DIFF
--- a/src/components/Charts/BarChart.vue
+++ b/src/components/Charts/BarChart.vue
@@ -196,7 +196,7 @@ export default {
             this.padding +
             this.left +
             (i * (this.viewBoxWidth - this.left - 2 * this.padding)) /
-              (this.count - 1)
+              (this.count - 1 || 1) // The "or" one (1) prevents accidentally dividing by 0
         );
     },
     z() {

--- a/src/components/Charts/LineChart.vue
+++ b/src/components/Charts/LineChart.vue
@@ -193,7 +193,7 @@ export default {
             this.padding +
             this.left +
             (i * (this.viewBoxWidth - this.left - 2 * this.padding)) /
-              (this.count - 1)
+              (this.count - 1 || 1) // The "or" one (1) prevents accidentally dividing by 0
         );
     },
     ys() {


### PR DESCRIPTION
In the Dashboard, when selecting "Year to Date", an error occurs as the graph is trying to generate off an array that only contains a single item. As the graph is trying to figure out where to place the item, the count of items (1 in this case) has an item subtracted from it... accidentally resulting in a divide-by-zero edge case