### PR TITLE
Fix issue : Purchase Payment Bug on Both Party #860

### DIFF
--- a/models/baseModels/Payment/Payment.ts
+++ b/models/baseModels/Payment/Payment.ts
@@ -604,7 +604,7 @@ export class Payment extends Transactional {
         const outstanding = partyDoc.outstandingAmount as Money;
 
         if (outstanding.isNegative()) {
-          if (this.referenceType === ModelNameEnum.SalesInvoice) {
+          if (this.referenceType === ModelNameEnum.PurchaseInvoice) {
             return 'Pay';
           }
           return 'Receive';


### PR DESCRIPTION
I found out that when a party is created with both role and when we try to add payment, the payment type is marked as Receive even if it is a Purchase invoice. This is happening in case outstanding amount is negative and when it is purchase invoice, payment type is set to receive. Changed it in Payment.ts. I am not sure if this disturbs any other flow. 

Please review and let me know.

Thanks.