### PR TITLE
feat : add multiple selection option in item master

### DIFF
--- a/models/baseModels/Payment/Payment.ts
+++ b/models/baseModels/Payment/Payment.ts
@@ -26,7 +26,8 @@ import { AccountTypeEnum } from '../Account/types';
 import { Invoice } from '../Invoice/Invoice';
 import { Party } from '../Party/Party';
 import { PaymentFor } from '../PaymentFor/PaymentFor';
-import { PaymentType } from './types';
+import { PaymentType, PaymentTypeEnum } from './types';
+import { PartyRoleEnum } from '../Party/types';
 import { TaxSummary } from '../TaxSummary/TaxSummary';
 import { PaymentMethod } from '../PaymentMethod/PaymentMethod';
 
@@ -662,17 +663,23 @@ export class Payment extends Transactional {
         const partyDoc = (await this.loadAndGetLink('party')) as Party;
         const outstanding = partyDoc.outstandingAmount as Money;
 
-        if (partyDoc.role === 'Supplier') {
+        if (partyDoc.role === PartyRoleEnum.Supplier) {
           if (refDoc?.isReturn) {
-            return 'Receive';
+            return PaymentTypeEnum.Receive;
           } else {
-            return 'Pay';
+            return PaymentTypeEnum.Pay;
           }
-        } else if (partyDoc.role === 'Customer') {
+        } else if (partyDoc.role === PartyRoleEnum.Customer) {
           if (refDoc?.isSales && refDoc.isReturn) {
-            return 'Pay';
+            return PaymentTypeEnum.Pay;
           } else {
-            return 'Receive';
+            return PaymentTypeEnum.Receive;
+          }
+        } else if (partyDoc.role === PartyRoleEnum.Both) {
+          if (refDoc?.isSales && refDoc.isReturn) {
+            return PaymentTypeEnum.Pay;
+          } else {
+            return PaymentTypeEnum.Receive;
           }
         }
 
@@ -681,9 +688,9 @@ export class Payment extends Transactional {
         }
 
         if (outstanding?.isPositive()) {
-          return 'Receive';
+          return PaymentTypeEnum.Receive;
         }
-        return 'Pay';
+        return PaymentTypeEnum.Pay;
       },
     },
     amount: {

--- a/src/components/Controls/Check.vue
+++ b/src/components/Controls/Check.vue
@@ -8,7 +8,7 @@
         {{ df.label }}
       </div>
       <div
-        style="width: 14px; height: 14px; overflow: hidden"
+        style="width: 14px; height: 14px"
         :class="isReadOnly ? 'cursor-default' : 'cursor-pointer'"
       >
         <svg

--- a/src/pages/ListView/ListView.vue
+++ b/src/pages/ListView/ListView.vue
@@ -6,9 +6,6 @@
           schemaName === 'Item' &&
           (!isSelectionMode || (isSelectionMode && selectedItems.length === 0))
         "
-        ref="selectButton"
-        :icon="false"
-        @click="toggleSelectionMode"
       >
         {{ t`Select` }}
       </Button>
@@ -16,7 +13,6 @@
         v-if="
           isSelectionMode && schemaName === 'Item' && selectedItems.length > 0
         "
-        ref="actionSelect"
         :df="{
           fieldtype: 'Select',
           fieldname: 'Create ',
@@ -90,6 +86,7 @@ import { QueryFilter } from 'utils/db/types';
 import { defineComponent, inject, ref } from 'vue';
 import List from './List.vue';
 import { Money } from 'pesa';
+import { ModelNameEnum } from 'models/types';
 
 export default defineComponent({
   name: 'ListView',
@@ -113,7 +110,6 @@ export default defineComponent({
       list: ref<InstanceType<typeof List> | null>(null),
       makeNewDocButton: ref<InstanceType<typeof Button> | null>(null),
       exportButton: ref<InstanceType<typeof Button> | null>(null),
-      selectButton: ref<InstanceType<typeof Button> | null>(null),
       filterDropdown: ref<InstanceType<typeof FilterDropdown> | null>(null),
     };
   },
@@ -219,7 +215,10 @@ export default defineComponent({
     },
     async onActionChange(value: string) {
       this.selectedAction = value;
-      if (value === 'SalesInvoice' || value === 'PurchaseInvoice') {
+      if (
+        value === ModelNameEnum.SalesInvoice ||
+        value === ModelNameEnum.PurchaseInvoice
+      ) {
         const doc = fyo.doc.getNewDoc(value);
 
         for (const itemName of this.selectedItems) {

--- a/src/pages/ListView/ListView.vue
+++ b/src/pages/ListView/ListView.vue
@@ -6,23 +6,41 @@
           schemaName === 'Item' &&
           (!isSelectionMode || (isSelectionMode && selectedItems.length === 0))
         "
+        @click="toggleSelectionMode"
       >
         {{ t`Select` }}
       </Button>
-      <Select
+      <div
         v-if="
           isSelectionMode && schemaName === 'Item' && selectedItems.length > 0
         "
-        :df="{
-          fieldtype: 'Select',
-          fieldname: 'Create ',
-          label: 'Create Invoice',
-          options: actionOptions,
-        }"
-        :value="selectedAction"
-        class="w-40"
-        @change="onActionChange"
-      />
+        class="relative"
+      >
+        <Button class="w-40" @click="toggleDropdown"> Create Invoice </Button>
+        <div
+          v-if="showDropdown"
+          class="
+            absolute
+            top-full
+            mt-1
+            bg-white
+            border border-gray-300
+            rounded
+            shadow-lg
+            z-10
+            w-40
+          "
+        >
+          <div
+            v-for="option in actionOptions"
+            :key="option.value"
+            class="px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm"
+            @click="createInvoice(option.value)"
+          >
+            {{ option.label }}
+          </div>
+        </div>
+      </div>
       <Button ref="exportButton" :icon="false" @click="openExportModal = true">
         {{ t`Export` }}
       </Button>
@@ -73,7 +91,7 @@ import ExportWizard from 'src/components/ExportWizard.vue';
 import FilterDropdown from 'src/components/FilterDropdown.vue';
 import Modal from 'src/components/Modal.vue';
 import PageHeader from 'src/components/PageHeader.vue';
-import Select from 'src/components/Controls/Select.vue';
+
 import { fyo } from 'src/initFyo';
 import { shortcutsKey } from 'src/utils/injectionKeys';
 import {
@@ -97,7 +115,6 @@ export default defineComponent({
     FilterDropdown,
     Modal,
     ExportWizard,
-    Select,
   },
   props: {
     schemaName: { type: String, required: true },
@@ -119,14 +136,14 @@ export default defineComponent({
       openExportModal: false,
       listFilters: {},
       isSelectionMode: false,
-      selectedAction: '',
+      showDropdown: false,
       selectedItems: [] as string[],
     } as {
       listConfig: undefined | ReturnType<typeof getListConfig>;
       openExportModal: boolean;
       listFilters: QueryFilter;
       isSelectionMode: boolean;
-      selectedAction: string;
+      showDropdown: boolean;
       selectedItems: string[];
     };
   },
@@ -209,12 +226,14 @@ export default defineComponent({
     toggleSelectionMode() {
       this.isSelectionMode = !this.isSelectionMode;
       if (!this.isSelectionMode) {
-        this.selectedAction = '';
+        this.showDropdown = false;
         this.selectedItems = [];
       }
     },
-    async onActionChange(value: string) {
-      this.selectedAction = value;
+    toggleDropdown() {
+      this.showDropdown = !this.showDropdown;
+    },
+    async createInvoice(value: string) {
       if (
         value === ModelNameEnum.SalesInvoice ||
         value === ModelNameEnum.PurchaseInvoice
@@ -237,6 +256,7 @@ export default defineComponent({
         await routeTo(route);
         this.selectedItems = [];
         this.isSelectionMode = false;
+        this.showDropdown = false;
       }
     },
 


### PR DESCRIPTION
Added a **Select** button in the item list to enable multiple item selection. When the **Select** button is clicked, checkboxes appear beside each item, allowing users to choose multiple items at once. After selecting the desired items, an option appears to select an invoice type — either **Sales Invoice** or **Purchase Invoice**. Upon choosing the invoice type, the system redirects to the corresponding invoice page, and the selected items are automatically added to the cart.
