### PR TITLE
fix: use startsWith('Sales') for party labels in print templates

### DIFF
--- a/templates/Business.template.html
+++ b/templates/Business.template.html
@@ -26,9 +26,7 @@
     <div class="mt-8 text-lg">
       <!-- Doc Details -->
       <section class="flex">
-        <h3 class="w-1/3 font-semibold">
-          {{ doc.entryType === 'SalesInvoice' ? 'Invoice' : 'Bill' }}
-        </h3>
+        <h3 class="w-1/3 font-semibold">{{ doc.entryLabel }}</h3>
         <div class="w-2/3 text-gray-800">
           <p class="font-semibold">{{ doc.name }}</p>
 
@@ -42,7 +40,7 @@
       <!-- Party Details -->
       <section class="mt-4 flex">
         <h3 class="w-1/3 font-semibold">
-          {{ doc.entryType === 'SalesInvoice' ? 'Customer' : 'Supplier' }}
+          {{ doc.entryType.startsWith('Sales') ? 'Customer' : 'Supplier' }}
         </h3>
 
         <div class="w-2/3 text-gray-800" v-if="doc.party">

--- a/templates/Minimal.template.html
+++ b/templates/Minimal.template.html
@@ -35,7 +35,7 @@
     <!-- Party Details -->
     <section class="w-1/2">
       <h3 class="uppercase text-sm font-semibold tracking-widest text-gray-800">
-        {{ doc.entryType === 'SalesInvoice' ? 'To' : 'From' }}
+        {{ doc.entryType.startsWith('Sales') ? 'To' : 'From' }}
       </h3>
       <p class="mt-4 text-black leading-relaxed text-lg">{{ doc.party }}</p>
       <p
@@ -64,7 +64,7 @@
           ml-8
         "
       >
-        {{ doc.entryType === 'SalesInvoice' ? 'From' : 'To' }}
+        {{ doc.entryType.startsWith('Sales') ? 'From' : 'To' }}
       </h3>
       <p class="mt-4 ml-8 text-black leading-relaxed text-lg">
         {{ print.companyName }}


### PR DESCRIPTION
## Description

Print templates (`Business.template.html` and `Minimal.template.html`) hard-coded `doc.entryType === 'SalesInvoice'` to determine party labels and the document heading. This caused any non-invoice sales entry type (e.g. SalesQuote) to fall through to the wrong branch — showing "Supplier" instead of "Customer", "From" instead of "To", and "Bill" instead of the correct label.

### Changes

**Business template:**
- Document heading: replaced hard-coded `'Invoice' / 'Bill'` ternary with `doc.entryLabel`, which already provides the correct human-readable label for every entry type (consistent with the Basic template)
- Party label: changed `=== 'SalesInvoice'` to `startsWith('Sales')` so that SalesQuote, SalesOrder, etc. all show "Customer" correctly

**Minimal template:**
- To/From labels: changed `=== 'SalesInvoice'` to `startsWith('Sales')` for both the party and company sections

The `Basic.template.html` already uses `doc.entryLabel` and does not have this bug.

### How to test

1. Create a Sales Quote with a customer and at least one item
2. Open the print preview using the Business or Minimal template
3. Verify the party label shows **"Customer"** (not "Supplier") and the heading shows **"Quote"** (not "Bill")
4. Repeat with a Purchase Invoice to confirm it still shows "Supplier" / "From" correctly

Fixes #1399