### PR TITLE
feat: allow customization of button colors in POS

### DIFF
--- a/models/baseModels/Defaults/Defaults.ts
+++ b/models/baseModels/Defaults/Defaults.ts
@@ -43,6 +43,16 @@ export class Defaults extends Doc {
   posCashDenominations?: DefaultCashDenominations[];
   posCustomer?: string;
 
+  //Buttons
+  saveButton?: string;
+  submitButton?: string;
+  cancelButton?: string;
+  heldButton?: string;
+  returnButton?: string;
+  buyButton?: string;
+  payButton?: string;
+  payAndPrintButton?: string;
+
   static commonFilters = {
     // Auto Payments
     salesPaymentAccount: () => ({ isGroup: false, accountType: 'Cash' }),
@@ -110,6 +120,14 @@ export class Defaults extends Doc {
     stockMovementPrintTemplate: this.getInventoryHidden(),
     posCashDenominations: this.getPointOfSaleHidden(),
     posCustomer: this.getPointOfSaleHidden(),
+    saveButton: this.getPointOfSaleHidden(),
+    cancelButton: this.getPointOfSaleHidden(),
+    submitButton: this.getPointOfSaleHidden(),
+    heldButton: this.getPointOfSaleHidden(),
+    returnButton: this.getPointOfSaleHidden(),
+    buyButton: this.getPointOfSaleHidden(),
+    payButton: this.getPointOfSaleHidden(),
+    payAndPrintButton: this.getPointOfSaleHidden(),
   };
 }
 

--- a/models/baseModels/Defaults/Defaults.ts
+++ b/models/baseModels/Defaults/Defaults.ts
@@ -44,14 +44,14 @@ export class Defaults extends Doc {
   posCustomer?: string;
 
   //Buttons
-  saveButton?: string;
-  submitButton?: string;
-  cancelButton?: string;
-  heldButton?: string;
-  returnButton?: string;
-  buyButton?: string;
-  payButton?: string;
-  payAndPrintButton?: string;
+  saveButtonColour?: string;
+  submitButtonColour?: string;
+  cancelButtonColour?: string;
+  heldButtonColour?: string;
+  returnButtonColour?: string;
+  buyButtonColour?: string;
+  payButtonColour?: string;
+  payAndPrintButtonColour?: string;
 
   static commonFilters = {
     // Auto Payments
@@ -120,14 +120,14 @@ export class Defaults extends Doc {
     stockMovementPrintTemplate: this.getInventoryHidden(),
     posCashDenominations: this.getPointOfSaleHidden(),
     posCustomer: this.getPointOfSaleHidden(),
-    saveButton: this.getPointOfSaleHidden(),
-    cancelButton: this.getPointOfSaleHidden(),
-    submitButton: this.getPointOfSaleHidden(),
-    heldButton: this.getPointOfSaleHidden(),
-    returnButton: this.getPointOfSaleHidden(),
-    buyButton: this.getPointOfSaleHidden(),
-    payButton: this.getPointOfSaleHidden(),
-    payAndPrintButton: this.getPointOfSaleHidden(),
+    saveButtonColour: this.getPointOfSaleHidden(),
+    cancelButtonColour: this.getPointOfSaleHidden(),
+    submitButtonColour: this.getPointOfSaleHidden(),
+    heldButtonColour: this.getPointOfSaleHidden(),
+    returnButtonColour: this.getPointOfSaleHidden(),
+    buyButtonColour: this.getPointOfSaleHidden(),
+    payButtonColour: this.getPointOfSaleHidden(),
+    payAndPrintButtonColour: this.getPointOfSaleHidden(),
   };
 }
 

--- a/schemas/app/Defaults.json
+++ b/schemas/app/Defaults.json
@@ -196,9 +196,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "saveButton",
-      "label": "Save Button",
-      "placeholder": "Select Color",
+      "fieldname": "saveButtonColour",
+      "label": "Save Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#6846e3",
       "options": [
@@ -246,9 +246,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "cancelButton",
-      "label": "Cancel Button",
-      "placeholder": "Select Color",
+      "fieldname": "cancelButtonColour",
+      "label": "Cancel Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#b52a2a",
       "options": [
@@ -296,9 +296,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "submitButton",
-      "label": "Submit Button",
-      "placeholder": "Select Color",
+      "fieldname": "submitButtonColour",
+      "label": "Submit Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#f56565",
       "options": [
@@ -346,9 +346,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "heldButton",
-      "label": "Held Button",
-      "placeholder": "Select Color",
+      "fieldname": "heldButtonColour",
+      "label": "Held Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#0070cb",
       "options": [
@@ -396,9 +396,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "returnButton",
-      "label": "Return Button",
-      "placeholder": "Select Color",
+      "fieldname": "returnButtonColour",
+      "label": "Return Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#bd3e0b",
       "options": [
@@ -446,9 +446,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "buyButton",
-      "label": "Buy Button",
-      "placeholder": "Select Color",
+      "fieldname": "buyButtonColour",
+      "label": "Buy Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#58ba8a",
       "options": [
@@ -496,9 +496,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "payButton",
-      "label": "Pay Button",
-      "placeholder": "Select Color",
+      "fieldname": "payButtonColour",
+      "label": "Pay Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#0070cb",
       "options": [
@@ -546,9 +546,9 @@
       "section": "Point of Sale"
     },
     {
-      "fieldname": "payAndPrintButton",
-      "label": "Pay And Print Button",
-      "placeholder": "Select Color",
+      "fieldname": "payAndPrintButtonColour",
+      "label": "Pay And Print Button Colour",
+      "placeholder": "Select Colour",
       "fieldtype": "Color",
       "default": "#58ba8a",
       "options": [

--- a/schemas/app/Defaults.json
+++ b/schemas/app/Defaults.json
@@ -194,6 +194,406 @@
       "fieldtype": "Table",
       "target": "DefaultCashDenominations",
       "section": "Point of Sale"
+    },
+    {
+      "fieldname": "saveButton",
+      "label": "Save Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#6846e3",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
+    },
+    {
+      "fieldname": "cancelButton",
+      "label": "Cancel Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#b52a2a",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
+    },
+    {
+      "fieldname": "submitButton",
+      "label": "Submit Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#f56565",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
+    },
+    {
+      "fieldname": "heldButton",
+      "label": "Held Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#0070cb",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
+    },
+    {
+      "fieldname": "returnButton",
+      "label": "Return Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#bd3e0b",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
+    },
+    {
+      "fieldname": "buyButton",
+      "label": "Buy Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#58ba8a",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
+    },
+    {
+      "fieldname": "payButton",
+      "label": "Pay Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#0070cb",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
+    },
+    {
+      "fieldname": "payAndPrintButton",
+      "label": "Pay And Print Button",
+      "placeholder": "Select Color",
+      "fieldtype": "Color",
+      "default": "#58ba8a",
+      "options": [
+        {
+          "label": "Red",
+          "value": "#b52a2a"
+        },
+        {
+          "label": "Orange",
+          "value": "#e9612b"
+        },
+        {
+          "label": "Yellow",
+          "value": "#ecc94b"
+        },
+        {
+          "label": "Green",
+          "value": "#58ba8a"
+        },
+        {
+          "label": "Teal",
+          "value": "#38b2ac"
+        },
+        {
+          "label": "Blue",
+          "value": "#0070cb"
+        },
+        {
+          "label": "Indigo",
+          "value": "#667eea"
+        },
+        {
+          "label": "Purple",
+          "value": "#6846e3"
+        },
+        {
+          "label": "Pink",
+          "value": "#ed64a6"
+        },
+        {
+          "label": "Black",
+          "value": "#112B42"
+        }
+      ],
+      "section": "Point of Sale"
     }
   ]
 }

--- a/src/pages/POS/ClassicPOS.vue
+++ b/src/pages/POS/ClassicPOS.vue
@@ -254,7 +254,7 @@
                   <Button
                     class="w-full"
                     :style="{
-                      backgroundColor: fyo.singles.Defaults?.saveButton,
+                      backgroundColor: fyo.singles.Defaults?.saveButtonColour,
                     }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     :disabled="!sinvDoc?.party || !sinvDoc?.items?.length"
@@ -269,7 +269,7 @@
                   <Button
                     class="w-full"
                     :style="{
-                      backgroundColor: fyo.singles.Defaults?.cancelButton,
+                      backgroundColor: fyo.singles.Defaults?.cancelButtonColour,
                     }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     :disabled="!sinvDoc?.items?.length"
@@ -289,7 +289,7 @@
                   <Button
                     class="w-full"
                     :style="{
-                      backgroundColor: fyo.singles.Defaults?.heldButton,
+                      backgroundColor: fyo.singles.Defaults?.heldButtonColour,
                     }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     @click="emitEvent('toggleModal', 'SavedInvoice', true)"
@@ -305,7 +305,7 @@
                     v-if="isReturnInvoiceEnabledReturn"
                     class="w-full py-5"
                     :style="{
-                      backgroundColor: fyo.singles.Defaults?.returnButton,
+                      backgroundColor: fyo.singles.Defaults?.returnButtonColour,
                     }"
                     @click="
                       emitEvent('toggleModal', 'ReturnSalesInvoice', true)
@@ -321,7 +321,7 @@
                     v-else
                     class="w-full"
                     :style="{
-                      backgroundColor: fyo.singles.Defaults?.payButton,
+                      backgroundColor: fyo.singles.Defaults?.payButtonColour,
                     }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     :disabled="disablePayButton"
@@ -337,7 +337,9 @@
                 <Button
                   v-if="isReturnInvoiceEnabledReturn"
                   class="w-full mt-2 py-5"
-                  :style="{ backgroundColor: fyo.singles.Defaults?.payButton }"
+                  :style="{
+                    backgroundColor: fyo.singles.Defaults?.payButtonColour,
+                  }"
                   :disabled="disablePayButton"
                   @click="emitEvent('toggleModal', 'Payment', true)"
                 >

--- a/src/pages/POS/ClassicPOS.vue
+++ b/src/pages/POS/ClassicPOS.vue
@@ -252,7 +252,10 @@
               <div class="w-full">
                 <div class="w-full flex gap-2">
                   <Button
-                    class="w-full bg-violet-500 dark:bg-violet-700"
+                    class="w-full"
+                    :style="{
+                      backgroundColor: fyo.singles.Defaults?.saveButton,
+                    }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     :disabled="!sinvDoc?.party || !sinvDoc?.items?.length"
                     @click="$emit('saveInvoiceAction')"
