### PR TITLE
fix: hide pricelist field when its empty and doc is submitted/cancelled

### DIFF
--- a/models/baseModels/Invoice/Invoice.ts
+++ b/models/baseModels/Invoice/Invoice.ts
@@ -692,7 +692,9 @@ export abstract class Invoice extends Transactional {
       !(this.attachment || !(this.isSubmitted || this.isCancelled)),
     backReference: () => !this.backReference,
     quote: () => !this.quote,
-    priceList: () => !this.fyo.singles.AccountingSettings?.enablePriceList,
+    priceList: () =>
+      !this.fyo.singles.AccountingSettings?.enablePriceList ||
+      (!this.canEdit && !this.priceList),
     returnAgainst: () =>
       (this.isSubmitted || this.isCancelled) && !this.returnAgainst,
   };


### PR DESCRIPTION
fixes #844 

### Screenshots

Pricelist: none, Doc Status: `Cancelled`
![image](https://github.com/frappe/books/assets/60477442/19c8b5b8-0af7-4669-9c5b-d70aadadbfb0)

Pricelist: yes, Doc Status: `Submitted`
![image](https://github.com/frappe/books/assets/60477442/4291ae23-a8fa-48d7-b13c-a438d346a5ad)

Pricelist: no, Doc Status: `Saved`
![image](https://github.com/frappe/books/assets/60477442/7851b343-75c3-442e-9f1c-de7c9b312f15)



