### PR TITLE
feat: allow to turn off filtering

### DIFF
--- a/schemas/core/SystemSettings.json
+++ b/schemas/core/SystemSettings.json
@@ -65,6 +65,14 @@
       "section": "Default"
     },
     {
+      "fieldname": "allowFilterBypass",
+      "label": "Allow to bypass filters",
+      "fieldtype": "Check",
+      "default": false,
+      "description": "When linking documents, if no match is found and filtering is in effect, allow to disable filters.",
+      "section": "Default"
+    },
+    {
       "fieldname": "locale",
       "label": "Locale",
       "fieldtype": "AutoComplete",

--- a/translations/fr.csv
+++ b/translations/fr.csv
@@ -572,6 +572,7 @@ No,Non,
 "No filters selected","Aucun filtre sélectionné",
 "No linked entries found",,
 "No results found","Aucun résultat trouvé",
+"No results found, disable filters","Aucun résultat trouvé, désactiver les filtres",
 "No rows added. Select a file or add rows.",,
 "No transactions yet","Aucune transaction pour le moment",
 "Non Active Serial Number ${0} cannot be used as Manufacture raw material",,
@@ -1056,3 +1057,5 @@ Yes,Oui,
 "in Batch ${0}",,
 john@doe.com,,
 "to apply changes","pour appliquer les changements",
+"Allow to bypass filters","Autoriser la désactivation des filtres"
+"When linking documents, if no match is found and filtering is in effect, allow to disable filters.","Lors de la sélection d'un document lié, autoriser à désactiver les filtres si aucun résultat n'est trouvé"


### PR DESCRIPTION
Replaces #778

Add an option to turn off  filtering when no matches is found. This allows to link to an account that is not matched by the link filters. This can be useful on occasions.

![image](https://github.com/user-attachments/assets/294d3efe-c26d-4570-a985-b5dab9554e7a)

This is not enabled by default (global feature flag in system configuration)