@@ -264,7 +267,10 @@
                     </slot>
                   </Button>
                   <Button
-                    class="w-full bg-red-500 dark:bg-red-700"
+                    class="w-full"
+                    :style="{
+                      backgroundColor: fyo.singles.Defaults?.cancelButton,
+                    }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     :disabled="!sinvDoc?.items?.length"
                     @click="() => $emit('clearValues')"
@@ -281,7 +287,10 @@
                   :class="`${isReturnInvoiceEnabledReturn ? 'mt-2' : 'mt-4'}`"
                 >
                   <Button
-                    class="w-full bg-blue-500 dark:bg-blue-700"
+                    class="w-full"
+                    :style="{
+                      backgroundColor: fyo.singles.Defaults?.heldButton,
+                    }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     @click="emitEvent('toggleModal', 'SavedInvoice', true)"
                   >
@@ -294,7 +303,10 @@
 
                   <Button
                     v-if="isReturnInvoiceEnabledReturn"
-                    class="w-full bg-orange-500 dark:bg-orange-700 py-5"
+                    class="w-full py-5"
+                    :style="{
+                      backgroundColor: fyo.singles.Defaults?.returnButton,
+                    }"
                     @click="
                       emitEvent('toggleModal', 'ReturnSalesInvoice', true)
                     "
