### PR TITLE
fix: Link field search stops working after clearing selection

### DIFF
--- a/src/components/Controls/Link.vue
+++ b/src/components/Controls/Link.vue
@@ -16,8 +16,11 @@ export default {
   watch: {
     value: {
       immediate: true,
-      handler(newValue) {
+      handler(newValue, oldValue) {
         this.setLinkValue(newValue);
+        if (oldValue && !newValue) {
+          this.results = [];
+        }
       },
     },
   },


### PR DESCRIPTION
## Summary
- The `Link.vue` component caches database results in `this.results` after the first fetch via `getOptions()`
- When a user selects an account, clears the field, and tries to search again, the stale cached results were returned instead of re-querying the database
- Added cache invalidation in the `value` watcher: when the value transitions from truthy to falsy (field cleared), `this.results` is reset to an empty array
- This matches the existing pattern in `DynamicLink.vue` which already clears results at the start of its `getOptions()` override

## Test plan
- [ ] Open an Invoice or Payment form
- [ ] Click on an Account link field and select an account
- [ ] Clear the selection
- [ ] Click the field again and search — verify the dropdown shows results
- [ ] Repeat the select/clear/search cycle multiple times to confirm it works consistently

Fixes #1403