### PR TITLE
feat: configurable page margins with printer-safe defaults (report-print)

### DIFF
--- a/src/pages/PrintView/ReportPrintView.vue
+++ b/src/pages/PrintView/ReportPrintView.vue
@@ -33,7 +33,7 @@
           :height="size.height"
           :show-overflow="true"
         >
-          <div class="bg-white mx-auto">
+          <div class="bg-white mx-auto" :style="contentPaddingStyle">
             <div class="p-2">
               <div class="font-semibold text-xl w-full flex justify-between">
                 <h1>
@@ -133,6 +133,85 @@
           />
         </div>
 
+        <!-- Margin Settings -->
+        <div class="border-t dark:border-gray-800 p-4">
+          <div class="flex items-center justify-between mb-1">
+            <h2 class="text-sm text-gray-600 dark:text-gray-400">
+              {{ t`Page Margins (cm)` }}
+            </h2>
+            <button
+              class="
+                text-xs text-blue-500
+                hover:text-blue-600
+                dark:text-blue-400
+                hover:underline
+              "
+              @click="setRecommendedMargins"
+            >
+              {{ t`Use Recommended` }}
+            </button>
+          </div>
+          <p class="text-xs text-gray-400 dark:text-gray-500 mb-3">
+            {{
+              t`1.5 cm (~0.6 in) per side is a safe default for most printers.`
+            }}
+          </p>
+          <div class="grid grid-cols-2 gap-x-3 gap-y-3">
+            <Float
+              :show-label="true"
+              :border="true"
+              :df="{
+                label: t`Top`,
+                fieldtype: 'Float',
+                fieldname: 'marginTop',
+                minvalue: 0,
+                maxvalue: 5,
+              }"
+              :value="margins.top"
+              @change="(v) => (margins.top = v)"
+            />
+            <Float
+              :show-label="true"
+              :border="true"
+              :df="{
+                label: t`Bottom`,
+                fieldtype: 'Float',
+                fieldname: 'marginBottom',
+                minvalue: 0,
+                maxvalue: 5,
+              }"
+              :value="margins.bottom"
+              @change="(v) => (margins.bottom = v)"
+            />
+            <Float
+              :show-label="true"
+              :border="true"
+              :df="{
+                label: t`Left`,
+                fieldtype: 'Float',
+                fieldname: 'marginLeft',
+                minvalue: 0,
+                maxvalue: 5,
+              }"
+              :value="margins.left"
+              @change="(v) => (margins.left = v)"
+            />
+            <Float
+              :show-label="true"
+              :border="true"
+              :df="{
+                label: t`Right`,
+                fieldtype: 'Float',
+                fieldname: 'marginRight',
+                minvalue: 0,
+                maxvalue: 5,
+              }"
+              :value="margins.right"
+              @change="(v) => (margins.right = v)"
+            />
+          </div>
+        </div>
+
         <!-- Pick Columns -->
         <div class="border-t dark:border-gray-800 p-4">
           <h2 class="text-sm text-gray-600 dark:text-gray-400">
@@ -166,6 +245,7 @@ import { reports } from 'reports/index';
 import { OptionField } from 'schemas/types';
 import Button from 'src/components/Button.vue';
 import Check from 'src/components/Controls/Check.vue';
+import Float from 'src/components/Controls/Float.vue';
 import Int from 'src/components/Controls/Int.vue';
 import Select from 'src/components/Controls/Select.vue';
 import PageHeader from 'src/components/PageHeader.vue';
