### PR TITLE
fix: sum outstanding amounts across all references in payment validation

### DIFF
--- a/models/baseModels/Payment/Payment.ts
+++ b/models/baseModels/Payment/Payment.ts
@@ -725,13 +725,16 @@ export class Payment extends Transactional {
       }
 
       if (!this.totalAmount) {
+        this.totalAmount = this.fyo.pesa(0);
         for (const row of this.for ?? []) {
           const referenceDoc = (await this.fyo.doc.getDoc(
             row.referenceType as string,
             row.referenceName as string
           )) as Invoice;
 
-          this.totalAmount = referenceDoc.outstandingAmount?.abs();
+          this.totalAmount = (this.totalAmount as Money).add(
+            referenceDoc.outstandingAmount?.abs() ?? this.fyo.pesa(0)
+          );
         }
       }
 

--- a/models/baseModels/tests/testPayment.spec.ts
+++ b/models/baseModels/tests/testPayment.spec.ts
@@ -1,0 +1,99 @@
+import test from 'tape';
+import { closeTestFyo, getTestFyo, setupTestFyo } from 'tests/helpers';
+import { ModelNameEnum } from 'models/types';
+import { SalesInvoice } from '../SalesInvoice/SalesInvoice';
+import { Payment } from '../Payment/Payment';
+import { assertDoesNotThrow } from 'backend/database/tests/helpers';
+
+const fyo = getTestFyo();
+setupTestFyo(fyo, __filename);
+
+const itemMap = {
+  Widget: { name: 'Widget', rate: 100, unit: 'Unit', for: 'Sales' },
+  Gadget: { name: 'Gadget', rate: 250, unit: 'Unit', for: 'Sales' },
+};
+
+const partyData = {
+  name: 'Alice',
+  email: 'alice@example.com',
+};
+
+test('create items and party for payment tests', async (t) => {
+  for (const item of Object.values(itemMap)) {
+    await fyo.doc.getNewDoc(ModelNameEnum.Item, item).sync();
+    t.ok(
+      await fyo.db.exists(ModelNameEnum.Item, item.name),
+      `item ${item.name} exists`
+    );
+  }
+
+  await fyo.doc.getNewDoc(ModelNameEnum.Party, partyData).sync();
+  t.ok(
+    await fyo.db.exists(ModelNameEnum.Party, partyData.name),
+    `party ${partyData.name} exists`
+  );
+});
+
+test('create and submit two sales invoices', async (t) => {
+  // Invoice 1: 2 × Widget @ 100 = 200
+  const sinv1 = fyo.doc.getNewDoc(ModelNameEnum.SalesInvoice, {
+    account: 'Debtors',
+    party: partyData.name,
+    items: [{ item: 'Widget', rate: 100, quantity: 2 }],
+  }) as SalesInvoice;
+  await sinv1.sync();
+  await sinv1.runFormulas();
+  await sinv1.submit();
+  t.equal(sinv1.name, 'SINV-1001', 'first invoice created');
+  t.equal(sinv1.outstandingAmount?.float, 200, 'SINV-1001 outstanding = 200');
+
+  // Invoice 2: 1 × Gadget @ 250 = 250
+  const sinv2 = fyo.doc.getNewDoc(ModelNameEnum.SalesInvoice, {
+    account: 'Debtors',
+    party: partyData.name,
+    items: [{ item: 'Gadget', rate: 250, quantity: 1 }],
+  }) as SalesInvoice;
+  await sinv2.sync();
+  await sinv2.runFormulas();
+  await sinv2.submit();
+  t.equal(sinv2.name, 'SINV-1002', 'second invoice created');
+  t.equal(sinv2.outstandingAmount?.float, 250, 'SINV-1002 outstanding = 250');
+});
+
+test('payment against multiple invoices should validate total = sum of all outstanding amounts', async (t) => {
+  // Create a payment referencing BOTH invoices.
+  // Total outstanding across both = 200 + 250 = 450.
+  const paymentDoc = fyo.doc.getNewDoc(ModelNameEnum.Payment, {
+    party: partyData.name,
+    paymentType: 'Receive',
+    paymentMethod: 'Cash',
+    for: [
+      {
+        referenceType: ModelNameEnum.SalesInvoice,
+        referenceName: 'SINV-1001',
+        amount: fyo.pesa(200),
+      },
+      {
+        referenceType: ModelNameEnum.SalesInvoice,
+        referenceName: 'SINV-1002',
+        amount: fyo.pesa(250),
+      },
+    ],
+  }) as Payment;
+
+  // Setting amount to the correct total (200 + 250 = 450) triggers the
+  // `amount` validator. The bug causes totalAmount to be 250 (last invoice
+  // only), so the validator rejects 450 > 250 with a ValidationError.
+  await assertDoesNotThrow(
+    async () => await paymentDoc.set('amount', fyo.pesa(450)),
+    'setting amount to 450 against two invoices (200 + 250) should not throw'
+  );
+
+  t.equal(
+    paymentDoc.amount?.float,
+    450,
+    'payment amount = 450 (sum of both invoices)'
+  );
+});
+
+closeTestFyo(fyo, __filename);


### PR DESCRIPTION
## Description

The `amount` validator in `Payment.ts` computes `totalAmount` by iterating over all referenced invoices, but uses direct assignment instead of accumulation:

```typescript
// Before (buggy): only the last invoice's value survives
this.totalAmount = referenceDoc.outstandingAmount?.abs();
```

When a payment references multiple invoices (e.g. Invoice A = $200, Invoice B = $250), `totalAmount` ends up as $250 (last value) instead of $450 (correct sum). The validator then rejects any payment amount above $250, even though $450 is the correct total.

### Fix

Initialize `totalAmount` to zero before the loop and accumulate with `.add()`:

```typescript
// After (fixed): accumulate across all references
this.totalAmount = this.fyo.pesa(0);
for (const row of this.for ?? []) {
  const referenceDoc = /* ... */;
  this.totalAmount = (this.totalAmount as Money).add(
    referenceDoc.outstandingAmount?.abs() ?? this.fyo.pesa(0)
  );
}
```

### How to test

1. Create two Sales Invoices for the same customer (e.g. $200 and $250)
2. Submit both invoices
3. Create a Payment referencing both invoices
4. Verify the payment amount of $450 is accepted (previously rejected with "Payment amount cannot exceed $250.00")

### Automated test

Added `testPayment.spec.ts` that creates two invoices ($200 + $250), constructs a multi-reference payment, and asserts that setting amount to $450 does not throw a validation error.

Fixes #1400
Fixes #1424