@@ -307,7 +319,10 @@
                   </Button>
                   <Button
                     v-else
-                    class="w-full bg-green-500 dark:bg-green-700"
+                    class="w-full"
+                    :style="{
+                      backgroundColor: fyo.singles.Defaults?.payButton,
+                    }"
                     :class="`${isReturnInvoiceEnabledReturn ? 'py-5' : 'py-6'}`"
                     :disabled="disablePayButton"
                     @click="emitEvent('toggleModal', 'Payment', true)"
@@ -321,7 +336,8 @@
                 </div>
                 <Button
                   v-if="isReturnInvoiceEnabledReturn"
-                  class="w-full bg-green-500 mt-2 dark:bg-green-700 py-5"
+                  class="w-full mt-2 py-5"
+                  :style="{ backgroundColor: fyo.singles.Defaults?.payButton }"
                   :disabled="disablePayButton"
                   @click="emitEvent('toggleModal', 'Payment', true)"
                 >

--- a/src/pages/POS/ModernPOS.vue
+++ b/src/pages/POS/ModernPOS.vue
@@ -177,7 +177,8 @@
             <div class="flex w-full gap-2">
               <div class="w-full">
                 <Button
-                  class="mt-2 w-full bg-violet-500 dark:bg-violet-700 py-5"
+                  class="mt-2 w-full py-5"
+                  :style="{ backgroundColor: fyo.singles.Defaults?.saveButton }"
                   :disabled="!sinvDoc?.party || !sinvDoc?.items?.length"
                   @click="$emit('saveInvoiceAction')"
                 >
