### PR TITLE
feat: add update button next to version

### DIFF
--- a/main/preload.ts
+++ b/main/preload.ts
@@ -64,7 +64,9 @@ const ipc = {
   },
 
   async downloadUpdate(): Promise<unknown> {
-    const result: unknown = await ipcRenderer.invoke('download-update');
+    const result: unknown = await ipcRenderer.invoke(
+      IPC_ACTIONS.DOWNLOAD_UPDATE
+    );
     return result;
   },
 
@@ -144,7 +146,7 @@ const ipc = {
 
   async downloadUpdateManual(): Promise<{ path: string }> {
     const result: { path: string } = (await ipcRenderer.invoke(
-      'download-update-manual'
+      IPC_ACTIONS.DOWNLOAD_UPDATE_MANUAL
     )) as { path: string };
     return result;
   },

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -4,12 +4,14 @@ import type {
   SaveDialogOptions,
   SaveDialogReturnValue,
 } from 'electron';
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 import type { ConfigMap } from 'fyo/core/types';
 import config from 'utils/config';
 import type { DatabaseMethod } from 'utils/db/types';
 import type { BackendResponse } from 'utils/ipc/types';
 import { IPC_ACTIONS, IPC_CHANNELS, IPC_MESSAGES } from 'utils/messages';
+import type { UpdateCheckResult } from 'src/utils/types';
+
 import type {
   ConfigFilesWithModified,
   Creds,
@@ -45,6 +47,25 @@ const ipc = {
         }
       );
     });
+  },
+
+  on(channel: string, callback: (...args: unknown[]) => void) {
+    const subscription = (_event: IpcRendererEvent, ...args: unknown[]) =>
+      callback(...args);
+    ipcRenderer.on(channel, subscription);
+
+    return () => {
+      ipcRenderer.removeListener(channel, subscription);
+    };
+  },
+
+  removeAllListeners(channel: string) {
+    ipcRenderer.removeAllListeners(channel);
+  },
+
+  async downloadUpdate(): Promise<unknown> {
+    const result: unknown = await ipcRenderer.invoke('download-update');
+    return result;
   },
 
   isFullscreen() {
@@ -114,8 +135,18 @@ const ipc = {
     )) as boolean;
   },
 
