### PR TITLE
fix: fix horizontal scroll, off-center page, and dynamic rescaling (ReportPrintView)

### DIFF
--- a/src/pages/PrintView/ReportPrintView.vue
+++ b/src/pages/PrintView/ReportPrintView.vue
@@ -269,12 +269,14 @@ export default defineComponent({
     await this.$nextTick();
     this.setScale();
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     window.addEventListener('resize', this.setScale);
 
     // @ts-ignore
     window.rpv = this;
   },
   unmounted() {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     window.removeEventListener('resize', this.setScale);
   },
   methods: {

--- a/src/pages/PrintView/ReportPrintView.vue
+++ b/src/pages/PrintView/ReportPrintView.vue
@@ -14,20 +14,19 @@
     >
       <!-- Report Print Display Area -->
       <div
+        ref="previewContainer"
         class="
           p-4
           bg-gray-25
           dark:bg-gray-890
           overflow-auto
-          flex
-          justify-center
           custom-scroll custom-scroll-thumb1
         "
       >
         <!-- Report Print Display Container -->
         <ScaledContainer
           ref="scaledContainer"
-          class="shadow-lg border bg-white"
+          class="shadow-lg border bg-white mx-auto"
           :scale="scale"
           :width="size.width"
           :height="size.height"
@@ -266,20 +265,39 @@ export default defineComponent({
     this.report = await getReport(this.reportName);
     this.limit = this.report.reportData.length;
     this.columnSelection = this.report.columns.map(() => true);
+
+    await this.$nextTick();
     this.setScale();
+
+    window.addEventListener('resize', this.setScale);
 
     // @ts-ignore
     window.rpv = this;
   },
+  unmounted() {
+    window.removeEventListener('resize', this.setScale);
+  },
   methods: {
     setScale() {
-      const width = this.size.width * 37.2;
-      let containerWidth = window.innerWidth - 26 * 16;
-      if (showSidebar.value) {
-        containerWidth -= 12 * 16;
+      const el = this.$refs.previewContainer as HTMLElement | undefined;
+      const pageWidthPx = this.size.width * 37.2;
+      if (!pageWidthPx) {
+        return;
       }
-
-      this.scale = Math.min(containerWidth / width, 1);
+      let containerWidth: number;
+      if (el && el.clientWidth > 0) {
+        const style = window.getComputedStyle(el);
+        const pl = parseFloat(style.paddingLeft) || 0;
+        const pr = parseFloat(style.paddingRight) || 0;
+        containerWidth = Math.max(el.clientWidth - pl - pr, 0);
+      } else {
+        // fallback: subtract settings panel, optional sidebar, and p-4 padding (32px)
+        containerWidth = window.innerWidth - 26 * 16 - 32;
+        if (showSidebar.value) {
+          containerWidth -= 12 * 16;
+        }
+      }
+      this.scale = Math.min(containerWidth / pageWidthPx, 1);
     },
     async savePDF(shouldPrint?: boolean): Promise<void> {
       // @ts-ignore


### PR DESCRIPTION
**Problem**

The Report Print View had three related layout bugs:

1. **Horizontal clipping** — when the page preview was wider than the visible area, it was silently clipped on the right instead of showing a horizontal scrollbar. Vertical overflow worked fine.

2. **Page shifted slightly right** — even when the page appeared to fit, it sat a few pixels right of centre. The surrounding grey background bled off the right edge of the view.

3. **Scale not updated on window resize** — resizing the app window from small to large left the page preview at its original (small) scale instead of expanding to fill the newly available space.

**Root causes**

The preview area used `flex justify-content: center` to centre the `ScaledContainer`. CSS centres overflowing flex children symmetrically, so overflow spills equally left and right. The left-side spill lives at a negative scroll position — unreachable — making it look like a hard clip.

`setScale()` calculated available width using hard-coded offsets (`window.innerWidth - 26 * 16`) that did not subtract the `p-4` horizontal padding (2 × 16 px = 32 px) applied to the preview container. This made the scaled page 32 px wider than its content area, pushing it right of centre.

`setScale()` was only called once (on `mounted`) and when the paper size setting changed. There was no listener for window resize events.

**Changes — `ReportPrintView.vue`**

| Area | Before | After |
|---|---|---|
| Preview wrapper | `flex justify-center` | Block container (no flex) |
| `ScaledContainer` class | `shadow-lg border bg-white` | + `mx-auto` |
| Scale measurement | `window.innerWidth` minus magic numbers, ignoring `p-4` | `el.clientWidth - paddingLeft - paddingRight` via `getComputedStyle`; falls back to window math with the 32 px padding correction |
| Window resize | Not handled | `window.addEventListener('resize', setScale)` in `mounted`, removed in `unmounted` |
| DOM readiness | `setScale()` called immediately after `await` | `await this.$nextTick()` before `setScale()` to let reactive updates flush |
| Edge-case guards | None | Early return on zero `pageWidthPx`; `Math.max(..., 0)` on `containerWidth`; skips element measurement if `clientWidth === 0

Existing print preview with horizontal clipping bug:
<img width="1262" height="863" alt="Screenshot 2026-04-05 at 9 35 42 AM" src="https://github.com/user-attachments/assets/21778275-4dd4-4440-a24c-f6f7343b141d" />

Fixed print preview with the 3 primary changes:
<img width="1502" height="912" alt="Screenshot 2026-04-05 at 9 33 35 AM" src="https://github.com/user-attachments/assets/a0b9f7c9-424e-4016-82a6-d0fa14f737b2" />


