### PR TITLE
fix: SalesQuote list view shows 'Paid' status incorrectly

### DIFF
--- a/models/baseModels/SalesQuote/SalesQuote.ts
+++ b/models/baseModels/SalesQuote/SalesQuote.ts
@@ -2,7 +2,7 @@ import { Fyo } from 'fyo';
 import { DocValueMap } from 'fyo/core/types';
 import { Action, FiltersMap, ListViewSettings } from 'fyo/model/types';
 import { ModelNameEnum } from 'models/types';
-import { getQuoteActions, getTransactionStatusColumn } from '../../helpers';
+import { getDocStatusListColumn, getQuoteActions } from '../../helpers';
 import { Invoice } from '../Invoice/Invoice';
 import { SalesQuoteItem } from '../SalesQuoteItem/SalesQuoteItem';
 import { Defaults } from '../Defaults/Defaults';
@@ -75,11 +75,10 @@ export class SalesQuote extends Invoice {
     return {
       columns: [
         'name',
-        getTransactionStatusColumn(),
+        getDocStatusListColumn(),
         'party',
         'date',
         'baseGrandTotal',
-        'outstandingAmount',
       ],
     };
   }

--- a/models/helpers.ts
+++ b/models/helpers.ts
@@ -508,6 +508,11 @@ function getSubmittableDocStatus(doc: RenderData | Doc) {
     }
   }
 
+  /**
+   * SalesQuote extends Invoice but should never show payment-related
+   * statuses (Paid, Unpaid, etc.) since quotes cannot be paid.
+   * Return early with simple submitted/cancelled/saved statuses.
+   */
   if (!!doc.submitted && !doc.cancelled) {
     return 'Submitted';
   }


### PR DESCRIPTION
## Summary
- SalesQuote extends Invoice and was using `getTransactionStatusColumn()` which casts status through `InvoiceStatus` — designed for invoices that can be paid
- Switched to `getDocStatusListColumn()` which shows simple Draft/Submitted/Cancelled statuses appropriate for quotes
- Removed the misleading `outstandingAmount` column from the SalesQuote list view since quotes cannot receive payments

## Test plan
- [ ] Create a SalesQuote and submit it
- [ ] Verify the list view shows "Submitted" (not "Paid" or "Unpaid")
- [ ] Verify no `outstandingAmount` column appears in the list

Fixes #1417