### PR TITLE
Bug fix recorddate inconsistency

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 **/dist_electron
 **/dummy/*.json
 **/.github/ISSUE_TEMPLATE/*.yml
+**/patches/v0_21_0/*

--- a/backend/patches/index.ts
+++ b/backend/patches/index.ts
@@ -5,6 +5,7 @@ import fixRoundOffAccount from './fixRoundOffAccount';
 import testPatch from './testPatch';
 import updateSchemas from './updateSchemas';
 import setPaymentReferenceType from './setPaymentReferenceType';
+import fixLedgerDateTime from './v0_21_0/fixLedgerDateTime';
 
 export default [
   { name: 'testPatch', version: '0.5.0-beta.0', patch: testPatch },
@@ -33,5 +34,10 @@ export default [
     name: 'setPaymentReferenceType',
     version: '0.20.1',
     patch: setPaymentReferenceType,
+  },
+  {
+    name: 'fixLedgerDateTime',
+    version: '0.21.1',
+    patch: fixLedgerDateTime,
   },
 ] as Patch[];

--- a/backend/patches/v0_21_0/fixLedgerDateTime.ts
+++ b/backend/patches/v0_21_0/fixLedgerDateTime.ts
@@ -1,0 +1,34 @@
+import { DatabaseManager } from '../../database/manager';
+
+/* eslint-disable */
+async function execute(dm: DatabaseManager) {
+    await dm.db!.knex!('AccountingLedgerEntry')
+        .select('name', 'date')
+        .then((trx: Array<{name: string; date: Date;}> ) => {
+            trx.forEach(async entry => {
+                const entryDate = new Date(entry['date']);
+                const timeZoneOffset = entryDate.getTimezoneOffset();
+                const offsetMinutes = timeZoneOffset % 60;
+                const offsetHours = (timeZoneOffset - offsetMinutes) / 60;
+
+                let daysToAdd = 0; // If behind or at GMT/Zulu time, don't need to add a day
+                if (timeZoneOffset < 0) {
+                    // If ahead of GMT/Zulu time, need to advance a day forward first
+                    daysToAdd = 1; 
+                }
+
+                entryDate.setDate(entryDate.getDate() + daysToAdd);
+                entryDate.setHours(0 - offsetHours);
+                entryDate.setMinutes(0 - offsetMinutes);
+                entryDate.setSeconds(0);
+                entryDate.setMilliseconds(0);
+
+                await dm.db!.knex!('AccountingLedgerEntry')
+                    .where({ name: entry['name'] })
+                    .update({ date: entryDate.toISOString() });
+            });
+        });
+}
+
+export default { execute, beforeMigrate: true };
+/* eslint-enable */

--- a/models/Transactional/LedgerPosting.ts
+++ b/models/Transactional/LedgerPosting.ts
@@ -90,12 +90,28 @@ export class LedgerPosting {
       return map[account];
     }
 
+    // Timezone inconsistency fix (very ugly code for now)
+    let entryDateTime = this.refDoc.date as string | Date;
+    let dateTimeValue: Date;
+    if (typeof entryDateTime === 'string' || entryDateTime instanceof String) {
+      dateTimeValue = new Date(entryDateTime);
+    } else {
+      dateTimeValue = entryDateTime;
+    }
+    let dtFixedValue = dateTimeValue;
+    let dtMinutes = dtFixedValue.getTimezoneOffset() % 60;
+    let dtHours = (dtFixedValue.getTimezoneOffset() - dtMinutes) / 60;
+    dtFixedValue.setHours(dtFixedValue.getHours() - dtHours);
+    dtFixedValue.setMinutes(dtFixedValue.getMinutes() - dtMinutes);
+
+    // end ugly timezone fix code
+
     const ledgerEntry = this.fyo.doc.getNewDoc(
       ModelNameEnum.AccountingLedgerEntry,
       {
         account: account,
         party: (this.refDoc.party as string) ?? '',
-        date: this.refDoc.date as string | Date,
+        date: dtFixedValue,
         referenceType: this.refDoc.schemaName,
         referenceName: this.refDoc.name!,
         reverted: this.reverted,

--- a/models/Transactional/LedgerPosting.ts
+++ b/models/Transactional/LedgerPosting.ts
@@ -91,18 +91,21 @@ export class LedgerPosting {
     }
 
     // Timezone inconsistency fix (very ugly code for now)
-    let entryDateTime = this.refDoc.date as string | Date;
+    const entryDateTime = this.refDoc.date as string | Date;
     let dateTimeValue: Date;
     if (typeof entryDateTime === 'string' || entryDateTime instanceof String) {
       dateTimeValue = new Date(entryDateTime);
     } else {
       dateTimeValue = entryDateTime;
     }
-    let dtFixedValue = dateTimeValue;
-    let dtMinutes = dtFixedValue.getTimezoneOffset() % 60;
-    let dtHours = (dtFixedValue.getTimezoneOffset() - dtMinutes) / 60;
-    dtFixedValue.setHours(dtFixedValue.getHours() - dtHours);
-    dtFixedValue.setMinutes(dtFixedValue.getMinutes() - dtMinutes);
+    const dtFixedValue = dateTimeValue;
+    const dtMinutes = dtFixedValue.getTimezoneOffset() % 60;
+    const dtHours = (dtFixedValue.getTimezoneOffset() - dtMinutes) / 60;
+    // Forcing the time to always be set to 00:00.000 for locale time
+    dtFixedValue.setHours(0 - dtHours);
+    dtFixedValue.setMinutes(0 - dtMinutes);
+    dtFixedValue.setSeconds(0);
+    dtFixedValue.setMilliseconds(0);
 
     // end ugly timezone fix code
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frappe-books",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Simple book-keeping app for everyone",
   "author": {
     "name": "Frappe Technologies Pvt. Ltd.",


### PR DESCRIPTION
After doing some testing in various timezones it looks like this (very ugly) patch successfully fixes the various timestamp inconsistency issues, which resulted in incorrect ledgers, profit/loss, etc

What was happening is that depending on one's timezone, the Date that was saved in the JournalEntry/Ledger would convert the Datetime to a timestamp of `00:00.000` for the local timezone and *then* calculates the GMT timestamp based on the local timezone. This creates an instance where what is saved may not properly reflect what was entered and expected in the related invoices (or other items). 

Here are two test cases showing the issue of what was happening:
---



1. Test case 1 (Myanmar timezone -> `GMT +6.5`)
<img width="490" alt="image" src="https://github.com/frappe/books/assets/1480896/dae5d6ef-5b58-48db-80c0-6a713eb80e7d">

The time is converted to GMT which is 6.5 hours behind Myanmar at that point of time, resulting in saving the datetime as previous date (in this test case, `2022-12-31T17:30.000Z`)  

---

2. Test case 2 (US Pacific timezone -> `GMT -8`)
<img width="649" alt="Screenshot 2024-01-30 193727" src="https://github.com/frappe/books/assets/1480896/0191e994-f8ec-4f66-aaeb-7b20498ad1de">  

In this case, when the timestamp for the local timezone is `00:00.000`,  GMT time will be 8 hours ahead (`2023-01-01T08:00.000Z`)
