### PR TITLE
Feat: Sort by Column Header

### DIFF
--- a/src/pages/ListView/List.vue
+++ b/src/pages/ListView/List.vue
@@ -40,28 +40,37 @@
             h-row
             items-center
             flex
-            cursor-pointer
-            select-none
             gap-1
-            group
           "
           :class="{
             'ms-auto': isNumeric(column.fieldtype),
             'pe-4': i === columns.length - 1,
+            'cursor-pointer select-none group': sortableFieldnames.has(
+              column.fieldname
+            ),
           }"
           @click="handleColumnHeaderClick(column.fieldname)"
         >
           {{ column.label }}
-          <feather-icon
-            v-if="sortField === column.fieldname"
-            :name="sortOrder === 'asc' ? 'chevron-up' : 'chevron-down'"
-            class="w-3 h-3 flex-shrink-0"
-          />
-          <feather-icon
-            v-else
-            name="chevron-up"
-            class="w-3 h-3 flex-shrink-0 opacity-0 group-hover:opacity-40 transition-opacity"
-          />
+          <template v-if="sortableFieldnames.has(column.fieldname)">
+            <feather-icon
+              v-if="sortField === column.fieldname"
+              :name="sortOrder === 'asc' ? 'chevron-up' : 'chevron-down'"
+              class="w-3 h-3 flex-shrink-0"
+            />
+            <feather-icon
+              v-else
+              name="chevron-up"
+              class="
+                w-3
+                h-3
+                flex-shrink-0
+                opacity-0
+                group-hover:opacity-40
+                transition-opacity
+              "
+            />
+          </template>
         </div>
       </Row>
     </div>
@@ -214,6 +223,14 @@ export default defineComponent({
         this.data.length > 0 && this.selectedItems.length === this.data.length
       );
     },
+    sortableFieldnames(): Set<string> {
+      const schemaFieldMap = fyo.db.fieldMap[this.schemaName] ?? {};
+      return new Set(
+        Object.values(schemaFieldMap)
+          .filter((field) => !field.computed && field.fieldtype !== 'Table')
+          .map((field) => field.fieldname)
+      );
+    },
     columns() {
       let columns = this.listConfig?.columns ?? [];
 
@@ -331,13 +348,16 @@ export default defineComponent({
       this.$emit('updatedData', filters);
     },
     handleColumnHeaderClick(fieldname: string) {
+      if (!this.sortableFieldnames.has(fieldname)) {
+        return;
+      }
       if (this.sortField === fieldname) {
         this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
       } else {
         this.sortField = fieldname;
         this.sortOrder = 'asc';
       }
-      this.updateData();
+      void this.updateData();
     },
     toggleItemSelection(itemName: string) {
       const index = this.selectedItems.indexOf(itemName);

--- a/src/pages/ListView/List.vue
+++ b/src/pages/ListView/List.vue
@@ -40,13 +40,28 @@
             h-row
             items-center
             flex
+            cursor-pointer
+            select-none
+            gap-1
+            group
           "
           :class="{
             'ms-auto': isNumeric(column.fieldtype),
             'pe-4': i === columns.length - 1,
           }"
+          @click="handleColumnHeaderClick(column.fieldname)"
         >
           {{ column.label }}
+          <feather-icon
+            v-if="sortField === column.fieldname"
+            :name="sortOrder === 'asc' ? 'chevron-up' : 'chevron-down'"
+            class="w-3 h-3 flex-shrink-0"
+          />
+          <feather-icon
+            v-else
+            name="chevron-up"
+            class="w-3 h-3 flex-shrink-0 opacity-0 group-hover:opacity-40 transition-opacity"
+          />
         </div>
       </Row>
     </div>
@@ -183,6 +198,8 @@ export default defineComponent({
       pageEnd: 0,
       statusMap: {} as Record<string, string>,
       selectedItems: [] as string[],
+      sortField: null as string | null,
+      sortOrder: 'asc' as 'asc' | 'desc',
     };
   },
   computed: {
@@ -272,15 +289,25 @@ export default defineComponent({
         delete filters['status'];
       }
 
-      const orderBy = ['created'];
-      if (fyo.db.fieldMap[this.schemaName]['date']) {
-        orderBy.unshift('date');
+      let orderBy: string[];
+      let order: 'asc' | 'desc';
+
+      if (this.sortField) {
+        orderBy = [this.sortField];
+        order = this.sortOrder;
+      } else {
+        orderBy = ['created'];
+        if (fyo.db.fieldMap[this.schemaName]['date']) {
+          orderBy.unshift('date');
+        }
+        order = 'desc';
       }
 
       const tableData = await fyo.db.getAll(this.schemaName, {
         fields: ['*'],
         filters: filters as QueryFilter,
         orderBy,
+        order,
       });
 
       let filteredData = tableData;
@@ -302,6 +329,15 @@ export default defineComponent({
         schema: fyo.schemaMap[this.schemaName],
       })) as RenderData[];
       this.$emit('updatedData', filters);
+    },
+    handleColumnHeaderClick(fieldname: string) {
+      if (this.sortField === fieldname) {
+        this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
+      } else {
+        this.sortField = fieldname;
+        this.sortOrder = 'asc';
+      }
+      this.updateData();
     },
     toggleItemSelection(itemName: string) {
       const index = this.selectedItems.indexOf(itemName);


### PR DESCRIPTION
Implement fixes #1485. Clicking a column header in any list view now sorts the table by that column. Clicking the same header again toggles between ascending and descending order. A chevron indicator shows the active sort column and direction; a faint chevron appears on hover for other sort-able columns.

Columns that are not real database fields (computed values like Status within the Journal Entries view, or child Table fields) are excluded from sorting, clicking them does nothing.

Initial View, sorted by created date:
<img width="1312" height="912" alt="Screenshot 2026-04-04 at 5 18 21 PM" src="https://github.com/user-attachments/assets/c9cd2650-2af2-4145-a038-667cf55cbd57" />

Sorted by Item Name:
<img width="1312" height="912" alt="Screenshot 2026-04-04 at 5 18 27 PM" src="https://github.com/user-attachments/assets/db573e8f-c32a-4342-9782-3aee7db96b47" />

Sorted by Rate Asc:
<img width="1312" height="912" alt="Screenshot 2026-04-04 at 5 18 33 PM" src="https://github.com/user-attachments/assets/8ede3314-437b-4f24-ab18-5f0fc2956ea6" />

Sorted by Rate Desc:
<img width="1312" height="912" alt="Screenshot 2026-04-04 at 5 18 37 PM" src="https://github.com/user-attachments/assets/a08509be-cc1f-41de-92a9-9bf2e358a578" />