### PR TITLE
chore: use SAR unicode symbol

### DIFF
--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -1757,7 +1757,7 @@
     "currency_fraction": "Halala",
     "currency_fraction_units": 100,
     "currency_name": "Saudi Riyal",
-    "currency_symbol": "ر.س",
+    "currency_symbol": "﷼",
     "timezones": ["Asia/Riyadh"],
     "locale": "ar-SA"
   },


### PR DESCRIPTION
Updated the currency symbol of SAR to be the unicode of the symbol.


In the future when the new Saudi Riyal symbol is officially in the [unicode](https://github.com/frappe/books/pull/1167) I'll remember to update it here