### PR TITLE
fix: dark mode support for date input calendar

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,8 +25,9 @@ html {
 }
 
 html.dark {
-  color: theme('colors.white');
+  color: theme('colors.black');
   background-color: theme('colors.gray.900');
+  color-scheme: dark;
 }
 
 html.dark input[type='date']::-webkit-calendar-picker-indicator {


### PR DESCRIPTION

<img width="272" alt="image" src="https://github.com/user-attachments/assets/faa71163-6aa2-45ee-b6c1-18a2f75e35d4">
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
<img width="274" alt="image" src="https://github.com/user-attachments/assets/66796aa5-431a-46b6-98ab-708abc80dcf9">
