### PR TITLE
fix: (macos) implement double-click title bar to zoom/unzoom

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -26,6 +26,19 @@ import { setLanguageMap } from './utils/language';
   fyo.store.isDevelopment = isDevelopment;
   fyo.store.appVersion = version;
   fyo.store.platform = platform;
+
+  if (platform === 'darwin') {
+    document.addEventListener('dblclick', (event) => {
+      const target = event.target as Element;
+      if (
+        target.closest('.window-drag') &&
+        !target.closest('.window-no-drag')
+      ) {
+        ipc.toggleMaximize();
+      }
+    });
+  }
+
   const platformName = getPlatformName(platform);
 
   setOnWindow(isDevelopment);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -41,6 +41,7 @@ input[type='number']::-webkit-inner-spin-button {
 
 .window-drag {
   -webkit-app-region: drag;
+  user-select: none;
 }
 
 .window-no-drag {


### PR DESCRIPTION
**Problem**

On macOS, double-clicking at the top of the window (the custom title bar area) was selecting text lower in the page instead of zooming or restoring the window. This happened for two reasons:

1. The `.window-drag` CSS class did not include `user-select: none`, so double-clicks could still trigger the browser's native text-selection behaviour on nearby content.
2. Electron does not automatically forward the macOS "double-click title bar" zoom action to elements styled with `-webkit-app-region: drag`. With `titleBarStyle: 'hidden'` and a custom drag region, that behaviour has to be wired up manually.

**Changes**

- **`src/styles/index.css`** — added `user-select: none` to `.window-drag` so that no text can be selected inside any drag region, regardless of what content sits nearby.
- **`src/renderer.ts`** — after the platform is resolved from the main process, registers a single `dblclick` listener on `document` (darwin only). When a double-click target is a descendant of `.window-drag` but not of `.window-no-drag`, it calls the existing `ipc.toggleMaximize()`, which already drives `BrowserWindow.maximize()` / `unmaximize()` in the main process.

**Why this approach**

- No UI changes — the listener is invisible and the CSS addition has no visual effect.
- Re-uses the `ipc.toggleMaximize()` path that was already implemented for the Windows custom title bar, so no new IPC surface is introduced.
- A single document-level listener covers all three app screens (`Desk`, `DatabaseSelector`, `SetupWizard`) without modifying any of their components.
- The `.window-no-drag` guard ensures interactive controls (buttons, inputs, nav items) inside the header are never accidentally captured.

Example of existing double click behavior on MacOS:

https://github.com/user-attachments/assets/6a4cd971-b964-4736-9452-bd43df140b25

Example of fix implemented:

https://github.com/user-attachments/assets/7ee8fa78-2eab-4ebe-9465-fb7984034a07


