### PR TITLE
feat: upgrade nodejs to v20.18.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Set yarn version
         run: yarn set version 1.22.18

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Set yarn version
         run: yarn set version 1.22.18

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Checkout Books
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Checkout Books
         uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Checkout Books
         uses: actions/checkout@v4
@@ -157,7 +157,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Checkout Books
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Set yarn version
         run: yarn set version 1.22.18
@@ -37,7 +37,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.19.0'
+          node-version: '20.18.1'
 
       - name: Set yarn version
         run: yarn set version 1.22.18

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ a local SQLite file as the database.
 
 ### Pre-requisites
 
-To get the dev environment up and running you need to first set up Node.js version
-16.14.0 and npm. For this, we suggest using
+To get the dev environment up and running you need to first set up Node.js `v20.18.1` and npm. For this, we suggest using
 [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
 
 Next, you will need to install [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).

--- a/build/scripts/helpers.mjs
+++ b/build/scripts/helpers.mjs
@@ -18,7 +18,7 @@ export function getMainProcessCommonConfig(root) {
     sourcemap: true,
     sourcesContent: false,
     platform: 'node',
-    target: 'node16',
+    target: 'node20',
     external: ['knex', 'electron', 'better-sqlite3', 'electron-store'],
     plugins: [excludeVendorFromSourceMap],
     write: true,


### PR DESCRIPTION
The current version 18 (tho README.md says 16) 
is almost out of support, see https://nodejs.org/en/about/previous-releases
I have tested with node20 and everything works just as good and
with the added benefit of extra support.