### PR TITLE
feat: implement provisional mode

### DIFF
--- a/fyo/model/doc.ts
+++ b/fyo/model/doc.ts
@@ -368,17 +368,14 @@ export class Doc extends Observable<DocValue | Doc[]> {
     value?: DocValue | Doc[] | DocValueMap[]
   ): boolean {
     if (fieldname === 'numberSeries' && !this.notInserted) {
-      // console.log("cannot set %s, numberSeries inserted", fieldname)
       return false;
     }
 
     if (value === undefined) {
-      // console.log("cannot set %s, undefined value", fieldname)
       return false;
     }
 
     if (this.fieldMap[fieldname] === undefined) {
-      // console.log("cannot set %s, no fieldMap", fieldname, this.fieldMap)
       return false;
     }
 

--- a/fyo/telemetry/types.ts
+++ b/fyo/telemetry/types.ts
@@ -8,6 +8,7 @@ export enum Verb {
   Created = 'created',
   Deleted = 'deleted',
   Submitted = 'submitted',
+  SubmitUndone = 'submitUndone',
   Cancelled = 'cancelled',
   Imported = 'imported',
   Exported = 'exported',

--- a/models/Transactional/Transactional.ts
+++ b/models/Transactional/Transactional.ts
@@ -56,6 +56,15 @@ export abstract class Transactional extends Doc {
     await posting.post();
   }
 
+  async afterSubmitUndo(): Promise<void> {
+    await super.afterSubmitUndo();
+    if (!this.isTransactional) {
+      return;
+    }
+
+    await this._deletePostings();
+  }
+
   async afterCancel(): Promise<void> {
     await super.afterCancel();
     if (!this.isTransactional) {
@@ -76,6 +85,10 @@ export abstract class Transactional extends Doc {
       return;
     }
 
+    await this._deletePostings();
+  }
+
+  async _deletePostings(): Promise<void> {
     const ledgerEntryIds = (await this.fyo.db.getAll(
       ModelNameEnum.AccountingLedgerEntry,
       {

--- a/models/baseModels/Invoice/Invoice.ts
+++ b/models/baseModels/Invoice/Invoice.ts
@@ -245,9 +245,29 @@ export abstract class Invoice extends Transactional {
     }
   }
 
+  async afterSubmitUndo() {
+    await super.afterSubmitUndo();
+    await this._cancelPayments({ undo: true });
+    await this._updatePartyOutStanding();
+    await this._updateIsItemsReturned();
+    await this._removeLoyaltyPointEntry();
+    this.reduceUsedCountOfCoupons();
+  }
+
+  async _undoPayments() {
+    const paymentIds = await this.getPaymentIds();
+    for (const paymentId of paymentIds) {
+      const paymentDoc = (await this.fyo.doc.getDoc(
+        'Payment',
+        paymentId
+      )) as Payment;
+      await paymentDoc.cancel();
+    }
+  }
+
   async afterCancel() {
     await super.afterCancel();
-    await this._cancelPayments();
+    await this._cancelPayments({ undo: false });
     await this._updatePartyOutStanding();
     await this._updateIsItemsReturned();
     await this._removeLoyaltyPointEntry();
@@ -258,14 +278,18 @@ export abstract class Invoice extends Transactional {
     await removeLoyaltyPoint(this);
   }
 
-  async _cancelPayments() {
+  async _cancelPayments({ undo }: { undo: boolean }) {
     const paymentIds = await this.getPaymentIds();
     for (const paymentId of paymentIds) {
       const paymentDoc = (await this.fyo.doc.getDoc(
         'Payment',
         paymentId
       )) as Payment;
-      await paymentDoc.cancel();
+      if (undo) {
+        await paymentDoc.submitUndo();
+      } else {
+        await paymentDoc.cancel();
+      }
     }
   }
 

--- a/models/baseModels/Payment/Payment.ts
+++ b/models/baseModels/Payment/Payment.ts
@@ -442,6 +442,11 @@ export class Payment extends Transactional {
     }
   }
 
+  async afterSubmitUndo() {
+    await super.afterSubmitUndo();
+    await this.revertOutstandingAmount();
+  }
+
   async afterCancel() {
     await super.afterCancel();
     await this.revertOutstandingAmount();

--- a/models/inventory/StockManager.ts
+++ b/models/inventory/StockManager.ts
@@ -46,6 +46,10 @@ export class StockManager {
     await this.#sync();
   }
 
+  async undoTransfers() {
+    await this.cancelTransfers();
+  }
+
   async cancelTransfers() {
     const { referenceName, referenceType } = this.details;
     await this.fyo.db.deleteAll(ModelNameEnum.StockLedgerEntry, {

--- a/models/inventory/StockMovement.ts
+++ b/models/inventory/StockMovement.ts
@@ -69,6 +69,11 @@ export class StockMovement extends Transfer {
     await updateSerialNumbers(this, false);
   }
 
+  async afterSubmitUndo(): Promise<void> {
+    await super.afterSubmitUndo();
+    await updateSerialNumbers(this, true);
+  }
+
   async afterCancel(): Promise<void> {
     await super.afterCancel();
     await updateSerialNumbers(this, true);

--- a/models/inventory/StockTransfer.ts
+++ b/models/inventory/StockTransfer.ts
@@ -217,6 +217,13 @@ export abstract class StockTransfer extends Transfer {
     await this._updateItemsReturned();
   }
 
+  async afterSubmitUndo() {
+    await super.afterSubmitUndo();
+    await updateSerialNumbers(this, false, this.isReturn);
+    await this._updateBackReference();
+    await this._updateItemsReturned();
+  }
+
   async afterCancel(): Promise<void> {
     await super.afterCancel();
     await updateSerialNumbers(this, true, this.isReturn);

--- a/models/inventory/Transfer.ts
+++ b/models/inventory/Transfer.ts
@@ -21,6 +21,19 @@ export abstract class Transfer extends Transactional {
     await this._getStockManager().createTransfers(transferDetails);
   }
 
+  async beforeSubmitUndo(): Promise<void> {
+    await super.beforeSubmitUndo();
+    const transferDetails = this._getTransferDetails();
+    const stockManager = this._getStockManager();
+    stockManager.isCancelled = true;
+    await stockManager.validateCancel(transferDetails);
+  }
+
+  async afterSubmitUndo(): Promise<void> {
+    await super.afterSubmitUndo();
+    await this._getStockManager().undoTransfers();
+  }
+
   async beforeCancel(): Promise<void> {
     await super.beforeCancel();
     const transferDetails = this._getTransferDetails();

--- a/schemas/core/SystemSettings.json
+++ b/schemas/core/SystemSettings.json
@@ -125,6 +125,13 @@
       "default": false,
       "description": "Sets the theme of the app.",
       "section": "Theme"
+    },
+    {
+      "fieldname": "provisionalModeSince",
+      "label": "Provisional Mode Since",
+      "fieldtype": "Datetime",
+      "description": "Date since the provisional mode is set, or NULL for definitive mode",
+      "hidden": true
     }
   ],
   "quickEditFields": [

--- a/schemas/meta/submittable.json
+++ b/schemas/meta/submittable.json
@@ -10,6 +10,14 @@
       "section": "System"
     },
     {
+      "fieldname": "submittedAt",
+      "label": "Submition Date",
+      "fieldtype": "Datetime",
+      "required": false,
+      "meta": true,
+      "section": "System"
+    },
+    {
       "fieldname": "cancelled",
       "label": "Cancelled",
       "fieldtype": "Check",

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -119,6 +119,32 @@
           gap-1
           items-center
         "
+        @click="toggleProvisionalMode"
+        :title="
+          isProvisionalMode()
+            ? t`Provisional mode since` + ' ' + provisionalModeDate()
+            : ''
+        "
+      >
+        <feather-icon
+          :name="isProvisionalMode() ? 'pause-circle' : 'play-circle'"
+          class="h-4 w-4 flex-shrink-0"
+        />
+        <p>
+          {{ isProvisionalMode() ? t`Provisional mode` : t`Definitive mode` }}
+        </p>
+      </button>
+
+      <button
+        class="
+          flex
+          text-sm text-gray-600
+          dark:text-gray-500
+          hover:text-gray-800
+          dark:hover:text-gray-400
+          gap-1
+          items-center
+        "
         @click="openDocumentation"
       >
         <feather-icon name="help-circle" class="h-4 w-4 flex-shrink-0" />
@@ -184,7 +210,12 @@
         @click="showDevMode = false"
         title="Open dev tools with Ctrl+Shift+I"
       >
-        dev mode
+        <feather-icon
+          name="hash"
+          class="h-4 w-4 flex-shrink-0"
+          style="display: inline"
+        />
+        hide dev mode
       </p>
     </div>
 
@@ -214,6 +245,7 @@
   </div>
 </template>
 <script lang="ts">
+import { t } from 'fyo';
 import { reportIssue } from 'src/errorHandling';
 import { fyo } from 'src/initFyo';
 import { languageDirectionKey, shortcutsKey } from 'src/utils/injectionKeys';
@@ -226,6 +258,7 @@ import router from '../router';
 import Icon from './Icon.vue';
 import Modal from './Modal.vue';
 import ShortcutsHelper from './ShortcutsHelper.vue';
+import { showDialog } from 'src/utils/interactive';
 
 const COMPONENT_NAME = 'Sidebar';
 
@@ -291,6 +324,64 @@ export default defineComponent({
     routeTo,
     reportIssue,
     toggleSidebar,
+    async toggleProvisionalMode() {
+      let title, detail, provisionalModeSince, showUnlimited;
+      if (fyo.singles.SystemSettings?.provisionalModeSince != null) {
+        title = t`Leave provisional mode?`;
+        detail = t`All submissions while provisional mode was effective will be definitive.`;
+        provisionalModeSince = null;
+      } else {
+        title = t`Enter provisional mode?`;
+        detail = t`Documents submission while in provisional mode can be undone.`;
+        provisionalModeSince = new Date();
+        showUnlimited = this.showDevMode;
+      }
+
+      let response = (await showDialog({
+        title,
+        detail,
+        type: 'warning',
+        buttons: [
+          {
+            label: t`Yes`,
+            action() {
+              return true;
+            },
+            isPrimary: true,
+          },
+          {
+            label: t`No`,
+            action() {
+              return false;
+            },
+            isEscape: true,
+          },
+          showUnlimited
+            ? {
+                label: t`Unlimited`,
+                action() {
+                  provisionalModeSince = new Date(0);
+                  return true;
+                },
+                isPrimary: false,
+              }
+            : null,
+        ].filter((x) => x),
+      })) as boolean;
+
+      if (response) {
+        await fyo.singles.SystemSettings?.setAndSync(
+          'provisionalModeSince',
+          provisionalModeSince
+        );
+      }
+    },
+    isProvisionalMode() {
+      return fyo.singles.SystemSettings?.provisionalModeSince != null;
+    },
+    provisionalModeDate() {
+      return fyo.singles.SystemSettings?.provisionalModeSince;
+    },
     openDocumentation() {
       ipc.openLink('https://docs.frappe.io/' + docsPathRef.value);
     },


### PR DESCRIPTION
Implements #756

Sometimes it's difficult to understand what submitting a document would do and it's useful to try submitting and see the actual balance, but leave an option for undo.

Provisional mode, while in effect, allows to undo submission performed while provisional mode was in effect. Once provisional mode is stopped, all submissions are definitive. An option in dev mode can enable unlimited provisional mode.

~~Commits in this PR includes #1022~~

![image](https://github.com/user-attachments/assets/91c7d27e-622b-4663-a1e7-b943a256f936)

![image](https://github.com/user-attachments/assets/93c5fb9e-24c3-45e1-8e63-8184049da3fa)

![image](https://github.com/user-attachments/assets/4509b939-836d-48cd-9064-479878f74b24)
