### PR TITLE
feat: add Australian GST tax templates

### DIFF
--- a/src/regional/au/au.ts
+++ b/src/regional/au/au.ts
@@ -1,0 +1,29 @@
+import { Fyo } from 'fyo';
+
+/**
+ * Creates Australian GST (Goods and Services Tax) templates during setup.
+ *
+ * Current Australian GST rates:
+ * - 10% Standard rate (most goods and services)
+ * -  0% GST-Free (basic food, health, education, exports)
+ */
+export async function createAustralianRecords(fyo: Fyo) {
+  await createTaxes(fyo);
+}
+
+async function createTaxes(fyo: Fyo) {
+  const taxAccount = 'GST';
+
+  const taxes = [
+    { name: 'GST-10', rate: 10 },
+    { name: 'GST-Free', rate: 0 },
+  ];
+
+  for (const { name, rate } of taxes) {
+    const newTax = fyo.doc.getNewDoc('Tax', {
+      name,
+      details: [{ account: taxAccount, rate }],
+    });
+    await newTax.sync();
+  }
+}

--- a/src/regional/index.ts
+++ b/src/regional/index.ts
@@ -1,7 +1,12 @@
 import { Fyo } from 'fyo';
+import { createAustralianRecords } from './au/au';
 import { createIndianRecords } from './in/in';
 
 export async function createRegionalRecords(country: string, fyo: Fyo) {
+  if (country === 'Australia') {
+    await createAustralianRecords(fyo);
+  }
+
   if (country === 'India') {
     await createIndianRecords(fyo);
   }


### PR DESCRIPTION
## Summary
- Added regional setup for Australia that automatically creates GST tax templates during company setup
- Templates created: **GST-10** (10% standard rate) and **GST-Free** (0% exempt)
- Follows the established pattern used by India, Czech Republic, and Slovakia

### Files changed
| File | Change |
|------|--------|
| `src/regional/au/au.ts` | New file — `createAustralianRecords()` function |
| `src/regional/index.ts` | Added Australia branch to `createRegionalRecords()` |

## Test plan
- [ ] Select "Australia" during company setup
- [ ] Verify that GST-10 and GST-Free tax templates are created automatically
- [ ] Create a Sales Invoice using GST-10 — verify 10% tax is calculated correctly
- [ ] Verify existing regional setups (India, Czech Republic, Slovakia) still work

Closes #1358