### PR TITLE
feat: add Recent Used Options to Quick Search Command Bar

### DIFF
--- a/models/baseModels/Invoice/Invoice.ts
+++ b/models/baseModels/Invoice/Invoice.ts
@@ -1274,13 +1274,16 @@ export abstract class Invoice extends Transactional {
 
     let accountField: AccountFieldEnum = AccountFieldEnum.Account;
     let paymentType: PaymentTypeEnum = PaymentTypeEnum.Receive;
+    let referenceType: 'SalesInvoice' | 'PurchaseInvoice';
 
-    if (this.isSales && this.isReturn) {
-      accountField = AccountFieldEnum.PaymentAccount;
-      paymentType = PaymentTypeEnum.Pay;
-    }
-
-    if (!this.isSales) {
+    if (this.isSales) {
+      referenceType = 'SalesInvoice';
+      if (this.isReturn) {
+        accountField = AccountFieldEnum.PaymentAccount;
+        paymentType = PaymentTypeEnum.Pay;
+      }
+    } else {
+      referenceType = 'PurchaseInvoice';
       accountField = AccountFieldEnum.PaymentAccount;
       paymentType = PaymentTypeEnum.Pay;
 
@@ -1296,6 +1299,7 @@ export abstract class Invoice extends Transactional {
       paymentType,
       amount: this.outstandingAmount?.abs(),
       [accountField]: this.account,
+      referenceType,
       for: [
         {
           referenceType: this.schemaName,

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -317,6 +317,7 @@ export default defineComponent({
         List: 'teal',
         Report: 'yellow',
         Page: 'orange',
+        Recent: 'purple',
       };
     },
     groupColorClassMap(): Record<SearchGroup, string> {
@@ -422,7 +423,13 @@ export default defineComponent({
     },
     select(idx?: number): void {
       this.idx = idx ?? this.idx;
-      this.suggestions[this.idx]?.action?.();
+      const selectedItem = this.suggestions[this.idx];
+
+      if (selectedItem?.action) {
+        this.searcher?.addToRecent(selectedItem);
+        selectedItem.action();
+      }
+
       this.close();
     },
     scrollToHighlighted(): void {

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -252,6 +252,7 @@ import { docsPathMap } from 'src/utils/misc';
 import {
   SearchGroup,
   SearchItems,
+  SearchItem,
   getGroupLabelMap,
   searchGroups,
 } from 'src/utils/search';

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -192,6 +192,7 @@ export function getActionsForDoc(doc?: Doc): Action[] {
   const actions: Action[] = [
     ...getActions(doc),
     getDuplicateAction(doc),
+    getNewAction(doc),
     getDeleteAction(doc),
     getCancelAction(doc),
   ];
@@ -283,6 +284,21 @@ function getDuplicateAction(doc: Doc): Action {
       try {
         const dupe = doc.duplicate();
         await openEdit(dupe);
+      } catch (err) {
+        await handleErrorWithDialog(err as Error, doc);
+      }
+    },
+  };
+}
+
+function getNewAction(doc: Doc): Action {
+  return {
+    label: t`New Entry`,
+    group: t`Create`,
+    async action() {
+      try {
+        const newDoc = fyo.doc.getNewDoc(doc.schemaName);
+        await openEdit(newDoc);
       } catch (err) {
         await handleErrorWithDialog(err as Error, doc);
       }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -79,3 +79,21 @@ interface ModMap {
 export interface ConfigFilesWithModified extends ConfigFile {
   modified: string;
 }
+
+export const searchGroups = [
+  'Docs',
+  'List',
+  'Create',
+  'Report',
+  'Page',
+  'Recent',
+] as const;
+
+export type SearchGroup = typeof searchGroups[number];
+
+export interface SearchItem {
+  label: string;
+  group: Exclude<SearchGroup, 'Docs' | 'Recent'>;
+  route?: string;
+  action?: () => void | Promise<void>;
+}


### PR DESCRIPTION
Introduced a "Recently "  Options section in the Quick Search command bar to improve repetitive data entry. 
Users can now quickly reuse recently selected accounts, ledgers, or items without retyping, as the section displays 
the last 10 items. This enhancement speeds up frequent entries, improves workflow efficiency, and keeps the 
interface clean and intuitive.
