### PR TITLE
fix: don't await checkForUpdates in setDesk; handle setupComplete errors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -168,7 +168,7 @@ export default defineComponent({
       this.activeScreen = Screen.Desk;
       await this.setDeskRoute();
       await fyo.telemetry.start(true);
-      await ipc.checkForUpdates();
+      void ipc.checkForUpdates();
       this.dbPath = filePath;
       this.companyName = (await fyo.getValue(
         ModelNameEnum.AccountingSettings,
@@ -202,11 +202,16 @@ export default defineComponent({
       }
     },
     async setupComplete(setupWizardOptions: SetupWizardOptions): Promise<void> {
-      const companyName = setupWizardOptions.companyName;
-      const filePath = await ipc.getDbDefaultPath(companyName);
-      await setupInstance(filePath, setupWizardOptions, fyo);
-      fyo.config.set('lastSelectedFilePath', filePath);
-      await this.setDesk(filePath);
+      try {
+        const companyName = setupWizardOptions.companyName;
+        const filePath = await ipc.getDbDefaultPath(companyName);
+        await setupInstance(filePath, setupWizardOptions, fyo);
+        fyo.config.set('lastSelectedFilePath', filePath);
+        await this.setDesk(filePath);
+      } catch (error) {
+        await handleErrorWithDialog(error, undefined, true, true);
+        await this.showDbSelector();
+      }
     },
     async showSetupWizardOrDesk(filePath: string): Promise<void> {
       const { countryCode, error, actionSymbol } = await connectToDatabase(


### PR DESCRIPTION
**Bug: AppImage stalls on "Loading instance..." on Linux ARM64**

Fixes #1413

#### What was happening

After clicking Submit in the setup wizard, the app showed "Loading instance…" indefinitely — even after 20+ minutes — with no error and no way to recover short of force-quitting.

The call chain was:

```/dev/null/chain.txt#L1-5
submit() → [emit setup-complete]
  → setupComplete()
    → setupInstance()   (SQLite writes — fine)
    → setDesk()
        → await ipc.checkForUpdates()  ← hangs forever
```

`ipc.checkForUpdates()` invokes `autoUpdater.checkForUpdates()` in the main process. On Linux ARM64, this network request can stall indefinitely. The existing `isNetworkError` guard only catches specific thrown Chromium error codes — a hung connection never throws at all, so the `await` never resolves. The `setupComplete` method also lacked any `try/catch`, so no error dialog was shown and `loading` was never reset to `false`.

#### Changes

**`src/App.vue`**

- **`setDesk`**: change `await ipc.checkForUpdates()` → `void ipc.checkForUpdates()`. The update check result is handled entirely through `autoUpdater` event listeners (`update-available`, `update-downloaded`), so awaiting the initial call was always unnecessary. Making it fire-and-forget removes the blocking network call from the startup path.

- **`setupComplete`**: wrap the body in `try/catch`, matching the pattern already used in `fileSelected`. If anything in the setup pipeline throws, the user now gets an error dialog and is returned to the database selector instead of being stranded on a spinner with no feedback.

#### Testing

Reproduce on any Linux ARM64 machine (or by temporarily making `autoUpdater.checkForUpdates()` hang with `await new Promise(() => {})`) — the desk now loads immediately and any thrown errors surface as a dialog.