### PR TITLE
feat: show narration/remarks in General Ledger report

### DIFF
--- a/models/Transactional/LedgerPosting.ts
+++ b/models/Transactional/LedgerPosting.ts
@@ -118,6 +118,7 @@ export class LedgerPosting {
         reverted: this.reverted,
         debit: this.fyo.pesa(0),
         credit: this.fyo.pesa(0),
+        userRemark: this._getUserRemark(),
       },
       false
     ) as AccountingLedgerEntry;
@@ -126,6 +127,16 @@ export class LedgerPosting {
     map[account] = ledgerEntry;
 
     return map[account];
+  }
+
+  /**
+   * Get the user remark / narration from the reference document.
+   * JournalEntry uses 'userRemark', Invoice/SalesQuote use 'terms'.
+   */
+  _getUserRemark(): string {
+    return (
+      (this.refDoc.userRemark as string) ?? (this.refDoc.terms as string) ?? ''
+    );
   }
 
   _validateIsEqual() {

--- a/reports/GeneralLedger/GeneralLedger.ts
+++ b/reports/GeneralLedger/GeneralLedger.ts
@@ -79,6 +79,7 @@ export class GeneralLedger extends LedgerReport {
       party: '',
       reverted: false,
       reverts: '',
+      userRemark: '',
     });
 
     this.reportData = this._convertEntriesToReportData(consolidated);
@@ -189,6 +190,7 @@ export class GeneralLedger extends LedgerReport {
       party: '',
       reverted: false,
       reverts: '',
+      userRemark: '',
     });
   }
 
@@ -226,6 +228,7 @@ export class GeneralLedger extends LedgerReport {
           party: '',
           reverted: false,
           reverts: '',
+          userRemark: '',
         });
       }
 
@@ -410,6 +413,12 @@ export class GeneralLedger extends LedgerReport {
         label: t`Ref Type`,
         fieldtype: 'Data',
         fieldname: 'referenceType',
+      },
+      {
+        label: t`Remarks`,
+        fieldtype: 'Data',
+        fieldname: 'userRemark',
+        width: 1.5,
       },
       {
         label: t`Reverted`,

--- a/reports/LedgerReport.ts
+++ b/reports/LedgerReport.ts
@@ -87,6 +87,7 @@ export abstract class LedgerReport extends Report {
       'party',
       'reverted',
       'reverts',
+      'userRemark',
     ];
 
     const filters = await this._getQueryFilters();
@@ -113,6 +114,7 @@ export abstract class LedgerReport extends Report {
         party: entry.party,
         reverted: Boolean(entry.reverted),
         reverts: entry.reverts,
+        userRemark: entry.userRemark ?? '',
       } as LedgerEntry;
     });
   }

--- a/reports/types.ts
+++ b/reports/types.ts
@@ -52,6 +52,7 @@ export interface RawLedgerEntry {
   party: string;
   reverted: number;
   reverts: string;
+  userRemark: string;
   [key: string]: RawValue;
 }
 
@@ -68,6 +69,7 @@ export interface LedgerEntry {
   party: string;
   reverted: boolean;
   reverts: string;
+  userRemark: string;
 }
 
 export type GroupedMap = Map<string, LedgerEntry[]>;

--- a/schemas/app/AccountingLedgerEntry.json
+++ b/schemas/app/AccountingLedgerEntry.json
@@ -68,6 +68,13 @@
       "section": "Reference"
     },
     {
+      "fieldname": "userRemark",
+      "label": "User Remark",
+      "fieldtype": "Data",
+      "readOnly": true,
+      "section": "Reference"
+    },
+    {
       "fieldname": "reverted",
       "label": "Reverted",
       "fieldtype": "Check",


### PR DESCRIPTION
## Summary
- Added `userRemark` field to `AccountingLedgerEntry` schema to store narration at the ledger level
- `LedgerPosting` now copies `userRemark` (from JournalEntry) or `terms` (from Invoice) into each ledger entry when posting
- Added "Remarks" column to the General Ledger report so users can see transaction context without opening individual vouchers
- Updated `RawLedgerEntry` and `LedgerEntry` types to include the new field

### Files changed
| File | Change |
|------|--------|
| `schemas/app/AccountingLedgerEntry.json` | Added `userRemark` field |
| `models/Transactional/LedgerPosting.ts` | Copy remark from source doc into ledger entries |
| `reports/types.ts` | Added `userRemark` to entry interfaces |
| `reports/LedgerReport.ts` | Fetch `userRemark` in raw data query |
| `reports/GeneralLedger/GeneralLedger.ts` | Added "Remarks" column + `userRemark` in synthetic rows |

## Test plan
- [ ] Create a Journal Entry with a user remark and submit it
- [ ] Open General Ledger — verify the "Remarks" column shows the remark text
- [ ] Create a Sales Invoice with notes/terms and submit it
- [ ] Verify the General Ledger shows the notes for that invoice's ledger entries
- [ ] Verify blank/total/closing rows show empty remarks without errors

Closes #1411