### PR TITLE
feat: Added Terms and Conditions section to print template

### DIFF
--- a/fyo/models/SystemSettings.ts
+++ b/fyo/models/SystemSettings.ts
@@ -17,6 +17,7 @@ export default class SystemSettings extends Doc {
   version?: string;
   instanceId?: string;
   darkMode?: boolean;
+  displayTermsAndConditions?: boolean;
 
   validations: ValidationMap = {
     displayPrecision(value: DocValue) {

--- a/models/baseModels/Payment/Payment.ts
+++ b/models/baseModels/Payment/Payment.ts
@@ -26,7 +26,8 @@ import { AccountTypeEnum } from '../Account/types';
 import { Invoice } from '../Invoice/Invoice';
 import { Party } from '../Party/Party';
 import { PaymentFor } from '../PaymentFor/PaymentFor';
-import { PaymentType } from './types';
+import { PaymentType, PaymentTypeEnum } from './types';
+import { PartyRoleEnum } from '../Party/types';
 import { TaxSummary } from '../TaxSummary/TaxSummary';
 import { PaymentMethod } from '../PaymentMethod/PaymentMethod';
 
@@ -662,17 +663,23 @@ export class Payment extends Transactional {
         const partyDoc = (await this.loadAndGetLink('party')) as Party;
         const outstanding = partyDoc.outstandingAmount as Money;
 
-        if (partyDoc.role === 'Supplier') {
+        if (partyDoc.role === PartyRoleEnum.Supplier) {
           if (refDoc?.isReturn) {
-            return 'Receive';
+            return PaymentTypeEnum.Receive;
           } else {
-            return 'Pay';
+            return PaymentTypeEnum.Pay;
           }
-        } else if (partyDoc.role === 'Customer') {
+        } else if (partyDoc.role === PartyRoleEnum.Customer) {
           if (refDoc?.isSales && refDoc.isReturn) {
-            return 'Pay';
+            return PaymentTypeEnum.Pay;
           } else {
-            return 'Receive';
+            return PaymentTypeEnum.Receive;
+          }
+        } else if (partyDoc.role === PartyRoleEnum.Both) {
+          if (refDoc?.isSales && refDoc.isReturn) {
+            return PaymentTypeEnum.Pay;
+          } else {
+            return PaymentTypeEnum.Receive;
           }
         }
 
@@ -681,9 +688,9 @@ export class Payment extends Transactional {
         }
 
         if (outstanding?.isPositive()) {
-          return 'Receive';
+          return PaymentTypeEnum.Receive;
         }
-        return 'Pay';
+        return PaymentTypeEnum.Pay;
       },
     },
     amount: {

--- a/models/baseModels/PrintSettings/PrintSettings.ts
+++ b/models/baseModels/PrintSettings/PrintSettings.ts
@@ -13,7 +13,11 @@ export class PrintSettings extends Doc {
   displayLogo?: boolean;
   displayTime?: boolean;
   displayDescription?: boolean;
+  displaytermsandconditions?: boolean;
+  termsAndConditions?: string;
   posPrintWidth?: number;
   amountInWords?: boolean;
-  override hidden: HiddenMap = {};
+  override hidden: HiddenMap = {
+    termsAndConditions: () => !this.displaytermsandconditions,
+  };
 }

--- a/schemas/app/PrintSettings.json
+++ b/schemas/app/PrintSettings.json
@@ -140,16 +140,16 @@
       "section": "Customizations"
     },
     {
-      "fieldname": "termsAndConditions",
-      "label": "Terms and Conditions",
-      "fieldtype": "Text",
-      "section": "Customizations"
-    },
-    {
       "fieldname": "posPrintWidth",
       "label": "Pos Print Width",
       "fieldtype": "Float",
       "default": 8,
+      "section": "Customizations"
+    },
+    {
+      "fieldname": "termsAndConditions",
+      "label": "Terms and Conditions",
+      "fieldtype": "Text",
       "section": "Customizations"
     }
   ]

--- a/schemas/app/PrintSettings.json
+++ b/schemas/app/PrintSettings.json
@@ -134,6 +134,18 @@
       "section": "Customizations"
     },
     {
+      "fieldname": "displaytermsandconditions",
+      "label": "Display Terms and Conditions",
+      "fieldtype": "Check",
+      "section": "Customizations"
+    },
+    {
+      "fieldname": "termsAndConditions",
+      "label": "Terms and Conditions",
+      "fieldtype": "Text",
+      "section": "Customizations"
+    },
+    {
       "fieldname": "posPrintWidth",
       "label": "Pos Print Width",
       "fieldtype": "Float",

--- a/schemas/core/SystemSettings.json
+++ b/schemas/core/SystemSettings.json
@@ -133,6 +133,13 @@
       "default": false,
       "description": "Sets the theme of the app.",
       "section": "Theme"
+    },
+    {
+      "fieldname": "displayTermsAndConditions",
+      "label": "Display Terms and Conditions",
+      "fieldtype": "Check",
+      "default": false,
+      "section": "Customizations"
     }
   ],
   "quickEditFields": [

--- a/src/pages/CommonForm/CommonFormSection.vue
+++ b/src/pages/CommonForm/CommonFormSection.vue
@@ -23,6 +23,7 @@
           field.fieldtype === 'Table' ? 'col-span-2 text-base' : '',
           field.fieldtype === 'AttachImage' ? 'row-span-2' : '',
           field.fieldtype === 'Check' ? 'mt-auto' : 'mb-auto',
+          field.fieldname === 'termsAndConditions' ? 'col-span-2' : '',
         ]"
       >
         <Table

