### PR TITLE
fix: deprecated runner for build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup_and_build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Setup node
         uses: actions/setup-node@v2


### PR DESCRIPTION
`macos-12` is deprecated by github. bumped to `macos-13`