### PR TITLE
fix: checks doesnt start due to unusable runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup_and_build:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup_and_build:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build-macos:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   setup_and_test:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
@@ -32,7 +32,7 @@ jobs:
         run: yarn test
 
   setup_and_uitest:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Setup node
         uses: actions/setup-node@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 >
 > Frappe Books is looking for a maintainer, please view [#775](https://github.com/frappe/books/issues/775) for more info.
 
-
 <div align="center" markdown="1">
 
 <img src="https://user-images.githubusercontent.com/29507195/207267672-d422db6c-d89a-4bbe-9822-468a55c15053.png" alt="Frappe Books logo" width="384"/>


### PR DESCRIPTION
Checks are waiting forever to be started due to the runner `macos-11` seems to be no longer usable. Switching to `macos-latest` fixes the issue.