### PR TITLE
fix: hide barcode field in pos if not enabled

### DIFF
--- a/src/pages/POS/POS.vue
+++ b/src/pages/POS/POS.vue
@@ -38,7 +38,11 @@
           <div class="flex gap-x-2">
             <!-- Item Search -->
             <Link
-              class="flex-shrink-0 w-2/3"
+              :class="
+                fyo.singles.InventorySettings?.enableBarcodes
+                  ? 'flex-shrink-0 w-2/3'
+                  : 'w-full'
+              "
               :df="{
                 label: t`Search an Item`,
                 fieldtype: 'Link',
@@ -54,6 +58,7 @@
             />
 
             <Barcode
+              v-if="fyo.singles.InventorySettings?.enableBarcodes"
               class="w-1/3"
               @item-selected="
                 async (name: string) => {


### PR DESCRIPTION
fixes #846 

### Screenshots
Barcode Feature is not enabled

![image](https://github.com/frappe/books/assets/60477442/81634b93-2993-4170-9b84-b471e6fc0dd5)


Barcode Feature is enabled
![image](https://github.com/frappe/books/assets/60477442/2f27cc99-36e4-4521-9029-4e5bfbc07945)
