### PR TITLE
feat: enable native Wayland support by default (linux)

### DIFF
--- a/build/scripts/dev.mjs
+++ b/build/scripts/dev.mjs
@@ -123,7 +123,7 @@ async function handleResult(result) {
 }
 
 function runElectron() {
-  const electronProcess = $$`npx electron --inspect=5858 ${path.join(
+  const electronProcess = $$`npx electron --inspect=5858 --ozone-platform-hint=auto ${path.join(
     root,
     'dist_electron',
     'dev',

--- a/electron-builder-config.mjs
+++ b/electron-builder-config.mjs
@@ -75,6 +75,10 @@ const frappeBooksConfig = {
     artifactName: '${productName}-v${version}-linux-${arch}.${ext}',
     category: 'Finance',
     publish: ['github'],
+    desktop: {
+      Exec: 'frappe-books --ozone-platform-hint=auto %U',
+      StartupWMClass: 'frappe-books',
+    },
     target: [
       {
         target: 'deb',

--- a/main.ts
+++ b/main.ts
@@ -48,6 +48,14 @@ export class Main {
 
     // https://github.com/electron-userland/electron-builder/issues/4987
     app.commandLine.appendSwitch('disable-http2');
+
+    if (this.isLinux) {
+      app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
+      app.commandLine.appendSwitch(
+        'enable-features',
+        'WaylandWindowDecorations'
+      );
+    }
     autoUpdater.requestHeaders = {
       'Cache-Control':
         'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0',


### PR DESCRIPTION
Draft PR for now. This has been tested and works with the current base repo, but further investigation on upgrading frappe books from Electron v22 to v38+ likely required before proceeding.

**Enable native Wayland support on Linux**

**Background**

On Linux, Electron historically renders through XWayland — an X11 compatibility layer — even when the user is running a native Wayland session (GNOME, KDE Plasma, Sway, etc.). This means the app misses out on native Wayland benefits: crisp HiDPI/fractional scaling, better input handling, and proper integration with the compositor.

Fixes #1009 

**What changed**

| File | Change |
|---|---|
| `main.ts` | Appends `--ozone-platform-hint=auto` and enables `WaylandWindowDecorations` on Linux before Chromium initialises |
| `build/scripts/dev.mjs` | Passes `--ozone-platform-hint=auto` to Electron when running in dev mode |
| `electron-builder-config.mjs` | Adds a custom `Exec` line and `StartupWMClass` to the generated `.desktop` file for packaged builds |

**Behaviour**

- On a **Wayland session** (`$WAYLAND_DISPLAY` is set) → app runs natively via Wayland
- On an **X11 session** → `auto` gracefully falls back, no regression
- No change for macOS or Windows

**Testing**

Run `yarn dev` on a Wayland session and confirm the app does not appear in `xlsclients` output (which lists X11 clients) and does appear in your compositor's native window list.