@@ -188,7 +189,8 @@
                   </slot>
                 </Button>
                 <Button
-                  class="w-full mt-2 bg-blue-500 dark:bg-blue-700 py-5"
+                  class="w-full mt-2 py-5"
+                  :style="{ backgroundColor: fyo.singles.Defaults?.heldButton }"
                   @click="emitEvent('toggleModal', 'SavedInvoice', true)"
                 >
                   <slot>
@@ -200,7 +202,10 @@
               </div>
               <div class="w-full">
                 <Button
-                  class="mt-2 w-full bg-red-500 dark:bg-red-700 py-5"
+                  class="mt-2 w-full py-5"
+                  :style="{
+                    backgroundColor: fyo.singles.Defaults?.cancelButton,
+                  }"
                   :disabled="!sinvDoc?.items?.length"
                   @click="() => $emit('clearValues')"
                 >
@@ -212,7 +217,10 @@
                 </Button>
                 <Button
                   v-if="isReturnInvoiceEnabledReturn"
-                  class="mt-2 w-full bg-orange-500 dark:bg-orange-700 py-5"
+                  class="mt-2 w-full py-5"
+                  :style="{
+                    backgroundColor: fyo.singles.Defaults?.returnButton,
+                  }"
                   @click="emitEvent('toggleModal', 'ReturnSalesInvoice', true)"
                 >
                   <slot>
@@ -223,7 +231,8 @@
                 </Button>
                 <Button
                   v-else
-                  class="mt-2 w-full bg-green-500 dark:bg-green-700 py-5"
+                  class="mt-2 w-full py-5"
+                  :style="{ backgroundColor: fyo.singles.Defaults?.buyButton }"
                   :disabled="disablePayButton"
                   @click="emitEvent('toggleModal', 'Payment', true)"
                 >
@@ -237,7 +246,8 @@
             </div>
             <Button
               v-if="isReturnInvoiceEnabledReturn"
-              class="mt-2 w-full bg-green-500 dark:bg-green-700 py-5"
+              class="mt-2 w-full py-5"
+              :style="{ backgroundColor: fyo.singles.Defaults?.buyButton }"
               :disabled="disablePayButton"
               @click="emitEvent('toggleModal', 'Payment', true)"
             >

--- a/src/pages/POS/ModernPOS.vue
+++ b/src/pages/POS/ModernPOS.vue
@@ -178,7 +178,9 @@
               <div class="w-full">
                 <Button
                   class="mt-2 w-full py-5"
-                  :style="{ backgroundColor: fyo.singles.Defaults?.saveButton }"
+                  :style="{
+                    backgroundColor: fyo.singles.Defaults?.saveButtonColour,
+                  }"
                   :disabled="!sinvDoc?.party || !sinvDoc?.items?.length"
                   @click="$emit('saveInvoiceAction')"
                 >
@@ -190,7 +192,9 @@
                 </Button>
                 <Button
                   class="w-full mt-2 py-5"
-                  :style="{ backgroundColor: fyo.singles.Defaults?.heldButton }"
+                  :style="{
+                    backgroundColor: fyo.singles.Defaults?.heldButtonColour,
+                  }"
                   @click="emitEvent('toggleModal', 'SavedInvoice', true)"
                 >
                   <slot>
@@ -204,7 +208,7 @@
                 <Button
                   class="mt-2 w-full py-5"
                   :style="{
-                    backgroundColor: fyo.singles.Defaults?.cancelButton,
+                    backgroundColor: fyo.singles.Defaults?.cancelButtonColour,
                   }"
                   :disabled="!sinvDoc?.items?.length"
                   @click="() => $emit('clearValues')"
@@ -219,7 +223,7 @@
                   v-if="isReturnInvoiceEnabledReturn"
                   class="mt-2 w-full py-5"
                   :style="{
-                    backgroundColor: fyo.singles.Defaults?.returnButton,
+                    backgroundColor: fyo.singles.Defaults?.returnButtonColour,
                   }"
                   @click="emitEvent('toggleModal', 'ReturnSalesInvoice', true)"
                 >
@@ -232,7 +236,9 @@
                 <Button
                   v-else
                   class="mt-2 w-full py-5"
