### PR TITLE
fix: use international AED symbol for UAE currency

### DIFF
--- a/fixtures/countryInfo.json
+++ b/fixtures/countryInfo.json
@@ -2101,9 +2101,9 @@
     "currency_fraction": "Fils",
     "currency_fraction_units": 100,
     "currency_name": "UAE Dirham",
-    "currency_symbol": "د.إ",
+    "currency_symbol": "AED",
     "timezones": ["Asia/Dubai"],
-    "locale": "ar-AE"
+    "locale": "en-AE"
   },
   "United Kingdom": {
     "code": "gb",


### PR DESCRIPTION
## Summary
- Changed UAE currency symbol from Arabic `د.إ` to the international ISO 4217 code `AED`
- Changed locale from `ar-AE` to `en-AE` for Western Arabic numeral formatting
- The Arabic symbol causes confusion with international banks and clients, as reported in the issue

## Test plan
- [ ] Select "United Arab Emirates" during company setup
- [ ] Verify the currency symbol displays as `AED` (not `د.إ`)
- [ ] Verify numbers format with Western Arabic numerals (1,234.56)

Fixes #1416