### PR TITLE
[Bug] - Fix Type error in Colors.vue without default colors

### DIFF
--- a/src/components/Controls/Color.vue
+++ b/src/components/Controls/Color.vue
@@ -71,6 +71,7 @@ export default {
       return this.df.options;
     },
     selectedColorLabel() {
+      if(!this.colors) return this.value;
       const color = this.colors.find((c) => this.value === c.value);
       return color ? color.label : this.value;
     },

--- a/src/components/Controls/Color.vue
+++ b/src/components/Controls/Color.vue
@@ -71,7 +71,7 @@ export default {
       return this.df.options;
     },
     selectedColorLabel() {
-      if(!this.colors) return this.value;
+      if (!this.colors) return this.value;
       const color = this.colors.find((c) => this.value === c.value);
       return color ? color.label : this.value;
     },


### PR DESCRIPTION
### Issue

When adding a color field by customizing the form without specifying default values, `Color.vue` throws a Type error because it tries to find the color from an undefined colors array

### Changes Made

Added a condition before the `find` call to return the value if there are no items in the colors array.
![Screenshot from 2024-02-02 18 23 29](https://github.com/frappe/books/assets/26800640/323418ed-220b-4a49-be6b-843db8ea62b3)
![Screenshot from 2024-02-02 18 21 44](https://github.com/frappe/books/assets/26800640/2500e586-756c-4cef-bd41-a54317233607)
