### PR TITLE
fix: allow clearing of default fields (Sales Invoice Terms & Purchase Invoice Terms)

### DIFF
--- a/src/pages/Settings/Settings.vue
+++ b/src/pages/Settings/Settings.vue
@@ -285,7 +285,7 @@ export default defineComponent({
       delete this.errors[fieldname];
 
       try {
-        await this.doc?.set(fieldname, value);
+        await this.doc?.set(fieldname, value ?? '');
       } catch (err) {
         if (!(err instanceof Error)) {
           return;


### PR DESCRIPTION
**Summary:**
This PR fixes a bug where clearing default fields did not persist after saving and restarting the app.

**Fixes:** #1333 

**Issue:**
Users were unable to clear certain default fields, specifically the Sales Invoice Terms. When a field was cleared and saved, the previous value would reappear after restarting the app. (Ref: #1333)

**Root Cause:**
- When a field was cleared, the value sent to the database was `null`.
- SQLite and the Frappe Books model treat null as “no value,” which does not overwrite the existing value in the database.
- As a result, the field was repopulated with the previous value on app restart.

**Fix:**
- Updated the onValueChange method to convert null to an empty string before saving:
   `await this.doc?.set(fieldname, value ?? '');`
- This ensures that clearing a field sets an explicit empty string in the database, so the cleared value persists.

**Impact:**
- Fixes clearing behavior for `Sales Invoice Terms` & `Purchase Invoice Terms`.
- Also resolves the same issue for any other default fields affected by this null persistence problem.

**Testing:**
- Manually cleared `Sales Invoice Terms` & `Purchase Invoice Terms`, saved, and restarted the app, the field remained empty.
- Verified that saving non-empty values still works correctly.

**Demo / Video:**
- Clear `Sales Invoice Terms` field.
- Save settings.
- Restart the app.
- Verify the field remains empty.


https://github.com/user-attachments/assets/4251d3d3-cc5f-4ecc-9257-f4123198270b
