### PR TITLE
fix: foreign currency invoices incorrectly marked as "Partly Paid" on submit

### DIFF
--- a/models/helpers.ts
+++ b/models/helpers.ts
@@ -542,7 +542,7 @@ export function getInvoiceStatus(doc: RenderData | Doc): InvoiceStatus {
   if (
     doc.submitted &&
     !doc.cancelled &&
-    (doc.outstandingAmount as Money).eq(doc.grandTotal as Money)
+    (doc.outstandingAmount as Money).eq(doc.baseGrandTotal as Money)
   ) {
     return 'Unpaid';
   }
@@ -555,7 +555,7 @@ export function getInvoiceStatus(doc: RenderData | Doc): InvoiceStatus {
     doc.submitted &&
     !doc.isCancelled &&
     (doc.outstandingAmount as Money).isPositive() &&
-    (doc.outstandingAmount as Money).neq(doc.grandTotal as Money)
+    (doc.outstandingAmount as Money).neq(doc.baseGrandTotal as Money)
   ) {
     return 'PartlyPaid';
   }

--- a/src/components/StatusPill.vue
+++ b/src/components/StatusPill.vue
@@ -181,7 +181,7 @@ function getSubmittableStatus(doc: Doc) {
     isInvoice &&
     !doc.isCancelled &&
     (doc.outstandingAmount as Money)?.isPositive() &&
-    (doc.outstandingAmount as Money)?.neq(doc.grandTotal as Money)
+    (doc.outstandingAmount as Money)?.neq(doc.baseGrandTotal as Money)
   ) {
     return 'PartlyPaid';
   }
@@ -190,7 +190,7 @@ function getSubmittableStatus(doc: Doc) {
     doc.isSubmitted &&
     isInvoice &&
     !doc.isCancelled &&
-    (doc.outstandingAmount as Money)?.eq(doc.grandTotal as Money)
+    (doc.outstandingAmount as Money)?.eq(doc.baseGrandTotal as Money)
   ) {
     return 'Unpaid';
   }


### PR DESCRIPTION
Problem

When submitting an invoice in a foreign currency (e.g. 500 EUR with base currency AED at a rate of 1 EUR = 4.28 AED), the invoice would immediately show a **Partly Paid** status instead of **Unpaid**.

Fixes #1490 

### Root Cause

On submit, `outstandingAmount` is set to `baseGrandTotal` — the invoice total converted into the **company's base currency** (e.g. 2140 AED). However, the payment status checks in both `getInvoiceStatus()` and `getSubmittableStatus()` were comparing `outstandingAmount` against `grandTotal`, which is stored in the **invoice currency** (e.g. 500 EUR).

Since `2140 ≠ 500`, the `Unpaid` check always failed, and the invoice fell through to `PartlyPaid`.

This bug is invisible for domestic invoices because when `exchangeRate === 1`, `grandTotal === baseGrandTotal`, so the comparison happens to be correct.

### Fix

In `models/helpers.ts` (`getInvoiceStatus`) and `src/components/StatusPill.vue` (`getSubmittableStatus`), replaced `grandTotal` with `baseGrandTotal` in the `outstandingAmount` equality checks — making both sides of the comparison in the same currency unit. This matches the pattern already used correctly in `Invoice.hasLinkedPayments`.

### Files Changed

| File | Change |
|---|---|
| `models/helpers.ts` | `getInvoiceStatus`: compare `outstandingAmount` vs `baseGrandTotal` |
| `src/components/StatusPill.vue` | `getSubmittableStatus`: compare `outstandingAmount` vs `baseGrandTotal` |

### Steps to Verify

1. Set base currency to **AED**
2. Create a Sales Invoice in **EUR** for 500 EUR with a conversion rate of 1 EUR = 4.28 AED
3. Submit the invoice
4. **Before fix:** Status shows *Partly Paid* ❌
5. **After fix:** Status shows *Unpaid* ✅