### PR TITLE
fix: pin macOS code signing identity via env var

### DIFF
--- a/electron-builder-config.mjs
+++ b/electron-builder-config.mjs
@@ -31,6 +31,7 @@ const frappeBooksConfig = {
     app: buildDirPath,
   },
   mac: {
+    identity: process.env.CSC_NAME || null,
     type: 'distribution',
     artifactName: '${productName}-v${version}-mac-${arch}.${ext}',
     category: 'public.app-category.finance',


### PR DESCRIPTION
## Summary

- Adds explicit `identity` field to the `mac` block in `electron-builder-config.mjs`, controlled via the `CSC_NAME` environment variable
- Prevents accidental signing with stale or incorrect certificates by allowing the identity to be pinned rather than relying solely on keychain auto-discovery

## Required follow-up: update GitHub Secrets

The following GitHub Actions secrets must be updated with the new Apple Developer credentials before the next publish workflow run.

### `APPLE_TEAM_ID`

Your Apple Team ID. Find this at [developer.apple.com/account](https://developer.apple.com/account) → Membership Details → Team ID (a 10-character alphanumeric string).

### `APPLE_ID`

The Apple ID email address associated with your developer account.

### `APPLE_APP_PASSWORD`

An app-specific password for notarization. Generate one at [appleid.apple.com](https://appleid.apple.com) → Sign-In and Security → App-Specific Passwords → Generate.

### `CSC_LINK`

A base64-encoded `.p12` certificate file containing the "Developer ID Application" certificate.

**To obtain and encode the certificate:**

1. In the Apple Developer portal ([developer.apple.com/account/resources/certificates](https://developer.apple.com/account/resources/certificates)), create a **Developer ID Application** certificate if you haven't already
2. Download and install it into your macOS keychain
3. Open **Keychain Access**, find the certificate named `Developer ID Application: <Your Company> (<Team ID>)`
4. Right-click → **Export** → save as a `.p12` file with a strong password
5. Base64-encode the `.p12` file:
   ```bash
   base64 -i certificate.p12 -o certificate-base64.txt
   ```
6. Copy the contents of `certificate-base64.txt` into the `CSC_LINK` GitHub secret

### `CSC_KEY_PASSWORD`

The password you chose when exporting the `.p12` file in the step above.

## Optional: local environment setup

For local signed builds, set the `CSC_NAME` environment variable to explicitly target the correct certificate:

```bash
export CSC_NAME="Developer ID Application: <Your Company> (<Team ID>)"
```

If `CSC_NAME` is not set, electron-builder falls back to auto-discovery from the keychain (the previous default behaviour).

## Test plan

- [ ] Verify `security find-identity -v -p codesigning` shows the expected "Developer ID Application" certificate
- [ ] Run `yarn build` locally and confirm the signing output shows the correct `identityName`
- [ ] After updating GitHub secrets, trigger the publish workflow and verify CI signs with the correct identity