### PR TITLE
fix: Sales Payment print issue

### DIFF
--- a/src/utils/printTemplates.ts
+++ b/src/utils/printTemplates.ts
@@ -64,14 +64,16 @@ export async function getPrintTemplatePropValues(
   }
 
   if (doc.referenceType == ModelNameEnum.SalesInvoice) {
-    sinvDoc = await fyo.doc.getDoc(
-      ModelNameEnum.SalesInvoice,
-      (doc as Payment)?.for![0].referenceName
-    );
+   
+    const referenceName = (doc as Payment)?.for![0]?.referenceName;
 
-    if (sinvDoc.taxes) {
-      (values.doc as PrintTemplateData).taxes = sinvDoc.taxes;
-    }
+    if (referenceName) {
+      sinvDoc = await fyo.doc.getDoc(ModelNameEnum.SalesInvoice, referenceName);
+  
+      if (sinvDoc.taxes) {
+        (values.doc as PrintTemplateData).taxes = sinvDoc.taxes;
+      }
+    } 
   }
 
   let totalTax;

--- a/src/utils/printTemplates.ts
+++ b/src/utils/printTemplates.ts
@@ -64,16 +64,15 @@ export async function getPrintTemplatePropValues(
   }
 
   if (doc.referenceType == ModelNameEnum.SalesInvoice) {
-   
     const referenceName = (doc as Payment)?.for![0]?.referenceName;
 
     if (referenceName) {
       sinvDoc = await fyo.doc.getDoc(ModelNameEnum.SalesInvoice, referenceName);
-  
+
       if (sinvDoc.taxes) {
         (values.doc as PrintTemplateData).taxes = sinvDoc.taxes;
       }
-    } 
+    }
   }
 
   let totalTax;


### PR DESCRIPTION
## Fix
The referenceName is safely retrieved using optional chaining and checks if it exists before trying to fetch the SalesInvoice document. This prevents undefined errors and avoids treating SalesInvoice as a "Single" schema, which was causing validation issues. Now the  payment pdf is viewable and can be saved as pdf

## Screenshot
![Screenshot (473)](https://github.com/user-attachments/assets/053b4474-4f3d-491f-888c-6d8f1c293795)

![Screenshot (478)](https://github.com/user-attachments/assets/b3fbab33-0850-4423-89ec-992bd3c5f6fb)
