### PR TITLE
Add currency details for Georgia in countryInfo.json

### DIFF
--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -776,9 +776,11 @@
   },
   "Georgia": {
     "code": "ge",
+    "currency": "GEL",
     "currency_fraction": "Tetri",
     "currency_fraction_units": 100,
-    "currency_symbol": "ლ",
+    "currency_name": "Georgian Lari",
+    "currency_symbol": "₾",
     "timezones": ["Asia/Tbilisi"],
     "locale": "ka-GE"
   },


### PR DESCRIPTION
Fix Country Info for country Georgia
* Add missing `currency` and `currency_name`
* Fix `currency_symbol`

Source: https://en.wikipedia.org/wiki/Georgian_lari