### PR TITLE
fix: preserve user-entered rate when changing exchange rate or quantity

### DIFF
--- a/models/baseModels/InvoiceItem/InvoiceItem.ts
+++ b/models/baseModels/InvoiceItem/InvoiceItem.ts
@@ -139,6 +139,19 @@ export abstract class InvoiceItem extends Doc {
     },
     rate: {
       formula: async (fieldname) => {
+        // Preserve user-entered rate if it exists and the change wasn't triggered by
+        // fields that should recalculate the rate (item, priceList, batch, pricingRuleDetail)
+        const shouldPreserveRate =
+          this.rate?.float &&
+          fieldname !== 'item' &&
+          fieldname !== 'priceList' &&
+          fieldname !== 'batch' &&
+          fieldname !== 'pricingRuleDetail';
+
+        if (shouldPreserveRate) {
+          return this.rate;
+        }
+
         const rate = await getItemRate(this);
         if (!rate?.float && this.rate?.float) {
           return this.rate;


### PR DESCRIPTION
## What This PR Does

Fixes a bug where manually entered item rates in Sales/Purchase Invoices were being reset when changing:
- Exchange rate
- Quantity  
- Party
- Date
- Other non-pricing fields

## The Problem

When a user manually enters an item rate and then changes the exchange rate or quantity, the rate field would recalculate and overwrite the user's input. This was frustrating for users who wanted to use custom pricing.

**Example:**
1. Create Sales Invoice with USD currency (system currency: CAD)
2. Add item which has a base rate of 60 CAD, but update it to 100. Since client billing is in USD it would be 100 USD
3. Change exchange rate from 1.3 to 1.4
4. ❌ Rate resets to item's base rate instead of staying at 100 USD

## The Solution

Modified the `rate` formula in `models/baseModels/InvoiceItem/InvoiceItem.ts` to preserve user-entered rates unless the change is triggered by fields that **should** recalculate pricing:
- Item change (new item = new pricing)
- Price list change (different pricing rules)
- Batch change (batch-specific pricing)
- Pricing rule change (promotional pricing)

## Changes Made

- Added early return in rate formula to check if rate should be preserved
- Rate is preserved when it exists (non-zero) AND change wasn't from pricing-related fields
- All other formula logic remains unchanged

## Testing

✅ **Tested Scenarios:**
- Changing exchange rate preserves rate
- Changing quantity preserves rate
- Changing party preserves rate
- Changing item still recalculates rate (expected)
- Changing price list still recalculates rate (expected)