@@ -177,7 +257,15 @@ import { PropType, defineComponent } from 'vue';
 import ScaledContainer from '../TemplateBuilder/ScaledContainer.vue';
 
 export default defineComponent({
-  components: { PageHeader, Button, Check, Int, ScaledContainer, Select },
+  components: {
+    PageHeader,
+    Button,
+    Check,
+    Float,
+    Int,
+    ScaledContainer,
+    Select,
+  },
   props: {
     reportName: {
       type: String as PropType<keyof typeof reports>,
@@ -193,6 +281,12 @@ export default defineComponent({
       scale: 0.65,
       report: null as null | Report,
       columnSelection: [] as boolean[],
+      margins: {
+        top: 1.5,
+        right: 1.5,
+        bottom: 1.5,
+        left: 1.5,
+      } as { top: number; right: number; bottom: number; left: number },
     };
   },
   computed: {
@@ -244,6 +338,15 @@ export default defineComponent({
       const numColumns = this.columnSelection.filter(Boolean).length;
       style['grid-template-columns'] = `repeat(${numColumns}, minmax(0, auto))`;
       return style;
+    },
+    contentPaddingStyle(): Record<string, string> {
+      const { top, right, bottom, left } = this.margins;
+      return {
+        paddingTop: `${top}cm`,
+        paddingRight: `${right}cm`,
+        paddingBottom: `${bottom}cm`,
+        paddingLeft: `${left}cm`,
+      };
     },
     size(): { width: number; height: number } {
       const size = paperSizeMap[this.printSize];
@@ -298,6 +401,9 @@ export default defineComponent({
       );
 
       this.fyo.telemetry.log(Verb.Printed, this.report!.reportName);
+    },
+    setRecommendedMargins() {
+      this.margins = { top: 1.5, right: 1.5, bottom: 1.5, left: 1.5 };
     },
     cellClasses(cIdx: number, rIdx: number): string[] {
       const classes: string[] = [];


### PR DESCRIPTION
Problem
When opening the Report Print View for any financial report (General Ledger, Profit & Loss, Trial Balance, and Balance Sheet) and clicking **Save as PDF** or **Print**, the report content renders flush to the page edge. This causes two issues:
- The output looks visually unprofessional with no breathing room around the content
- Most laser and inkjet printers have a hardware-enforced minimum unprintable zone (~0.4–1.2 cm), so content near the edge is physically clipped when sent to a printer

### Solution
A **Page Margins** section has been added to the existing right-hand configuration pane in the Report Print View. It sits between the Size Selection and Pick Columns sections.

**Controls**
- Four `Float` inputs — **Top**, **Bottom**, **Left**, **Right** — each accepting 0–5 cm with decimal precision
- A **"Use Recommended"** button that sets all four sides to `1.5 cm` in one click
- A hint line explaining the recommended value: *"1.5 cm (~0.6 in) per side is a safe default for most printers."*

**Default behaviour**
Margins initialise to **1.5 cm** on all sides. This was chosen because:
| Printer type | Typical hardware minimum |
|---|---|
| Laser (HP, Canon, Brother, Xerox) | ~0.4 cm (0.17 in) |
| Inkjet | 0.3–1.2 cm |
| General safe zone | ≤ 0.6 cm |

1.5 cm comfortably clears every printer's minimum and matches the default margins used by word processors such as Microsoft Word and Google Docs.

**Why no backend changes were needed**
The margins are applied as an inline CSS `padding` on the content container div inside `ScaledContainer`. Because inline `style` attributes have higher CSS specificity than the `* { padding: 0 }` rule in the print stylesheet, the padding survives the print render unchanged. The padded HTML is embedded directly in the content string passed through `constructPrintDocument`, so both `printToPDF` (Save as PDF) and the native `print` dialog path pick it up automatically. The existing `@page { margin: 0 }` contract in the print CSS is preserved.

### Files changed
| File | Change |
|---|---|
| `src/pages/PrintView/ReportPrintView.vue` | Added `Float` import, `margins` data, `contentPaddingStyle` computed, `setRecommendedMargins` method, margin UI section in settings pane |

### Testing
1. Open any report (General Ledger, Profit & Loss, Balance Sheet, etc.)
2. Click the printer icon → Report Print View opens
3. Confirm the preview shows 1.5 cm inset content by default
4. Adjust Top/Bottom/Left/Right inputs — preview updates live
5. Click **"Use Recommended"** — all four inputs reset to 1.5
6. Click **Save as PDF** — open the PDF and confirm margins are applied
7. Click **Print** — send to a physical printer and confirm content is not clipped

Example of new margin configuration set to 0:
<img width="1502" height="954" alt="Screenshot 2026-04-05 at 8 44 40 AM" src="https://github.com/user-attachments/assets/b43fee3a-be38-4589-915b-da5d22b467dc" />

Example of new margin configuration set to 1.5:
<img width="1502" height="954" alt="Screenshot 2026-04-05 at 8 44 52 AM" src="https://github.com/user-attachments/assets/d77c9fe0-99b2-4110-a801-9778b1b0324d" />


