### PR TITLE
fix: force Latin digits in number formatting for all locales

### DIFF
--- a/fyo/utils/format.ts
+++ b/fyo/utils/format.ts
@@ -170,7 +170,11 @@ function getNumberFormatter(fyo: Fyo) {
     (fyo.singles.SystemSettings?.displayPrecision as number) ??
     DEFAULT_DISPLAY_PRECISION;
 
-  return (fyo.currencyFormatter = Intl.NumberFormat(locale, {
+  // Force Latin (Western) digits for all locales by appending the Unicode
+  // locale extension '-u-nu-latn'. Without this, locales like 'ar-SA' use
+  // Arabic-Indic numerals (٠١٢٣) which are not suitable for accounting.
+  const latnLocale = `${locale}-u-nu-latn`;
+  return (fyo.currencyFormatter = Intl.NumberFormat(latnLocale, {
     style: 'decimal',
     minimumFractionDigits: display,
   }));

--- a/tests/testArabicLocaleFormatting.spec.ts
+++ b/tests/testArabicLocaleFormatting.spec.ts
@@ -1,0 +1,70 @@
+import test from 'tape';
+import { closeTestFyo, getTestFyo } from 'tests/helpers';
+import { SetupWizardOptions } from 'src/setup/types';
+import { DateTime } from 'luxon';
+import setupInstance from 'src/setup/setupInstance';
+import { getTestDbPath } from 'tests/helpers';
+import { getFiscalYear } from 'utils/misc';
+import { format } from 'fyo/utils/format';
+import { Field, FieldTypeEnum } from 'schemas/types';
+
+const fyo = getTestFyo();
+
+function getSaudiSetupOptions(): SetupWizardOptions {
+  return {
+    logo: null,
+    companyName: 'Test Saudi Company',
+    country: 'Saudi Arabia',
+    fullname: 'Test Person',
+    email: 'test@test.com',
+    bankName: 'Test Bank',
+    currency: 'SAR',
+    fiscalYearStart: DateTime.fromJSDate(
+      getFiscalYear('01-01', true)!
+    ).toISODate(),
+    fiscalYearEnd: DateTime.fromJSDate(
+      getFiscalYear('01-01', false)!
+    ).toISODate(),
+    chartOfAccounts: 'Saudi Arabia - Chart of Accounts',
+  };
+}
+
+test('setup: testArabicLocaleFormatting', async () => {
+  const options = getSaudiSetupOptions();
+  const dbPath = getTestDbPath();
+  await setupInstance(dbPath, options, fyo);
+});
+
+test('locale is set to ar-SA', async (t) => {
+  const locale = fyo.singles.SystemSettings?.locale as string;
+  t.equal(locale, 'ar-SA', 'locale should be ar-SA for Saudi Arabia');
+});
+
+test('formatted currency uses Latin digits, not Arabic-Indic', async (t) => {
+  // Format a known money value using the fyo formatter
+  const value = fyo.pesa(1234.56);
+  const currencyField: Field = {
+    fieldname: 'amount',
+    fieldtype: FieldTypeEnum.Currency,
+    label: 'Amount',
+  };
+
+  const formatted = format(value, currencyField, null, fyo);
+
+  // The formatted string should contain Latin digits (0-9), not
+  // Arabic-Indic digits (٠-٩). The bug causes Intl.NumberFormat('ar-SA')
+  // to produce Arabic-Indic numerals like "١٬٢٣٤٫٥٦".
+  const hasArabicIndicDigits = /[\u0660-\u0669]/.test(formatted);
+  t.notOk(
+    hasArabicIndicDigits,
+    `formatted value should not contain Arabic-Indic digits, got: "${formatted}"`
+  );
+
+  const hasLatinDigits = /[0-9]/.test(formatted);
+  t.ok(
+    hasLatinDigits,
+    `formatted value should contain Latin digits, got: "${formatted}"`
+  );
+});
+
+closeTestFyo(fyo, __filename);


### PR DESCRIPTION
## Description

When the locale is set to an Arabic region (e.g. `ar-SA` for Saudi Arabia), `Intl.NumberFormat` defaults to the Arabic-Indic numbering system and produces digits like `١٬٢٣٤٫٥٦` instead of `1,234.56`. This makes amounts unreadable for users who expect Latin (Western) digits, even when the app language is English.

### Root cause

In `fyo/utils/format.ts`, `getNumberFormatter()` passes the raw locale to `Intl.NumberFormat` without specifying a numbering system:

```typescript
Intl.NumberFormat(locale, { style: 'decimal', ... })
```

For `ar-SA`, this defaults to the `arab` numbering system (Arabic-Indic digits).

### Fix

Append the Unicode locale extension `-u-nu-latn` to force Latin digits:

```typescript
const latnLocale = `${locale}-u-nu-latn`;
Intl.NumberFormat(latnLocale, { style: 'decimal', ... })
```

This preserves locale-specific formatting conventions (decimal separators, grouping) while ensuring universally readable digits. This is the standard approach for accounting software — Latin digits are the global standard for financial data.

### Affected locales

Any locale that defaults to non-Latin digits: `ar-*` (Arabic), `fa-IR` (Persian), `bn-*` (Bengali), `my-*` (Myanmar), etc.

### How to test

1. Set up a new company with country "Saudi Arabia" (locale `ar-SA`, currency SAR)
2. Create a Sales Invoice with items
3. Verify all amounts display with Latin digits (e.g. `﷼ 1,234.56`) instead of Arabic-Indic digits (`﷼ ١٬٢٣٤٫٥٦`)

### Automated test

Added `testArabicLocaleFormatting.spec.ts` that sets up a Saudi Arabia instance and verifies formatted currency values contain only Latin digits.

Fixes #1166