### PR TITLE
feat: add full-width toggle to Settings view

### DIFF
--- a/src/pages/Settings/Settings.vue
+++ b/src/pages/Settings/Settings.vue
@@ -1,6 +1,16 @@
 <template>
-  <FormContainer>
+  <FormContainer :use-full-width="useFullWidth">
     <template #header>
+      <Button
+        :icon="true"
+        :title="t`Toggle between form and full width`"
+        @click="toggleWidth"
+      >
+        <feather-icon
+          :name="useFullWidth ? 'minimize' : 'maximize'"
+          class="w-4 h-4"
+        ></feather-icon>
+      </Button>
       <Button v-if="canSave" type="primary" @click="sync">
         {{ t`Save` }}
       </Button>
@@ -116,10 +126,12 @@ export default defineComponent({
       errors: {},
       activeTab: ModelNameEnum.AccountingSettings,
       groupedFields: null,
+      useFullWidth: false,
     } as {
       errors: Record<string, string>;
       activeTab: string;
       groupedFields: null | UIGroupedFields;
+      useFullWidth: boolean;
     };
   },
   computed: {
@@ -207,9 +219,11 @@ export default defineComponent({
       window.settings = this;
     }
 
+    this.useFullWidth = !!this.fyo.singles.Misc?.useFullWidth;
     this.update();
   },
   activated(): void {
+    this.useFullWidth = !!this.fyo.singles.Misc?.useFullWidth;
     const tab = this.$route.query.tab;
     if (typeof tab === 'string' && this.tabLabels[tab]) {
       this.activeTab = tab;
@@ -233,6 +247,11 @@ export default defineComponent({
     await this.reset();
   },
   methods: {
+    async toggleWidth() {
+      const value = !this.useFullWidth;
+      await this.fyo.singles.Misc?.setAndSync('useFullWidth', value);
+      this.useFullWidth = value;
+    },
     async reset() {
       const resetableDocs = this.schemas
         .map(({ name }) => this.fyo.singles[name])


### PR DESCRIPTION
**Add full-width toggle to Settings view**

**What**
The Settings view was locked to the narrow form-width layout with no way to expand it. This adds the same maximize/minimize toggle button that already exists on journal entry and new entry forms.

**How**
- Added a `useFullWidth` boolean to `Settings.vue`'s data, initialized from the persisted `Misc.useFullWidth` value in both `mounted` and `activated` hooks.
- Added a `toggleWidth` method that flips the value and persists it via `fyo.singles.Misc?.setAndSync('useFullWidth', value)`.
- Wired `:use-full-width="useFullWidth"` into `<FormContainer>`.
- Added the toggle `<Button>` with the `maximize`/`minimize` feather icon to the `#header` slot, to the left of the existing Save button.

**Why**
Settings contains a large number of fields across multiple tabs. Full-width mode makes them significantly easier to scan and edit, especially on wider screens. The preference is stored in the shared `Misc.useFullWidth` singleton, so the chosen layout is respected consistently across all views that support it.

**Testing**
- Open Settings — the toggle button appears in the header next to Save.
- Click the button — the form expands to full width and the icon changes to minimize.
- Click again — the form returns to narrow mode.
- Navigate away to a journal entry form — it reflects the same width preference.
- Reload the app — the last-used width preference is restored in Settings.

Original Settings view without toggle in top right:
<img width="1312" height="912" alt="Screenshot 2026-04-04 at 6 20 34 PM" src="https://github.com/user-attachments/assets/ddc150cb-81a1-4680-a7b3-9b2fc6964fc8" />

Setting view with toggle in Form width:
<img width="1312" height="912" alt="Screenshot 2026-04-04 at 6 21 04 PM" src="https://github.com/user-attachments/assets/b6602282-80bd-4f34-85ca-bde30e7b0359" />

Setting view with toggle in Full width:
<img width="1312" height="912" alt="Screenshot 2026-04-04 at 6 21 14 PM" src="https://github.com/user-attachments/assets/b2134c6b-9ea7-40c1-81b9-742bc614e8c8" />
