### PR TITLE
feat: improve trial balance report

### DIFF
--- a/reports/TrialBalance/TrialBalance.ts
+++ b/reports/TrialBalance/TrialBalance.ts
@@ -35,6 +35,7 @@ export class TrialBalance extends AccountReport {
 
   fromDate?: string;
   toDate?: string;
+  showOnlyBalance = false;
   hideGroupAmounts = false;
   loading = false;
 
@@ -42,6 +43,10 @@ export class TrialBalance extends AccountReport {
   _dateRanges?: DateRange[];
 
   accountMap?: Record<string, Account>;
+
+  get acceptSingleTimePeriod() {
+    return true;
+  }
 
   get rootTypes(): AccountRootType[] {
     return [
@@ -165,20 +170,32 @@ export class TrialBalance extends AccountReport {
       const map = al.valueMap?.get(k);
       const hide = this.hideGroupAmounts && al.isGroup;
 
-      return [
-        {
-          rawValue: map?.debit ?? 0,
-          value: hide ? '' : this.fyo.format(map?.debit ?? 0, 'Currency'),
-          align: 'right',
-          width: ACC_BAL_WIDTH,
-        },
-        {
-          rawValue: map?.credit ?? 0,
-          value: hide ? '' : this.fyo.format(map?.credit ?? 0, 'Currency'),
-          align: 'right',
-          width: ACC_BAL_WIDTH,
-        } as ReportCell,
-      ];
+      if (this.showOnlyBalance) {
+        const balance = (map?.debit ?? 0) - (map?.credit ?? 0);
+        return [
+          {
+            rawValue: balance,
+            value: hide ? '' : this.fyo.format(balance, 'Currency'),
+            align: 'right',
+            width: ACC_BAL_WIDTH,
+          } as ReportCell,
+        ];
+      } else {
+        return [
+          {
+            rawValue: map?.debit ?? 0,
+            value: hide ? '' : this.fyo.format(map?.debit ?? 0, 'Currency'),
+            align: 'right',
+            width: ACC_BAL_WIDTH,
+          },
+          {
+            rawValue: map?.credit ?? 0,
+            value: hide ? '' : this.fyo.format(map?.credit ?? 0, 'Currency'),
+            align: 'right',
+            width: ACC_BAL_WIDTH,
+          } as ReportCell,
+        ];
+      }
     });
 
     return {
@@ -231,61 +248,99 @@ export class TrialBalance extends AccountReport {
         fieldtype: 'Check',
         label: t`Hide Group Amounts`,
         fieldname: 'hideGroupAmounts',
+      },
+      {
+        fieldtype: 'Check',
+        label: t`Show Balance`,
+        fieldname: 'showOnlyBalance',
       } as Field,
     ] as Field[];
   }
 
   getColumns(): ColumnField[] {
-    return [
-      {
-        label: t`Account`,
-        fieldtype: 'Link',
-        fieldname: 'account',
-        align: 'left',
-        width: ACC_NAME_WIDTH,
-      },
-      {
-        label: t`Opening (Dr)`,
-        fieldtype: 'Data',
-        fieldname: 'openingDebit',
-        align: 'right',
-        width: ACC_BAL_WIDTH,
-      },
-      {
-        label: t`Opening (Cr)`,
-        fieldtype: 'Data',
-        fieldname: 'openingCredit',
-        align: 'right',
-        width: ACC_BAL_WIDTH,
-      },
-      {
-        label: t`Debit`,
-        fieldtype: 'Data',
-        fieldname: 'debit',
-        align: 'right',
-        width: ACC_BAL_WIDTH,
-      },
-      {
-        label: t`Credit`,
-        fieldtype: 'Data',
-        fieldname: 'credit',
-        align: 'right',
-        width: ACC_BAL_WIDTH,
-      },
-      {
-        label: t`Closing (Dr)`,
-        fieldtype: 'Data',
-        fieldname: 'closingDebit',
-        align: 'right',
-        width: ACC_BAL_WIDTH,
-      },
-      {
-        label: t`Closing (Cr)`,
-        fieldtype: 'Data',
-        fieldname: 'closingCredit',
-        align: 'right',
-        width: ACC_BAL_WIDTH,
-      },
-    ] as ColumnField[];
+    if (this.showOnlyBalance) {
+      return [
+        {
+          label: t`Account`,
+          fieldtype: 'Link',
+          fieldname: 'account',
+          align: 'left',
+          width: ACC_NAME_WIDTH,
+        },
+        {
+          label: t`Opening`,
+          fieldtype: 'Data',
+          fieldname: 'openingBalance',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+        {
+          label: t`Balance`,
+          fieldtype: 'Data',
+          fieldname: 'balance',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+        {
+          label: t`Closing`,
+          fieldtype: 'Data',
+          fieldname: 'closingBalance',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+      ] as ColumnField[];
+    } else {
+      return [
+        {
+          label: t`Account`,
+          fieldtype: 'Link',
+          fieldname: 'account',
+          align: 'left',
+          width: ACC_NAME_WIDTH,
+        },
+        {
+          label: t`Opening (Dr)`,
+          fieldtype: 'Data',
+          fieldname: 'openingDebit',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+        {
+          label: t`Opening (Cr)`,
+          fieldtype: 'Data',
+          fieldname: 'openingCredit',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+        {
+          label: t`Debit`,
+          fieldtype: 'Data',
+          fieldname: 'debit',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+        {
+          label: t`Credit`,
+          fieldtype: 'Data',
+          fieldname: 'credit',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+        {
+          label: t`Closing (Dr)`,
+          fieldtype: 'Data',
+          fieldname: 'closingDebit',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+        {
+          label: t`Closing (Cr)`,
+          fieldtype: 'Data',
+          fieldname: 'closingCredit',
+          align: 'right',
+          width: ACC_BAL_WIDTH,
+        },
+      ] as ColumnField[];
+    }
   }
 }


### PR DESCRIPTION
- #798
- add an option to only show the balance and not the individual debit and credit columns
- add an option to show the total of the preceeding rows in the closing column

before:

![image](https://github.com/user-attachments/assets/2121a57a-2d74-49f5-89e1-470dde7397cf)

with only balance columns:

![image](https://github.com/user-attachments/assets/b36a0bbb-f5a1-4ca5-a2c9-3e4bd91ff6fe)

with totals:

![image](https://github.com/user-attachments/assets/a1ed9dd7-581d-44a1-9404-988c2c51a1fd)
