### PR TITLE
feat(reports): Add company logo toggle to report print preview

### DIFF
--- a/src/pages/PrintView/ReportPrintView.vue
+++ b/src/pages/PrintView/ReportPrintView.vue
@@ -36,9 +36,16 @@
           <div class="bg-white mx-auto">
             <div class="p-2">
               <div class="font-semibold text-xl w-full flex justify-between">
-                <h1>
-                  {{ `${fyo.singles.PrintSettings?.companyName}` }}
-                </h1>
+                <div class="flex items-center gap-2">
+                  <img
+                    v-if="includeLogo && logoSrc"
+                    :src="logoSrc"
+                    class="h-12 max-w-32 object-contain"
+                  />
+                  <h1>
+                    {{ `${fyo.singles.PrintSettings?.companyName}` }}
+                  </h1>
+                </div>
                 <p class="text-gray-600">
                   {{ title }}
                 </p>
@@ -107,6 +114,21 @@
             }"
             :value="limit"
             @change="(v) => (limit = v)"
+          />
+        </div>
+
+        <!-- Logo Toggle -->
+        <div class="border-t dark:border-gray-800 p-4">
+          <Check
+            :show-label="true"
+            :border="true"
+            :df="{
+              label: t`Include Company Logo`,
+              fieldname: 'includeLogo',
+              fieldtype: 'Check',
+            }"
+            :value="includeLogo"
+            @change="(v) => (includeLogo = v)"
           />
         </div>
 
@@ -191,6 +213,7 @@ export default defineComponent({
       printSize: 'A4' as typeof printSizes[number],
       isLandscape: false,
       scale: 0.65,
+      includeLogo: false,
       report: null as null | Report,
       columnSelection: [] as boolean[],
     };
@@ -198,6 +221,13 @@ export default defineComponent({
   computed: {
     title(): string {
       return reports[this.reportName]?.title ?? this.t`Report`;
+    },
+    logoSrc(): string | undefined {
+      const logo = this.fyo.singles.PrintSettings?.logo;
+      if (!logo) {
+        return undefined;
+      }
+      return typeof logo === 'string' ? logo : (logo as { data: string }).data;
     },
     printSizeDf(): OptionField {
       return {


### PR DESCRIPTION
**Description:**

## What

Adds an **Include Company Logo** toggle to the settings sidebar of the Report Print Preview (`ReportPrintView.vue`). When switched on, the company logo from **Print Settings** is displayed next to the company name in the print header — matching the same logo placement used in invoice print templates.

## Why

The report print header already showed the company name, but had no way to include the company logo. This gives users a consistent branded header on printed reports without requiring any changes to Print Settings.

## How

- Added `includeLogo: false` as a new data property (off by default, so existing behaviour is unchanged).
- Added a `logoSrc` computed property that reads `fyo.singles.PrintSettings?.logo` and handles both raw string and `{ data: string }` attachment shapes.
- Wrapped the company name `<h1>` in a flex container so the logo and name sit inline.
- The `<img>` renders only when `includeLogo` is `true` **and** a logo is actually configured in Print Settings — no broken image shown otherwise.
- Added the `Check` toggle component to the settings panel, styled and sectioned consistently with the existing controls (Landscape, row limits, etc.).

## Testing

1. Open any report and click the printer icon to open Report Print Preview.
2. Confirm the header shows only the company name by default (logo toggle is off).
3. Enable **Include Company Logo** — the logo from Print Settings should appear to the left of the company name.
4. Save as PDF and verify the logo is present in the output.
5. If no logo is set in Print Settings, enabling the toggle should have no visible effect.


Example of rectangular logo:
<img width="1502" height="912" alt="Screenshot 2026-04-05 at 9 47 05 AM" src="https://github.com/user-attachments/assets/20ff2ac6-2724-48b7-80b9-722ce9173610" />

Example of Square logo:
<img width="1502" height="912" alt="Screenshot 2026-04-05 at 9 46 24 AM" src="https://github.com/user-attachments/assets/5915223b-9f1f-4b90-a331-1939c1eab731" />