-                  :style="{ backgroundColor: fyo.singles.Defaults?.buyButton }"
+                  :style="{
+                    backgroundColor: fyo.singles.Defaults?.buyButtonColour,
+                  }"
                   :disabled="disablePayButton"
                   @click="emitEvent('toggleModal', 'Payment', true)"
                 >
@@ -247,7 +253,9 @@
             <Button
               v-if="isReturnInvoiceEnabledReturn"
               class="mt-2 w-full py-5"
-              :style="{ backgroundColor: fyo.singles.Defaults?.buyButton }"
+              :style="{
+                backgroundColor: fyo.singles.Defaults?.buyButtonColour,
+              }"
               :disabled="disablePayButton"
               @click="emitEvent('toggleModal', 'Payment', true)"
             >

--- a/src/pages/POS/PaymentModal.vue
+++ b/src/pages/POS/PaymentModal.vue
@@ -133,7 +133,8 @@
       <div class="grid grid-cols-2 gap-4 bottom-8">
         <div class="col-span-1">
           <Button
-            class="w-full bg-violet-500 dark:bg-violet-700"
+            class="w-full"
+            :style="{ backgroundColor: fyo.singles.Defaults?.submitButton }"
             style="padding: 1.35rem"
             :disabled="disableSubmitButton"
             @click="submitTransaction()"
@@ -151,7 +152,8 @@
 
         <div class="col-span-1">
           <Button
-            class="w-full bg-red-500 dark:bg-red-700"
+            class="w-full"
+            :style="{ backgroundColor: fyo.singles.Defaults?.cancelButton }"
             style="padding: 1.35rem"
             @click="cancelTransaction()"
           >
@@ -165,7 +167,8 @@
 
         <div class="col-span-1">
           <Button
-            class="w-full bg-blue-500 dark:bg-blue-700"
+            class="w-full"
+            :style="{ backgroundColor: fyo.singles.Defaults?.payButton }"
             style="padding: 1.35rem"
             :disabled="disablePayButton"
             @click="payTransaction()"
@@ -180,7 +183,10 @@
 
         <div class="col-span-1">
           <Button
-            class="w-full bg-green-500 dark:bg-green-700"
+            class="w-full"
+            :style="{
+              backgroundColor: fyo.singles.Defaults?.payAndPrintButton,
+            }"
             style="padding: 1.35rem"
             :disabled="disablePayButton"
             @click="$emit('createTransaction', true, true)"

--- a/src/pages/POS/PaymentModal.vue
+++ b/src/pages/POS/PaymentModal.vue
@@ -134,7 +134,9 @@
         <div class="col-span-1">
           <Button
             class="w-full"
-            :style="{ backgroundColor: fyo.singles.Defaults?.submitButton }"
+            :style="{
+              backgroundColor: fyo.singles.Defaults?.submitButtonColour,
+            }"
             style="padding: 1.35rem"
             :disabled="disableSubmitButton"
             @click="submitTransaction()"
@@ -153,7 +155,9 @@
         <div class="col-span-1">
           <Button
             class="w-full"
-            :style="{ backgroundColor: fyo.singles.Defaults?.cancelButton }"
+            :style="{
+              backgroundColor: fyo.singles.Defaults?.cancelButtonColour,
+            }"
             style="padding: 1.35rem"
             @click="cancelTransaction()"
           >
@@ -168,7 +172,7 @@
         <div class="col-span-1">
           <Button
             class="w-full"
-            :style="{ backgroundColor: fyo.singles.Defaults?.payButton }"
+            :style="{ backgroundColor: fyo.singles.Defaults?.payButtonColour }"
             style="padding: 1.35rem"
             :disabled="disablePayButton"
             @click="payTransaction()"
@@ -185,7 +189,7 @@
           <Button
             class="w-full"
             :style="{
-              backgroundColor: fyo.singles.Defaults?.payAndPrintButton,
+              backgroundColor: fyo.singles.Defaults?.payAndPrintButtonColour,
             }"
             style="padding: 1.35rem"
             :disabled="disablePayButton"


### PR DESCRIPTION

<img width="585" alt="image" src="https://github.com/user-attachments/assets/a8d8a15e-9354-49b1-8275-ba2f78b4a514" />

<br/>
<br/>

This feature allows users to customize the colors of various buttons in the POS, including Save, Submit, Cancel, Pay, and more. It enhances the user experience by providing flexibility in button color selection.