### PR TITLE
fix: POS Setting Allows Cash in Hand Group to be Counter Cash Account

### DIFF
--- a/models/inventory/Point of Sale/POSSettings.ts
+++ b/models/inventory/Point of Sale/POSSettings.ts
@@ -14,6 +14,7 @@ export class POSSettings extends Doc {
     cashAccount: () => ({
       rootType: AccountRootTypeEnum.Asset,
       accountType: AccountTypeEnum.Cash,
+      isGroup: false,
     }),
   };
 }


### PR DESCRIPTION
fixes #855