-  async checkForUpdates() {
-    await ipcRenderer.invoke(IPC_ACTIONS.CHECK_FOR_UPDATES);
+  async checkForUpdates(): Promise<UpdateCheckResult> {
+    const result: UpdateCheckResult = (await ipcRenderer.invoke(
+      IPC_ACTIONS.CHECK_FOR_UPDATES
+    )) as UpdateCheckResult;
+    return result;
+  },
+
+  async downloadUpdateManual(): Promise<{ path: string }> {
+    const result: { path: string } = (await ipcRenderer.invoke(
+      'download-update-manual'
+    )) as { path: string };
+    return result;
   },
 
   openLink(link: string) {

--- a/main/registerAutoUpdaterListeners.ts
+++ b/main/registerAutoUpdaterListeners.ts
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron';
+import { dialog } from 'electron';
 import { autoUpdater, UpdateInfo } from 'electron-updater';
 import { emitMainProcessError } from '../backend/helpers';
 import { Main } from '../main';
@@ -28,28 +28,6 @@ export default function registerAutoUpdaterListeners(main: Main) {
       const updateInfo = info;
 
       availableUpdate = updateInfo;
-
-      const currentVersion = app.getVersion();
-      const nextVersion = updateInfo.version;
-      const isCurrentBeta = currentVersion.includes('beta');
-      const isNextBeta = nextVersion.includes('beta');
-
-      let downloadUpdate = true;
-      if (!isCurrentBeta && isNextBeta) {
-        const option = await dialog.showMessageBox({
-          type: 'info',
-          title: 'Update Available',
-          message: `Download version ${nextVersion}?`,
-          buttons: ['Yes', 'No'],
-        });
-
-        downloadUpdate = option.response === 0;
-      }
-
-      if (!downloadUpdate) {
-        availableUpdate = null;
-        return;
-      }
 
       await autoUpdater.downloadUpdate();
     })();

--- a/main/registerIpcMainActionListeners.ts
+++ b/main/registerIpcMainActionListeners.ts
@@ -29,6 +29,7 @@ import {
 import { saveHtmlAsPdf } from './saveHtmlAsPdf';
 import { sendAPIRequest } from './api';
 import { initScheduler } from './initSheduler';
+import { getAvailableUpdate } from './registerAutoUpdaterListeners';
 
 export default function registerIpcMainActionListeners(main: Main) {
   ipcMain.handle(IPC_ACTIONS.CHECK_DB_ACCESS, async (_, filePath: string) => {
@@ -153,19 +154,38 @@ export default function registerIpcMainActionListeners(main: Main) {
 
   ipcMain.handle(IPC_ACTIONS.CHECK_FOR_UPDATES, async () => {
     if (main.isDevelopment || main.checkedForUpdate) {
-      return;
+      return { available: false };
     }
 
     try {
       await autoUpdater.checkForUpdates();
+
+      const availableUpdate = getAvailableUpdate();
+      if (availableUpdate) {
+        const currentVersion = app.getVersion();
+        const isCurrentBeta = currentVersion.includes('beta');
+        const isNextBeta = availableUpdate.version.includes('beta');
+
+        return {
+          available: true,
+          currentVersion,
+          nextVersion: availableUpdate.version,
+          isCurrentBeta,
+          isNextBeta,
+          releaseNotes: availableUpdate.releaseNotes,
+          releaseDate: availableUpdate.releaseDate,
+        };
+      }
+
+      return { available: false };
     } catch (error) {
       if (isNetworkError(error as Error)) {
-        return;
+        return { available: false, error: 'Network error' };
       }
 
       emitMainProcessError(error);
+      return { available: false, error: (error as Error).message };
     }
-    main.checkedForUpdate = true;
   });
 
   ipcMain.handle(IPC_ACTIONS.GET_LANGUAGE_MAP, async (_, code: string) => {
@@ -178,6 +198,37 @@ export default function registerIpcMainActionListeners(main: Main) {
     }
 
     return obj;
+  });
+
+  ipcMain.handle('download-update-manual', async () => {
+    const availableUpdate = getAvailableUpdate();
+    if (!availableUpdate) {
+      throw new Error('No update available to download');
+    }
+
+    const currentVersion = app.getVersion();
+    const isCurrentBeta = currentVersion.includes('beta');
+    const isNextBeta = availableUpdate.version.includes('beta');
+
+    let downloadUpdate = true;
+
+    if (!isCurrentBeta && isNextBeta) {
+      const option = await dialog.showMessageBox({
+        type: 'info',
+        title: 'Update Available',
+        message: `Download version ${availableUpdate.version}?`,
+        buttons: ['Yes', 'No'],
+      });
+
+      downloadUpdate = option.response === 0;
+    }
+
+    if (!downloadUpdate) {
+      return { downloaded: false };
+    }
+
+    await autoUpdater.downloadUpdate();
+    return { downloaded: true };
   });
 
   ipcMain.handle(

--- a/main/registerIpcMainActionListeners.ts
+++ b/main/registerIpcMainActionListeners.ts
@@ -163,17 +163,11 @@ export default function registerIpcMainActionListeners(main: Main) {
       const availableUpdate = getAvailableUpdate();
       if (availableUpdate) {
         const currentVersion = app.getVersion();
-        const isCurrentBeta = currentVersion.includes('beta');
-        const isNextBeta = availableUpdate.version.includes('beta');
 
         return {
           available: true,
           currentVersion,
-          nextVersion: availableUpdate.version,
-          isCurrentBeta,
-          isNextBeta,
-          releaseNotes: availableUpdate.releaseNotes,
-          releaseDate: availableUpdate.releaseDate,
+          newVersion: availableUpdate.version,
         };
       }
 
@@ -200,7 +194,7 @@ export default function registerIpcMainActionListeners(main: Main) {
     return obj;
   });
 
-  ipcMain.handle('download-update-manual', async () => {
+  ipcMain.handle(IPC_ACTIONS.DOWNLOAD_UPDATE_MANUAL, async () => {
     const availableUpdate = getAvailableUpdate();
     if (!availableUpdate) {
       throw new Error('No update available to download');

--- a/schemas/core/SystemSettings.json
+++ b/schemas/core/SystemSettings.json
@@ -65,6 +65,12 @@
       "section": "Default"
     },
     {
+      "fieldname": "updateButton",
+      "label": "Update",
+      "fieldtype": "Button",
+      "section": "Default"
+    },
+    {
       "fieldname": "allowFilterBypass",
       "label": "Allow to bypass filters",
       "fieldtype": "Check",

--- a/src/pages/Settings/Settings.vue
+++ b/src/pages/Settings/Settings.vue
@@ -95,13 +95,14 @@ import { shortcutsKey } from 'src/utils/injectionKeys';
 import { showDialog } from 'src/utils/interactive';
 import { docsPathMap } from 'src/utils/misc';
 import { docsPathRef } from 'src/utils/refs';
-import { UIGroupedFields } from 'src/utils/types';
+import { UIGroupedFields, UpdateCheckResult } from 'src/utils/types';
 import { computed, defineComponent, inject } from 'vue';
 import CommonFormSection from '../CommonForm/CommonFormSection.vue';
 
 const COMPONENT_NAME = 'Settings';
 
 export default defineComponent({
+  name: COMPONENT_NAME,
   components: { FormContainer, Button, FormHeader, CommonFormSection },
   provide() {
     return { doc: computed(() => this.doc) };
@@ -113,13 +114,12 @@ export default defineComponent({
   },
   data() {
     return {
-      errors: {},
+      errors: {} as Record<string, string>,
       activeTab: ModelNameEnum.AccountingSettings,
-      groupedFields: null,
-    } as {
-      errors: Record<string, string>;
-      activeTab: string;
-      groupedFields: null | UIGroupedFields;
+      groupedFields: null as UIGroupedFields | null,
+      showUpdateModal: false,
+      showManualCheckModal: false,
+      updateInfo: null as UpdateCheckResult | null,
     };
   },
   computed: {
@@ -206,7 +206,7 @@ export default defineComponent({
       // @ts-ignore
       window.settings = this;
     }
-
+    this.setupUpdateListeners();
     this.update();
   },
   activated(): void {
@@ -233,6 +233,36 @@ export default defineComponent({
     await this.reset();
   },
   methods: {
+    setupUpdateListeners() {
+      if (window.ipc && window.ipc.on) {
+        window.ipc.on('update-available', (info: unknown) => {
+          this.updateInfo = info as UpdateCheckResult;
+          this.showUpdateModal = true;
+        });
+      }
+    },
+    async handleManualUpdateCheck() {
+      this.showManualCheckModal = true;
+
+      const result = await window.ipc?.checkForUpdates?.();
+
+      this.showManualCheckModal = false;
+
+      if (result && !result.available) {
+        await showDialog({
+          title: this.t`Check for Updates`,
+          detail: this.t`You are running the latest version.`,
+          type: 'info',
+          buttons: [
+            {
+              label: this.t`OK`,
+              action: () => null,
+              isPrimary: true,
+            },
+          ],
+        });
+      }
+    },
     async reset() {
       const resetableDocs = this.schemas
         .map(({ name }) => this.fyo.singles[name])
@@ -262,7 +292,7 @@ export default defineComponent({
           {
             label: this.t`Yes`,
             isPrimary: true,
-            action: ipc.reloadWindow.bind(ipc),
+            action: window.ipc?.reloadWindow?.bind(window.ipc),
           },
           {
             label: this.t`No`,
@@ -283,9 +313,12 @@ export default defineComponent({
     async onValueChange(field: Field, value: DocValue): Promise<void> {
       const { fieldname } = field;
       delete this.errors[fieldname];
-
+      if (fieldname === 'updateButton') {
+        await this.handleManualUpdateCheck();
+        return;
+      }
       try {
-        await this.doc?.set(fieldname, value);
+        await this.doc?.set(fieldname, value ?? '');
       } catch (err) {
         if (!(err instanceof Error)) {
           return;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,6 +21,25 @@ export interface MessageDialogOptions {
   detail?: string;
   buttons?: MessageDialogButton[];
 }
+export interface UpdateInfo {
+  currentVersion: string;
+  nextVersion: string;
+  isCurrentBeta: boolean;
+  isNextBeta: boolean;
+  releaseNotes?: string;
+  releaseDate?: string;
+}
+
+export interface UpdateCheckResult {
+  available: boolean;
+  currentVersion?: string;
+  nextVersion?: string;
+  isCurrentBeta?: boolean;
+  isNextBeta?: boolean;
+  releaseNotes?: string;
+  releaseDate?: string;
+  error?: string;
+}
 
 export interface ToastOptions {
   message: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,22 +21,9 @@ export interface MessageDialogOptions {
   detail?: string;
   buttons?: MessageDialogButton[];
 }
-export interface UpdateInfo {
-  currentVersion: string;
-  nextVersion: string;
-  isCurrentBeta: boolean;
-  isNextBeta: boolean;
-  releaseNotes?: string;
-  releaseDate?: string;
-}
 
 export interface UpdateCheckResult {
   available: boolean;
-  currentVersion?: string;
-  nextVersion?: string;
-  isCurrentBeta?: boolean;
-  isNextBeta?: boolean;
-  releaseNotes?: string;
   releaseDate?: string;
   error?: string;
 }

--- a/utils/messages.ts
+++ b/utils/messages.ts
@@ -29,6 +29,8 @@ export enum IPC_ACTIONS {
   SEND_ERROR = 'send-error',
   GET_LANGUAGE_MAP = 'get-language-map',
   CHECK_FOR_UPDATES = 'check-for-updates',
+  DOWNLOAD_UPDATE = 'download-update',
+  DOWNLOAD_UPDATE_MANUAL = 'download-update-manual',
   CHECK_DB_ACCESS = 'check-db-access',
   SELECT_FILE = 'select-file',
   GET_CREDS = 'get-creds',

--- a/utils/messages.ts
+++ b/utils/messages.ts
@@ -12,6 +12,8 @@ export enum IPC_MESSAGES {
   ISFULLSCREEN_MAIN_WINDOW = 'isfullscreen-main-window',
   ISFULLSCREEN_RESULT = 'isfullscreen-result',
   CLOSE_MAIN_WINDOW = 'close-main-window',
+  UPDATE_AVAILABLE = 'update-available',
+  UPDATE_DOWNLOADED = 'update-downloaded',
 }
 
 // ipcRenderer.invoke(...)


### PR DESCRIPTION
In the System Settings page, a button named “Update” has been added. When the user clicks the Update button, a modal appears displaying the message “Update Downloaded — Restart Frappe Books to install update?” with two options, Yes and No. If the user clicks Yes, the system will automatically update to the latest version.


<img width="1844" height="1001" alt="Screenshot from 2025-10-21 11-07-39" src="https://github.com/user-attachments/assets/31ae436d-79cf-4839-af77-8a0ff1cd3179" />