--- a/src/pages/TemplateBuilder/PrintContainer.vue
+++ b/src/pages/TemplateBuilder/PrintContainer.vue
@@ -4,6 +4,7 @@
     :scale="Math.max(scale, 0.1)"
     :width="width"
     :height="height"
+    :show-overflow="true"
     class="mx-auto shadow-lg border"
   >
     <ErrorBoundary

--- a/src/pages/TemplateBuilder/ScaledContainer.vue
+++ b/src/pages/TemplateBuilder/ScaledContainer.vue
@@ -2,7 +2,7 @@
   <div class="overflow-hidden" :style="outerContainerStyle">
     <div
       :style="innerContainerStyle"
-      :class="showOverflow ? 'overflow-auto no-scrollbar' : ''"
+      :class="showOverflow ? 'overflow-auto no-scrollbar' : 'overflow-visible'"
     >
       <slot></slot>
     </div>

--- a/src/utils/printTemplates.ts
+++ b/src/utils/printTemplates.ts
@@ -38,6 +38,8 @@ const printSettingsFields = [
   'address',
   'companyName',
   'amountInWords',
+  'displaytermsandconditions',
+  'termsAndConditions',
 ];
 const accountingSettingsFields = ['gstin', 'taxId'];
 

--- a/templates/Basic.template.html
+++ b/templates/Basic.template.html
@@ -153,4 +153,15 @@
       </div>
     </section>
   </footer>
+
+  <!-- Terms and Conditions -->
+  <section
+    class="mt-8 px-6"
+    v-if="print.displaytermsandconditions && print.termsAndConditions"
+  >
+    <h3 class="text-lg font-semibold">{{ t`Terms and Conditions` }}</h3>
+    <p class="mt-4 text-lg whitespace-pre-line">
+      {{ print.termsAndConditions }}
+    </p>
+  </section>
 </main>

--- a/templates/Business.Payment.template.html
+++ b/templates/Business.Payment.template.html
@@ -122,5 +122,16 @@
 
       <p class="mt-4 text-lg whitespace-pre-line">{{ doc.terms }}</p>
     </section>
+
+    <!-- Terms and Conditions -->
+    <section
+      class="mt-12"
+      v-if="print.displaytermsandconditions && print.termsAndConditions"
+    >
+      <h3 class="text-lg font-semibold">{{t`Terms and Conditions`}}</h3>
+      <p class="mt-4 text-lg whitespace-pre-line">
+        {{ print.termsAndConditions }}
+      </p>
+    </section>
   </footer>
 </main>

--- a/templates/Business.Shipment.template.html
+++ b/templates/Business.Shipment.template.html
@@ -107,5 +107,16 @@
 
       <p class="mt-4 text-lg whitespace-pre-line">{{ doc.terms }}</p>
     </section>
+
+    <!-- Terms and Conditions -->
+    <section
+      class="mt-12"
+      v-if="print.displaytermsandconditions && print.termsAndConditions"
+    >
+      <h3 class="text-lg font-semibold">{{t`Terms and Conditions`}}</h3>
+      <p class="mt-4 text-lg whitespace-pre-line">
+        {{ print.termsAndConditions }}
+      </p>
+    </section>
   </footer>
 </main>

--- a/templates/Business.template.html
+++ b/templates/Business.template.html
@@ -132,9 +132,21 @@
       <h3 class="text-lg font-semibold">{{t`Notes`}}</h3>
       <p class="mt-4 text-lg whitespace-pre-line">{{ doc.terms }}</p>
     </section>
+
     <div v-if="print.amountInWords" class="flex justify-end mt-10">
       <h3 class="text-lg font-semibold mr-2">{{t`Grand Total In Words`}}:</h3>
       <p>{{doc.grandTotalInWords}}</p>
     </div>
+
+    <!-- Terms and Conditions -->
+    <section
+      class="mt-12"
+      v-if="print.displaytermsandconditions && print.termsAndConditions"
+    >
+      <h3 class="text-lg font-semibold">{{t`Terms and Conditions`}}</h3>
+      <p class="mt-4 text-lg whitespace-pre-line">
+        {{ print.termsAndConditions }}
+      </p>
+    </section>
   </footer>
 </main>

--- a/templates/Minimal.template.html
+++ b/templates/Minimal.template.html
@@ -177,4 +177,17 @@
       </div>
     </section>
   </footer>
+
+  <!-- Terms and Conditions -->
+  <section
+    class="px-12 py-10"
+    v-if="print.displaytermsandconditions && print.termsAndConditions"
+  >
+    <h3 class="uppercase text-sm tracking-widest font-semibold text-gray-800">
+      {{ t`Terms and Conditions` }}
+    </h3>
+    <p class="mt-4 text-lg whitespace-pre-line">
+      {{ print.termsAndConditions }}
+    </p>
+  </section>
 </main>


### PR DESCRIPTION
In the Print Settings, a checkbox is available to enable Terms and Conditions.When this option is checked, a text field appears, allowing users to enter the desired Terms and Conditions content.The entered text will then be displayed at the bottom of the last page in the printed document.