### PR TITLE
fix: incorrect rounding of JPY amounts (zero-decimal currency)

### DIFF
--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -1060,8 +1060,9 @@
   "Japan": {
     "code": "jp",
     "currency": "JPY",
-    "currency_fraction": "Sen[G]",
-    "currency_fraction_units": 100,
+    "currency_fraction": "",
+    "currency_fraction_units": 1,
+    "smallest_currency_fraction_value": 1,
     "currency_name": "Yen",
     "currency_symbol": "¥",
     "timezones": ["Asia/Tokyo"],

--- a/src/setup/setupInstance.ts
+++ b/src/setup/setupInstance.ts
@@ -133,11 +133,16 @@ async function updateSystemSettings(
   const systemSettings = await fyo.doc.getDoc('SystemSettings');
   const instanceId = getRandomString();
 
+  const fractionUnits = countryOptions.currency_fraction_units ?? 100;
+  const displayPrecision =
+    fractionUnits > 0 ? Math.round(Math.log10(fractionUnits)) : 2;
+
   await systemSettings.setAndSync({
     locale,
     currency,
     instanceId,
     countryCode,
+    displayPrecision,
   });
 }
 

--- a/tests/testJPYPrecision.spec.ts
+++ b/tests/testJPYPrecision.spec.ts
@@ -1,0 +1,92 @@
+import { assertDoesNotThrow } from 'backend/database/tests/helpers';
+import { Fyo } from 'fyo';
+import { DummyAuthDemux } from 'fyo/tests/helpers';
+import { DatabaseManager } from 'backend/database/manager';
+import { DateTime } from 'luxon';
+import setupInstance from 'src/setup/setupInstance';
+import { SetupWizardOptions } from 'src/setup/types';
+import test from 'tape';
+import { getFiscalYear } from 'utils/misc';
+import { getTestDbPath } from './helpers';
+
+const dbPath = getTestDbPath();
+
+function getJPYSetupOptions(): SetupWizardOptions {
+  return {
+    logo: null,
+    companyName: 'Test JP Company',
+    country: 'Japan',
+    fullname: 'Test Person',
+    email: 'test@testjp.com',
+    bankName: 'Test Bank of Japan',
+    currency: 'JPY',
+    fiscalYearStart: DateTime.fromJSDate(
+      getFiscalYear('04-01', true)!
+    ).toISODate(),
+    fiscalYearEnd: DateTime.fromJSDate(
+      getFiscalYear('04-01', false)!
+    ).toISODate(),
+    chartOfAccounts: 'Standard Chart of Accounts',
+  };
+}
+
+const fyo = new Fyo({
+  DatabaseDemux: DatabaseManager,
+  AuthDemux: DummyAuthDemux,
+  isTest: true,
+  isElectron: false,
+});
+
+test('setup JPY instance', async () => {
+  const options = getJPYSetupOptions();
+  await assertDoesNotThrow(async () => {
+    await setupInstance(dbPath, options, fyo);
+  }, 'setup JPY instance failed');
+});
+
+test('JPY displayPrecision is 0', async (t) => {
+  const values = await fyo.db.getSingleValues('displayPrecision');
+  const displayPrecision = values.find(
+    (v) => v.fieldname === 'displayPrecision'
+  );
+
+  t.equals(
+    Number(displayPrecision?.value ?? 2),
+    0,
+    'displayPrecision should be 0 for JPY (zero-decimal currency)'
+  );
+});
+
+test('re-initialize fyo to pick up displayPrecision', async () => {
+  await assertDoesNotThrow(async () => {
+    await fyo.initializeAndRegister({}, {}, true);
+  }, 're-initialize fyo failed');
+});
+
+test('JPY pesa rounds to whole numbers', async (t) => {
+  const amount = fyo.pesa(1234.99);
+  const rounded = amount.round();
+
+  t.equals(
+    rounded,
+    '1235',
+    'JPY 1234.99 should round to 1235 (0 decimal places)'
+  );
+});
+
+test('JPY tax calculation produces whole number grand total', async (t) => {
+  const baseAmount = fyo.pesa(1127);
+  const taxRate = 10;
+  const taxAmount = baseAmount.mul(taxRate / 100);
+  const grandTotal = baseAmount.add(taxAmount);
+
+  t.equals(
+    grandTotal.round(),
+    '1240',
+    'JPY 1127 + 10% tax = 1239.7 rounds to 1240'
+  );
+});
+
+test.onFinish(async () => {
+  await fyo.close();
+});


### PR DESCRIPTION
## Summary

- **Bug:** JPY amounts displayed with 2 decimal places (e.g. ¥1234.99) instead of rounding to whole yen (¥1235). This affected all zero-decimal currencies.
- **Root cause 1:** `countryInfo.json` had `currency_fraction_units: 100` for Japan, but JPY has no fractional units — should be `1`.
- **Root cause 2:** `updateSystemSettings()` never set `displayPrecision` based on the currency, so it always defaulted to `2` regardless of country.

## Changes

### `fixtures/countryInfo.json`
- Japan: `currency_fraction_units` changed from `100` to `1`
- Japan: `currency_fraction` changed from `"Sen[G]"` to `""` (Sen hasn't been used since 1953)
- Japan: added `smallest_currency_fraction_value: 1`

### `src/setup/setupInstance.ts`
- `updateSystemSettings()` now derives `displayPrecision` from `currency_fraction_units` using `Math.log10()`:
  - `1` → precision `0` (JPY, KRW)
  - `100` → precision `2` (USD, EUR, INR)
  - `1000` → precision `3` (BHD, KWD)

### `tests/testJPYPrecision.spec.ts` (new)
- Sets up a full instance with Japan/JPY
- Verifies `displayPrecision` is stored as `0` in SystemSettings
- Verifies `fyo.pesa(1234.99).round()` produces `'1235'` (0 decimal places)
- Verifies tax calculation on ¥1127 + 10% rounds to `'1240'`

## Test plan

- [x] New JPY-specific test suite (3 tests)
- [x] All 911 existing tests continue to pass (including India/INR setup tests)
- [x] Prettier passes

Fixes #770