### PR TITLE
fix: update parent doc link field when nested Quick Edit Form

### DIFF
--- a/src/components/Controls/DynamicLink.vue
+++ b/src/components/Controls/DynamicLink.vue
@@ -86,10 +86,16 @@ export default {
       const doc = fyo.doc.getNewDoc(schemaName, { name, ...filters });
       openQuickEdit({ doc });
 
+      const parentDoc = this.doc;
+      const fieldname = this.df.fieldname;
+
       doc.once('afterSync', () => {
         this.$router.back();
         this.results = [];
         this.triggerChange(doc.name);
+        if (parentDoc && fieldname) {
+          parentDoc.set(fieldname, doc.name).catch(() => {});
+        }
       });
     },
   },

--- a/src/components/Controls/Link.vue
+++ b/src/components/Controls/Link.vue
@@ -169,10 +169,16 @@ export default {
       const doc = fyo.doc.getNewDoc(schemaName, { name, ...filters });
       openQuickEdit({ doc });
 
+      const parentDoc = this.doc;
+      const fieldname = this.df.fieldname;
+
       doc.once('afterSync', () => {
         this.$router.back();
         this.results = [];
         this.triggerChange(doc.name);
+        if (parentDoc && fieldname) {
+          parentDoc.set(fieldname, doc.name).catch(() => {});
+        }
       });
     },
     async getCreateFilters() {

--- a/src/components/Controls/MultiLabelLink.vue
+++ b/src/components/Controls/MultiLabelLink.vue
@@ -166,10 +166,16 @@ export default {
       const doc = fyo.doc.getNewDoc(schemaName, { name, ...filters });
       openQuickEdit({ doc });
 
+      const parentDoc = this.doc;
+      const fieldname = this.df.fieldname;
+
       doc.once('afterSync', () => {
         this.$router.back();
         this.results = [];
         this.triggerChange(doc.name);
+        if (parentDoc && fieldname) {
+          parentDoc.set(fieldname, doc.name).catch(() => {});
+        }
       });
     },
     async getCreateFilters() {


### PR DESCRIPTION
Problem

When creating a new linked record from inside a Quick Edit Form (QEF) — for example, creating an **Address** while in the middle of creating a **Customer** on an invoice — the newly-created child record is silently never linked back to the parent. 

Likely fixes #1487 too

**Steps to reproduce:**
1. Open a new Sales Invoice
2. Click the Customer field → **Create** a new customer
3. Inside the Customer QEF, click the Address field → **Create** a new address
4. Fill in and save the address
5. Save the customer

**Result:** The customer is saved without the address. No error is shown; the data is silently dropped.

---

### Root Cause

`Link.vue` (and its siblings `DynamicLink.vue`, `MultiLabelLink.vue`) use the following pattern in `openNewDoc()`:

```books/src/components/Controls/Link.vue#L169-177
const doc = fyo.doc.getNewDoc(schemaName, { name, ...filters });
openQuickEdit({ doc });

doc.once('afterSync', () => {
  this.$router.back();
  this.results = [];
  this.triggerChange(doc.name);   // relies on `this` being alive
});
```

`openQuickEdit` pushes a new route whose query changes the `schemaName` and `name` parameters. In `Desk.vue` the QEF component is keyed on exactly those values:

```books/src/pages/Desk.vue#L40-43
<component
  :is="Component"
  :key="route.query.schemaName + route.query.name"
/>
```

When the Address QEF opens, the key changes from `"PartyNew Party 01"` to `"AddressNew Address 01"`, which **destroys the Party QEF** — and with it, the `Link` component whose `this` is closed over in the listener.

When the address is later saved and `afterSync` fires, `triggerChange` calls `this.$emit('change', …)`. **Vue 3 returns early from `$emit` when a component is unmounted** (`instance.isUnmounted` guard), so the event never propagates, `parentDoc.set()` is never called, and the `address` field on the Party doc is never updated.

---

### Fix

Capture `parentDoc` and `fieldname` **before** the navigation destroys the component, then directly call `parentDoc.set()` in the listener as a guaranteed fallback — regardless of whether the Link component is still alive:

```books/src/components/Controls/Link.vue#L179-197
const parentDoc = this.doc;
const fieldname = this.df.fieldname;

doc.once('afterSync', () => {
  this.$router.back();
  this.results = [];
  this.triggerChange(doc.name);
  // Directly set on the parent doc to handle the case where this
  // component has been unmounted (nested QEF scenario).
  if (parentDoc && fieldname) {
    parentDoc.set(fieldname, doc.name).catch(() => {});
  }
});
```

Because the parent doc is wrapped in Vue's `reactive()`, the recreated QEF instance (which gets the same cached doc object) will **reactively reflect** the updated field value without any extra wiring.

`triggerChange` is kept as well so the first-level case (non-nested QEF, where the component is still alive) continues to work exactly as before.

---

### Files Changed

| File | Change |
|---|---|
| `src/components/Controls/Link.vue` | Capture `parentDoc`/`fieldname`; add direct `parentDoc.set()` call in `afterSync` listener |
| `src/components/Controls/DynamicLink.vue` | Same fix |
| `src/components/Controls/MultiLabelLink.vue` | Same fix |