### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ If you want to contribute code then you can fork this repo, make changes and rai
 
 - [Telegram Group](https://t.me/frappebooks): Used for discussions and decisions regarding everything Frappe Books.
 - [GitHub Discussions](https://github.com/frappe/books/discussions): Used for discussions around a specific topic.
-- [Documentation](https://docs.frappe.io/books): Offaicial documentation for more details.
+- [Documentation](https://docs.frappe.io/books): Official documentation for more details.


### PR DESCRIPTION
Fixes a small spelling mistake in the README.md file under the "Learn and Correct" subsection of the Documentation section.

<img width="699" height="163" alt="image_2025-07-18_131045241" src="https://github.com/user-attachments/assets/fb239d68-522a-47f1-b62d-697b505021be" />
