### PR TITLE
fix: 1426 General Ledger Ref Name filter dropdown empty & "Accounting…

### DIFF
--- a/models/helpers.ts
+++ b/models/helpers.ts
@@ -311,6 +311,8 @@ export function getLedgerLink(
     name: 'Report',
     params: {
       reportClassName,
+    },
+    query: {
       defaultFilters: JSON.stringify({
         referenceType: doc.schemaName,
         referenceName: doc.name,


### PR DESCRIPTION
Fixed report link issue for 

[Bug] - General Ledger Ref Name filter dropdown empty & "Accounting Entries" navigation broken #1426