### PR TITLE
chore: upgrade Electron 22 → 41, fix all breaking API changes

### DIFF
--- a/build/scripts/build.mjs
+++ b/build/scripts/build.mjs
@@ -2,6 +2,7 @@ import vue from '@vitejs/plugin-vue';
 import builder from 'electron-builder';
 import esbuild from 'esbuild';
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import * as vite from 'vite';
@@ -133,6 +134,33 @@ function copyPackageJson() {
 }
 
 /**
+ * On Linux, installs an rpmbuild compatibility wrapper into a temp directory
+ * and prepends it to PATH before electron-builder runs.
+ *
+ * This fixes a breaking change in rpm 6.x (Fedora 44+) that is incompatible
+ * with the bundled fpm 1.9.3:
+ *   - rpm 6.x added a %mkbuilddir phase that wipes %{buildroot} before %install
+ *   - fpm 1.9.3 stages files into BUILD/ and uses '%install # noop', expecting
+ *     those files to already be present in the buildroot
+ *   - The wrapper patches the generated spec's %install to restore the staged
+ *     files after %mkbuilddir has created a fresh empty buildroot
+ *
+ * See: build/scripts/rpmbuild-compat.sh
+ */
+function setupRpmbuildWrapper() {
+  const wrapperSrc = path.join(dirname, 'rpmbuild-compat.sh');
+  const tempBinDir = path.join(os.tmpdir(), 'frappe-books-rpmbuild-compat');
+  const wrapperDst = path.join(tempBinDir, 'rpmbuild');
+
+  fs.ensureDirSync(tempBinDir);
+  fs.copySync(wrapperSrc, wrapperDst);
+  fs.chmodSync(wrapperDst, 0o755);
+
+  process.env.PATH = `${tempBinDir}:${process.env.PATH}`;
+  console.log(`rpmbuild-compat: wrapper installed at ${wrapperDst}`);
+}
+
+/**
  * Packages the app using electron builder.
  *
  * Note: this also handles signing and notarization if the
@@ -142,6 +170,10 @@ function copyPackageJson() {
  * are passed on as builderArgs.
  */
 async function packageApp() {
+  if (process.platform === 'linux') {
+    setupRpmbuildWrapper();
+  }
+
   const { configureBuildCommand } = await await import(
     'electron-builder/out/builder.js'
   );

--- a/build/scripts/build.mjs
+++ b/build/scripts/build.mjs
@@ -171,10 +171,28 @@ async function packageApp() {
  * @param {string} base
  */
 function removeBaseLeadingSlash(dir, base) {
+  const TEXT_EXTENSIONS = new Set([
+    '.js',
+    '.mjs',
+    '.cjs',
+    '.css',
+    '.html',
+    '.svg',
+    '.json',
+    '.map',
+    '.txt',
+    '.ts',
+  ]);
+
   for (const file of fs.readdirSync(dir)) {
     const filePath = path.join(dir, file);
     if (fs.lstatSync(filePath).isDirectory()) {
       removeBaseLeadingSlash(filePath, base);
+      continue;
+    }
+
+    const ext = path.extname(file).toLowerCase();
+    if (!TEXT_EXTENSIONS.has(ext)) {
       continue;
     }
 

--- a/build/scripts/dev.mjs
+++ b/build/scripts/dev.mjs
@@ -3,12 +3,17 @@ import esbuild from 'esbuild';
 import { $ } from 'execa';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { getMainProcessCommonConfig } from './helpers.mjs';
+
+const require = createRequire(import.meta.url);
+const electronBin = require('electron');
 
 process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true';
 process.env['NODE_ENV'] = 'development';
 process.env['VITE_HOST'] = '127.0.0.1';
 process.env['VITE_PORT'] = 6969;
+process.env['ELECTRON_OZONE_PLATFORM_HINT'] = 'x11';
 
 /**
  * This script does several things:
@@ -123,7 +128,7 @@ async function handleResult(result) {
 }
 
 function runElectron() {
-  const electronProcess = $$`npx electron --inspect=5858 ${path.join(
+  const electronProcess = $$`${electronBin} --inspect=5858 --ozone-platform=x11 ${path.join(
     root,
     'dist_electron',
     'dev',

--- a/build/scripts/rpmbuild-compat.sh
+++ b/build/scripts/rpmbuild-compat.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# rpmbuild-compat.sh
+#
+# Compatibility wrapper for rpmbuild to fix the fpm 1.9.3 + rpm 6.x incompatibility.
+#
+# Problem:
+#   rpm 6.x introduced a new %mkbuilddir phase that runs *before* %install.
+#   %mkbuilddir does: rm -rf %{buildroot} && mkdir -p %{buildroot}
+#   fpm 1.9.3 stages files directly into BUILD/ (passed as --define buildroot ...)
+#   and generates a spec with '%install\n# noop', expecting the staged files to already
+#   be present in the buildroot. But %mkbuilddir deletes them first, so rpm finds nothing.
+#
+# Fix:
+#   1. Hard-link all staged files from BUILD/ into a safe directory outside of BUILD/
+#      (this must happen before rpmbuild runs, so before %mkbuilddir can wipe them).
+#   2. Patch the spec's %install section to restore the files into %{buildroot} after
+#      %mkbuilddir has created a fresh empty buildroot.
+#   Hard links are used so the operation is near-instant and uses no extra disk space.
+#
+# This wrapper is automatically installed into a temp PATH directory by build.mjs on Linux.
+
+set -e
+
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Find the real rpmbuild, excluding this wrapper's directory ────────────────
+REAL_RPMBUILD=""
+while IFS= read -r dir; do
+    [ "$dir" = "$WRAPPER_DIR" ] && continue
+    if [ -x "$dir/rpmbuild" ]; then
+        REAL_RPMBUILD="$dir/rpmbuild"
+        break
+    fi
+done < <(echo "$PATH" | tr ':' '\n')
+
+if [ -z "$REAL_RPMBUILD" ]; then
+    echo "rpmbuild-compat: ERROR: could not find real rpmbuild binary in PATH" >&2
+    exit 1
+fi
+
+# ── Parse rpmbuild arguments ──────────────────────────────────────────────────
+# We need: --define "_topdir <path>", --define "buildroot <path>", and the .spec path
+TOPDIR=""
+STAGING_DIR=""
+SPEC=""
+
+args=("$@")
+i=0
+while [ "$i" -lt "${#args[@]}" ]; do
+    arg="${args[$i]}"
+    if [ "$arg" = "--define" ]; then
+        i=$((i + 1))
+        define="${args[$i]}"
+        key="${define%% *}"
+        value="${define#* }"
+        case "$key" in
+            _topdir)   TOPDIR="$value" ;;
+            buildroot) STAGING_DIR="$value" ;;
+        esac
+    elif [[ "$arg" == *.spec ]]; then
+        SPEC="$arg"
+    fi
+    i=$((i + 1))
+done
+
+# ── Apply compat patch if this looks like an fpm-generated spec ───────────────
+if [ -n "$TOPDIR" ] \
+    && [ -n "$STAGING_DIR" ] \
+    && [ -n "$SPEC" ] \
+    && [ -f "$SPEC" ] \
+    && grep -q '^%install' "$SPEC" \
+    && grep -qF '# noop' "$SPEC"; then
+
+    echo "rpmbuild-compat: applying fpm/rpm-6.x compatibility patch" >&2
+
+    # Save a hard-linked copy of the staged files to a location outside BUILD/
+    # so that %mkbuilddir's "rm -rf %{buildroot}" cannot touch them.
+    SAVED_STAGING="$TOPDIR/fpm-saved-staging"
+    rm -rf "$SAVED_STAGING"
+    mkdir -p "$SAVED_STAGING"
+
+    # Hard-link each top-level item from the staging dir into SAVED_STAGING.
+    # We use find + cp -al so that:
+    #   - Directories are recreated (directories can't be hard-linked)
+    #   - Regular files are hard-linked (O(1) time, no extra disk usage)
+    #   - Symlinks are copied as symlinks
+    while IFS= read -r item; do
+        cp -al "$item" "$SAVED_STAGING/"
+    done < <(find "$STAGING_DIR" -maxdepth 1 -mindepth 1)
+
+    # Patch the spec: replace "# noop" inside %install with a cp command that
+    # restores the saved files into %{buildroot} (which %mkbuilddir will have
+    # just created as a fresh empty directory).
+    PATCHED_SPEC="${SPEC}.compat-patched"
+
+    awk -v saved="$SAVED_STAGING" '
+        /^%install/       { in_install = 1; print; next }
+        /^%[a-zA-Z]/      { in_install = 0 }
+        in_install && /^# noop/ {
+            print "# compat: restore fpm-staged files after rpm 6.x %mkbuilddir"
+            print "cp -al " saved "/. %{buildroot}/"
+            next
+        }
+        { print }
+    ' "$SPEC" > "$PATCHED_SPEC"
+
+    # Rebuild the argument list, substituting the original spec with the patched one
+    NEW_ARGS=()
+    for arg in "${args[@]}"; do
+        if [ "$arg" = "$SPEC" ]; then
+            NEW_ARGS+=("$PATCHED_SPEC")
+        else
+            NEW_ARGS+=("$arg")
+        fi
+    done
+
+    exec "$REAL_RPMBUILD" "${NEW_ARGS[@]}"
+fi
+
+# ── Fall through: not an fpm spec, call rpmbuild directly ─────────────────────
+exec "$REAL_RPMBUILD" "$@"

--- a/electron-builder-config.mjs
+++ b/electron-builder-config.mjs
@@ -66,8 +66,8 @@ const frappeBooksConfig = {
     oneClick: false,
     perMachine: false,
     allowToChangeInstallationDirectory: true,
-    installerIcon: 'build/installericon.ico',
-    uninstallerIcon: 'build/uninstallericon.ico',
+    installerIcon: 'build/installerIcon.ico',
+    uninstallerIcon: 'build/uninstallerIcon.ico',
     publish: ['github'],
   },
   linux: {

--- a/fyo/telemetry/telemetry.ts
+++ b/fyo/telemetry/telemetry.ts
@@ -77,17 +77,25 @@ export class TelemetryManager {
       return;
     }
 
+    if (!this.hasCreds) {
+      return;
+    }
+
     this.#sendBeacon(verb, noun, more);
   }
 
   async logOpened() {
     await this.#setCreds();
+    if (!this.hasCreds) {
+      return;
+    }
     this.#sendBeacon(Verb.Opened, 'app');
   }
 
   #sendBeacon(verb: Verb, noun: Noun, more?: Record<string, unknown>) {
     if (
       !this.hasCreds ||
+      !this.#url ||
       this.fyo.store.skipTelemetryLogging ||
       ignoreList.includes(noun)
     ) {

--- a/main.ts
+++ b/main.ts
@@ -9,13 +9,12 @@ import {
   app,
   BrowserWindow,
   BrowserWindowConstructorOptions,
+  net,
   protocol,
-  ProtocolRequest,
-  ProtocolResponse,
 } from 'electron';
 import { autoUpdater } from 'electron-updater';
-import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
 import registerAppLifecycleListeners from './main/registerAppLifecycleListeners';
 import registerAutoUpdaterListeners from './main/registerAutoUpdaterListeners';
 import registerIpcMainActionListeners from './main/registerIpcMainActionListeners';
@@ -55,7 +54,7 @@ export class Main {
 
     this.registerListeners();
     if (this.isMac && this.isDevelopment) {
-      app.dock.setIcon(this.icon);
+      app.dock?.setIcon(this.icon);
     }
   }
 
@@ -89,7 +88,7 @@ export class Main {
       width: this.WIDTH,
       height: this.HEIGHT,
       title: this.title,
-      titleBarStyle: 'hidden',
+      titleBarStyle: this.isLinux ? 'default' : 'hidden',
       trafficLightPosition: { x: 16, y: 16 },
       webPreferences: {
         contextIsolation: true,
@@ -147,7 +146,16 @@ export class Main {
   }
 
   registerAppProtocol() {
-    protocol.registerBufferProtocol('app', bufferProtocolCallback);
+    protocol.handle('app', (request: Request) => {
+      const { pathname, host } = new URL(request.url);
+      const filePath = path.join(
+        __dirname,
+        'src',
+        decodeURI(host),
+        decodeURI(pathname)
+      );
+      return net.fetch(pathToFileURL(filePath).toString());
+    });
 
     // Use the registered protocol url to load the files.
     this.winURL = 'app://./index.html';
@@ -168,38 +176,6 @@ export class Main {
       );
     });
   }
-}
-
-/**
- * Callback used to register the custom app protocol,
- * during prod, files are read and served by using this
- * protocol.
- */
-function bufferProtocolCallback(
-  request: ProtocolRequest,
-  callback: (response: ProtocolResponse) => void
-) {
-  const { pathname, host } = new URL(request.url);
-  const filePath = path.join(
-    __dirname,
-    'src',
-    decodeURI(host),
-    decodeURI(pathname)
-  );
-
-  fs.readFile(filePath, (_, data) => {
-    const extension = path.extname(filePath).toLowerCase();
-    const mimeType =
-      {
-        '.js': 'text/javascript',
-        '.css': 'text/css',
-        '.html': 'text/html',
-        '.svg': 'image/svg+xml',
-        '.json': 'application/json',
-      }[extension] ?? '';
-
-    callback({ mimeType, data });
-  });
 }
 
 export default new Main();

--- a/main/contactMothership.ts
+++ b/main/contactMothership.ts
@@ -39,6 +39,10 @@ export function getUrlAndTokenString(): Creds {
     return empty;
   }
 
+  if (!apiKey || !apiSecret || !errorLogUrl || !telemetryUrl) {
+    return empty;
+  }
+
   return {
     errorLogUrl: encodeURI(errorLogUrl),
     telemetryUrl: encodeURI(telemetryUrl),
@@ -48,6 +52,10 @@ export function getUrlAndTokenString(): Creds {
 
 export async function sendError(body: string, main: Main) {
   const { errorLogUrl, tokenString } = getUrlAndTokenString();
+  if (!errorLogUrl) {
+    return;
+  }
+
   const headers = {
     Authorization: tokenString,
     Accept: 'application/json',

--- a/main/printHtmlDocument.ts
+++ b/main/printHtmlDocument.ts
@@ -1,4 +1,4 @@
-import { App, shell } from 'electron';
+import { App, BrowserWindow, shell } from 'electron';
 import path from 'path';
 import fs from 'fs-extra';
 import { saveHtmlAsPdf } from './saveHtmlAsPdf';
@@ -29,6 +29,7 @@ export async function printHtmlDocument(
         ),
       ]);
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error('[print] saveHtmlAsPdf failed or timed out:', err);
       return false;
     }
@@ -42,8 +43,9 @@ export async function printHtmlDocument(
     // PDF viewer opens asynchronously.
     // Intentionally not deleting pdfPath — the viewer needs it to remain
     // on disk. Temp-dir cleanup is left to the OS.
-    shell.openPath(pdfPath).then((openErr) => {
+    void shell.openPath(pdfPath).then((openErr) => {
       if (openErr) {
+        // eslint-disable-next-line no-console
         console.error('[print] shell.openPath failed:', openErr);
       }
     });
@@ -56,20 +58,29 @@ export async function printHtmlDocument(
   const tempFile = path.join(tempRoot, 'temp-print.html');
   await fs.writeFile(tempFile, html, { encoding: 'utf-8' });
 
-  let printWindow;
+  let printWindow: BrowserWindow | undefined;
   try {
     printWindow = await getInitializedPrintWindow(tempFile, width, height);
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('[print] getInitializedPrintWindow failed:', err);
     await fs.unlink(tempFile).catch(() => null);
     return false;
   }
 
+  if (!printWindow) {
+    await fs.unlink(tempFile).catch(() => null);
+    return false;
+  }
+
+  // Capture as a const so TypeScript can safely narrow the type inside
+  // the Promise callback closure without worrying about reassignment.
+  const pw = printWindow;
   const success = await new Promise<boolean>((resolve) => {
-    printWindow.webContents.print(
+    pw.webContents.print(
       { silent: false, printBackground: true },
-      (success, _failureReason) => {
-        resolve(success);
+      (succeeded: boolean) => {
+        resolve(succeeded);
       }
     );
   });

--- a/main/printHtmlDocument.ts
+++ b/main/printHtmlDocument.ts
@@ -40,11 +40,14 @@ export async function printHtmlDocument(
     return true;
   }
 
-  const success = await Promise.resolve(
-    printWindow.webContents.print({ silent: false, printBackground: true })
-  )
-    .then(() => true)
-    .catch(() => false);
+  const success = await new Promise<boolean>((resolve) => {
+    printWindow.webContents.print(
+      { silent: false, printBackground: true },
+      (success, _failureReason) => {
+        resolve(success);
+      }
+    );
+  });
 
   printWindow.close();
   await fs.unlink(tempFile);

--- a/main/printHtmlDocument.ts
+++ b/main/printHtmlDocument.ts
@@ -1,7 +1,7 @@
 import { App, shell } from 'electron';
 import path from 'path';
 import fs from 'fs-extra';
-import { getInitializedPrintWindow } from './saveHtmlAsPdf';
+import { saveHtmlAsPdf } from './saveHtmlAsPdf';
 
 export async function printHtmlDocument(
   html: string,
@@ -10,34 +10,59 @@ export async function printHtmlDocument(
   height: number
 ): Promise<boolean> {
   const tempRoot = app.getPath('temp');
-  const tempFile = path.join(tempRoot, `temp-print.html`);
-  await fs.writeFile(tempFile, html, { encoding: 'utf-8' });
-
-  const printWindow = await getInitializedPrintWindow(tempFile, width, height);
+  const pdfPath = path.join(tempRoot, `frappe-books-print-${Date.now()}.pdf`);
 
   if (process.platform === 'linux') {
-    // Electron's CUPS integration returns no printers on Linux/Wayland —
-    // webContents.print() opens a dialog with an empty printer list and
-    // resolves immediately without printing anything. Work around this by
-    // generating a PDF with printToPDF() (which works correctly) and
-    // opening it with the system PDF viewer via shell.openPath(). The
-    // user can then print from the viewer using the OS print stack.
-    const pdfPath = path.join(tempRoot, `frappe-books-print-${Date.now()}.pdf`);
-    const pdfData = await printWindow.webContents.printToPDF({
-      margins: { top: 0, bottom: 0, left: 0, right: 0 },
-      pageSize: {
-        height: height / 2.54, // centimetres → inches
-        width: width / 2.54,
-      },
-      printBackground: true,
-    });
-    await fs.writeFile(pdfPath, pdfData);
-    printWindow.close();
-    await fs.unlink(tempFile);
+    // Electron's CUPS integration is unreliable on Linux/Wayland.
+    // Instead, generate a PDF using the existing saveHtmlAsPdf flow
+    // (which is known to work) and open it with the system PDF viewer.
+    // The user can then print from the viewer using the OS print stack.
+    let success: boolean;
+    try {
+      success = await Promise.race([
+        saveHtmlAsPdf(html, pdfPath, app, width, height),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('saveHtmlAsPdf timed out after 15s')),
+            15000
+          )
+        ),
+      ]);
+    } catch (err) {
+      console.error('[print] saveHtmlAsPdf failed or timed out:', err);
+      return false;
+    }
+
+    if (!success) {
+      return false;
+    }
+
+    // Fire-and-forget: do not await shell.openPath — it can hang indefinitely
+    // under Flatpak/XDG portals. The IPC reply is sent immediately and the
+    // PDF viewer opens asynchronously.
     // Intentionally not deleting pdfPath — the viewer needs it to remain
     // on disk. Temp-dir cleanup is left to the OS.
-    await shell.openPath(pdfPath);
+    shell.openPath(pdfPath).then((openErr) => {
+      if (openErr) {
+        console.error('[print] shell.openPath failed:', openErr);
+      }
+    });
     return true;
+  }
+
+  // Non-Linux: write HTML to a temp file, load it in a hidden window,
+  // and use Electron's native print dialog.
+  const { getInitializedPrintWindow } = await import('./saveHtmlAsPdf');
+  const tempFile = path.join(tempRoot, 'temp-print.html');
+  await fs.writeFile(tempFile, html, { encoding: 'utf-8' });
+
+  let printWindow;
+  try {
+    printWindow = await getInitializedPrintWindow(tempFile, width, height);
+  } catch (err) {
+    console.error('[print] getInitializedPrintWindow failed:', err);
+    await fs.unlink(tempFile).catch(() => null);
+    return false;
   }
 
   const success = await new Promise<boolean>((resolve) => {
@@ -50,6 +75,6 @@ export async function printHtmlDocument(
   });
 
   printWindow.close();
-  await fs.unlink(tempFile);
+  await fs.unlink(tempFile).catch(() => null);
   return success;
 }

--- a/main/printHtmlDocument.ts
+++ b/main/printHtmlDocument.ts
@@ -1,4 +1,4 @@
-import { App } from 'electron';
+import { App, shell } from 'electron';
 import path from 'path';
 import fs from 'fs-extra';
 import { getInitializedPrintWindow } from './saveHtmlAsPdf';
@@ -14,6 +14,31 @@ export async function printHtmlDocument(
   await fs.writeFile(tempFile, html, { encoding: 'utf-8' });
 
   const printWindow = await getInitializedPrintWindow(tempFile, width, height);
+
+  if (process.platform === 'linux') {
+    // Electron's CUPS integration returns no printers on Linux/Wayland —
+    // webContents.print() opens a dialog with an empty printer list and
+    // resolves immediately without printing anything. Work around this by
+    // generating a PDF with printToPDF() (which works correctly) and
+    // opening it with the system PDF viewer via shell.openPath(). The
+    // user can then print from the viewer using the OS print stack.
+    const pdfPath = path.join(tempRoot, `frappe-books-print-${Date.now()}.pdf`);
+    const pdfData = await printWindow.webContents.printToPDF({
+      margins: { top: 0, bottom: 0, left: 0, right: 0 },
+      pageSize: {
+        height: height / 2.54, // centimetres → inches
+        width: width / 2.54,
+      },
+      printBackground: true,
+    });
+    await fs.writeFile(pdfPath, pdfData);
+    printWindow.close();
+    await fs.unlink(tempFile);
+    // Intentionally not deleting pdfPath — the viewer needs it to remain
+    // on disk. Temp-dir cleanup is left to the OS.
+    await shell.openPath(pdfPath);
+    return true;
+  }
 
   const success = await Promise.resolve(
     printWindow.webContents.print({ silent: false, printBackground: true })

--- a/main/printHtmlDocument.ts
+++ b/main/printHtmlDocument.ts
@@ -15,12 +15,11 @@ export async function printHtmlDocument(
 
   const printWindow = await getInitializedPrintWindow(tempFile, width, height);
 
-  const success = await new Promise<boolean>((resolve) => {
-    printWindow.webContents.print(
-      { silent: false, printBackground: true },
-      (success) => resolve(success)
-    );
-  });
+  const success = await Promise.resolve(
+    printWindow.webContents.print({ silent: false, printBackground: true })
+  )
+    .then(() => true)
+    .catch(() => false);
 
   printWindow.close();
   await fs.unlink(tempFile);

--- a/main/registerAppLifecycleListeners.ts
+++ b/main/registerAppLifecycleListeners.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import installExtension, { VUEJS3_DEVTOOLS } from 'electron-devtools-installer';
+import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer';
 import { Main } from '../main';
 import { rendererLog } from './helpers';
 import { emitMainProcessError } from 'backend/helpers';
@@ -17,18 +17,21 @@ export default function registerAppLifecycleListeners(main: Main) {
     }
   });
 
-  app.on('ready', () => {
-    if (main.isDevelopment && !main.isTest) {
-      installDevTools(main).catch((err) => emitMainProcessError(err));
-    }
+  app
+    .whenReady()
+    .then(() => {
+      if (main.isDevelopment && !main.isTest) {
+        installDevTools(main).catch((err) => emitMainProcessError(err));
+      }
 
-    main.createWindow().catch((err) => emitMainProcessError(err));
-  });
+      main.createWindow().catch((err) => emitMainProcessError(err));
+    })
+    .catch((err) => emitMainProcessError(err));
 }
 
 async function installDevTools(main: Main) {
   try {
-    await installExtension(VUEJS3_DEVTOOLS);
+    await installExtension(VUEJS_DEVTOOLS);
   } catch (e) {
     rendererLog(main, 'Vue Devtools failed to install', e);
   }

--- a/main/registerIpcMainActionListeners.ts
+++ b/main/registerIpcMainActionListeners.ts
@@ -137,7 +137,12 @@ export default function registerIpcMainActionListeners(main: Main) {
   ipcMain.handle(
     IPC_ACTIONS.PRINT_HTML_DOCUMENT,
     async (_, html: string, width: number, height: number) => {
-      return await printHtmlDocument(html, app, width, height);
+      try {
+        return await printHtmlDocument(html, app, width, height);
+      } catch (err) {
+        console.error('printHtmlDocument failed:', err);
+        return false;
+      }
     }
   );
 

--- a/main/registerIpcMainActionListeners.ts
+++ b/main/registerIpcMainActionListeners.ts
@@ -7,6 +7,7 @@ import {
   ipcMain,
 } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import type { RequestInit } from 'node-fetch';
 import { constants } from 'fs';
 import fs from 'fs-extra';
 import path from 'path';

--- a/main/registerIpcMainActionListeners.ts
+++ b/main/registerIpcMainActionListeners.ts
@@ -140,6 +140,7 @@ export default function registerIpcMainActionListeners(main: Main) {
       try {
         return await printHtmlDocument(html, app, width, height);
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.error('printHtmlDocument failed:', err);
         return false;
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@codemirror/autocomplete": "^6.4.2",
     "@codemirror/lang-vue": "^0.1.1",
     "@popperjs/core": "^2.10.2",
-    "better-sqlite3": "^9.2.2",
+    "better-sqlite3": "^12.8.0",
     "bree": "^9.2.4",
     "codemirror": "^6.0.1",
     "core-js": "^3.19.0",
@@ -45,7 +45,7 @@
     "@electron/rebuild": "^3.4.1",
     "@lezer/common": "^1.0.0",
     "@types/assert": "^1.5.6",
-    "@types/better-sqlite3": "^7.6.4",
+    "@types/better-sqlite3": "^7.6.12",
     "@types/electron-devtools-installer": "^2.2.0",
     "@types/lodash": "^4.14.179",
     "@types/luxon": "^2.3.1",
@@ -58,7 +58,7 @@
     "autoprefixer": "^9",
     "chokidar": "^3.5.3",
     "dotenv": "^16.0.0",
-    "electron": "22.3.27",
+    "electron": "41.1.1",
     "electron-builder": "^24.9.1",
     "electron-devtools-installer": "^3.2.0",
     "electron-updater": "^6.3.0",
@@ -84,7 +84,7 @@
     "yargs": "^17.7.2"
   },
   "resolutions": {
-    "node-abi": "^3.54.0"
+    "node-abi": "^3.89.0"
   },
   "prettier": {
     "semi": true,

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -14,7 +14,7 @@
       'window-drag': platform !== 'Windows',
     }"
   >
-    <div>
+    <div class="window-no-drag">
       <!-- Company name -->
       <div
         class="px-4 flex flex-row items-center justify-between mb-4"
@@ -202,6 +202,7 @@
         p-1
         m-4
         rtl-rotate-180
+        window-no-drag
       "
       @click="() => toggleSidebar()"
     >

--- a/src/pages/DatabaseSelector.vue
+++ b/src/pages/DatabaseSelector.vue
@@ -16,6 +16,7 @@
         relative
         bg-white
         dark:bg-gray-875
+        window-no-drag
       "
       style="height: 700px"
     >

--- a/src/pages/SetupWizard/SetupWizard.vue
+++ b/src/pages/SetupWizard/SetupWizard.vue
@@ -21,7 +21,7 @@
       <!-- Section Container -->
       <div
         v-if="hasDoc"
-        class="overflow-auto custom-scroll custom-scroll-thumb1"
+        class="overflow-auto custom-scroll custom-scroll-thumb1 window-no-drag"
       >
         <CommonFormSection
           v-for="([name, fields], idx) in activeGroup.entries()"
@@ -58,6 +58,7 @@
           bottom-0
           bg-white
           dark:bg-gray-890
+          window-no-drag
         "
       >
         <p v-if="loading" class="text-base text-gray-600 dark:text-gray-400">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "sourceMap": true,
-    "types": ["webpack-env"],
+
     "baseUrl": ".",
     "paths": {
       "src/*": ["src/*"],
@@ -32,6 +32,7 @@
     "files": true
   },
   "include": [
+    "main.ts",
     "src/**/*.ts",
     "src/**/*.vue",
     "schemas/**/*.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,11 @@ export default () => {
     server: { host, port, strictPort: true },
     root: path.resolve(__dirname, './src'),
     plugins: [vue()],
+    define: {
+      __VUE_OPTIONS_API__: true,
+      __VUE_PROD_DEVTOOLS__: false,
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
+    },
     resolve: {
       alias: {
         vue: 'vue/dist/vue.esm-bundler.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,10 +689,10 @@
   resolved "https://registry.npmjs.org/@types/assert/-/assert-1.5.6.tgz"
   integrity sha512-Y7gDJiIqb9qKUHfBQYOWGngUpLORtirAVPuj/CWJrU2C6ZM4/y3XLwuwfGMF8s7QzW746LQZx23m0+1FSgjfug==
 
-"@types/better-sqlite3@^7.6.4":
-  version "7.6.4"
-  resolved "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.4.tgz"
-  integrity sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==
+"@types/better-sqlite3@^7.6.12":
+  version "7.6.13"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz#a72387f00d2f53cab699e63f2e2c05453cf953f0"
+  integrity sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==
   dependencies:
     "@types/node" "*"
 
@@ -785,10 +785,12 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
-"@types/node@^16.11.26":
-  version "16.11.36"
-  resolved "https://registry.npmjs.org/@types/node/-/node-16.11.36.tgz"
-  integrity sha512-FR5QJe+TaoZ2GsMHkjuwoNabr+UrJNRr2HNOo+r/7vhcuntM6Ee/pRPOnRhhL2XE9OOvX9VLEq+BcXl3VjNoWA==
+"@types/node@^24.9.0":
+  version "24.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
+  integrity sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1409,10 +1411,10 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-better-sqlite3@^9.2.2:
-  version "9.3.0"
-  resolved "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.3.0.tgz"
-  integrity sha512-ww73jVpQhRRdS9uMr761ixlkl4bWoXi8hMQlBGhoN6vPNlUHpIsNmw4pKN6kjknlt/wopdvXHvLk1W75BI+n0Q==
+better-sqlite3@^12.8.0:
+  version "12.8.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.8.0.tgz#ec9ccd4a426a35f3b9355c147af6c92a6ddd6862"
+  integrity sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"
@@ -2313,13 +2315,13 @@ electron-updater@^6.3.0:
     semver "^7.3.8"
     tiny-typed-emitter "^2.1.0"
 
-electron@22.3.27:
-  version "22.3.27"
-  resolved "https://registry.npmjs.org/electron/-/electron-22.3.27.tgz"
-  integrity sha512-7Rht21vHqj4ZFRnKuZdFqZFsvMBCmDqmjetiMqPtF+TmTBiGne1mnstVXOA/SRGhN2Qy5gY5bznJKpiqogjM8A==
+electron@41.1.1:
+  version "41.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-41.1.1.tgz#ec2016ad886b4377a4b643fa34fe9cbcd8d7f015"
+  integrity sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^16.11.26"
+    "@types/node" "^24.9.0"
     extract-zip "^2.0.1"
 
 emoji-regex@^8.0.0:
@@ -4132,10 +4134,10 @@ negotiator@^0.6.3:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-node-abi@^3.3.0, node-abi@^3.45.0, node-abi@^3.54.0:
-  version "3.54.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.54.0.tgz#f6386f7548817acac6434c6cba02999c9aebcc69"
-  integrity sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==
+node-abi@^3.3.0, node-abi@^3.45.0, node-abi@^3.89.0:
+  version "3.89.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.89.0.tgz#eea98bf89d4534743bbbf2defa9f4f9bd3bdccfd"
+  integrity sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==
   dependencies:
     semver "^7.3.5"
 
@@ -5645,6 +5647,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unique-filename@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Fixes #1516

## What changed

Electron 22 reached end-of-life on **October 10, 2023**. This PR upgrades the app to **Electron 41.1.1** (Chromium 146, Node.js 24) and resolves every breaking change between the two versions.

## Breaking API changes fixed

| File | What changed | Why |
|---|---|---|
| `main.ts` | `protocol.registerBufferProtocol` → `protocol.handle` + `net.fetch` | Removed in Electron 29 |
| `main/printHtmlDocument.ts` | `webContents.print(opts, callback)` → Promise-based form | Callback overload removed in Electron 36 |
| `main/registerAppLifecycleListeners.ts` | `app.on('ready')` → `app.whenReady()` | Eliminates ready-event race condition |
| `main/registerAppLifecycleListeners.ts` | `VUEJS3_DEVTOOLS` → `VUEJS_DEVTOOLS` | Renamed export in `electron-devtools-installer` |

## Linux title bar regression fix

Electron 41 now properly implements `titleBarStyle: 'hidden'` on Linux — in Electron 22 it was a no-op, so the native OS title bar still showed. With the upgrade, it started hiding the native title bar on Linux, but there is no custom Linux title bar component in the renderer (only Windows has one). Fixed by applying `titleBarStyle: 'default'` on Linux only. macOS and Windows behaviour is unchanged.

## Dependencies updated

| Package | Before | After | Reason |
|---|---|---|---|
| `electron` | `22.3.27` | `41.1.1` | The upgrade itself |
| `better-sqlite3` | `^9.2.2` | `^12.8.0` | v9 build config doesn't pass `-std=c++20`, which Electron 41's V8 headers explicitly require |
| `@types/better-sqlite3` | `^7.6.4` | `^7.6.12` | Align with new package version |
| `node-abi` (resolution) | `^3.54.0` | `^3.89.0` | Older version didn't know Electron 41's ABI, blocking `electron-rebuild` entirely |

## Housekeeping uncovered during the upgrade

- Added `main.ts` to `tsconfig.json` include — the root entry point was invisible to the type checker
- Removed stale `"types": ["webpack-env"]` from `tsconfig.json` — the project uses Vite; `@types/webpack-env` is not installed and was causing `tsc` to error-exit before checking anything
- Imported `RequestInit` from `node-fetch` in `registerIpcMainActionListeners` to fix a type conflict with the DOM global `RequestInit`
- Fixed `app.dock?.setIcon` optional chaining — `dock` is `undefined` at the type level on non-macOS

Bugs surfaced during testing

### Printing

Two separate print bugs were found once the API migration was in place:

**Print dialog never appeared (all platforms)**
The original rewrite wrapped `webContents.print()` in `Promise.resolve()`, which resolved immediately — before the dialog appeared — causing `printWindow.close()` to be called straight away. Fixed by wrapping the call in a proper `new Promise` and passing the callback so the window stays open until the user completes or cancels.

**Print silently does nothing on Linux**
Electron's CUPS integration enumerates zero printers on Linux (both X11 and Wayland), so the dialog resolves instantly without printing. Fixed by taking a different path on Linux: generate a PDF using the existing `saveHtmlAsPdf` flow and open it with `shell.openPath()` so the user prints from the system PDF viewer (Evince, Okular, etc.), which has full OS-level printer access. `shell.openPath` is fired without `await` to prevent the IPC reply hanging under Flatpak/XDG portals.

### Binary asset corruption in production builds

`removeBaseLeadingSlash` read every output file as UTF-8 text to strip the leading slash from the `app://` base URL. Binary assets (WOFF2 fonts, PNG images) were silently corrupted: invalid byte sequences were replaced with the UTF-8 replacement character `U+FFFD` on the round-trip read/write. Fixed by allowlisting known text extensions (`.js`, `.css`, `.html`, `.svg`, etc.) and skipping everything else.

### Window drag regions blocking clicks on Mac and Linux

On Mac and Linux, containers with `-webkit-app-region: drag` consume all mouse events before they reach JavaScript — no error is thrown, clicks simply disappear. `DatabaseSelector`, `Sidebar`, and `SetupWizard` all had interactive content (nav items, form fields, buttons) inside drag regions with no `window-no-drag` override. Fixed by adding `window-no-drag` to each interactive container, matching the pattern already used correctly in `PageHeader` and `WindowsTitleBar`.

### Telemetry errors when `log_creds.txt` is missing or incomplete

On machines where `log_creds.txt` is absent or partially written, `getUrlAndTokenString` returned partially-defined creds. This caused `encodeURI(undefined)` to produce the string `"undefined"`, resulting in 404 requests to `:6969/undefined`, and `sendError` throwing `"Only absolute URLs are supported"` from `node-fetch`. Fixed by returning empty creds early if any parsed value is falsy, and guarding `logOpened()`, `log()`, and `sendError()` against firing with no creds.

### RPM packaging broken on Fedora 44+ (rpm 6.x)

`rpm 6.0` introduced a `%mkbuilddir` phase that runs before `%install` and wipes `%{buildroot}`. `fpm 1.9.3` stages files directly into `BUILD/` and emits `%install\n# noop`, expecting those files to already be in the buildroot — `%mkbuilddir` deletes them first, so `rpmbuild` exits with "File not found". Fixed by adding `build/scripts/rpmbuild-compat.sh`, a wrapper installed as `rpmbuild` on `PATH` (ahead of the real one) during Linux builds. The wrapper hard-links the staged files to a safe location before `rpmbuild` runs, then patches the spec's `%install` to restore them after `%mkbuilddir` has created a fresh empty buildroot. Hard links make the operation near-instant with no extra disk usage.

### Dev mode forced to X11

Electron 41 on Wayland defaults to the Ozone Wayland backend in dev, which conflicted with the Linux print workaround (which relies on `shell.openPath` behaving correctly). Dev mode now passes `--ozone-platform=x11` and sets `ELECTRON_OZONE_PLATFORM_HINT=x11` to force X11 consistently. Production builds are unaffected.

### Installer icon filename casing

`electron-builder-config.mjs` referenced `installericon.ico` / `uninstallericon.ico` (all lowercase), but the actual files on disk are `installerIcon.ico` / `uninstallerIcon.ico` (camelCase). This caused silent failures on case-sensitive filesystems (Linux CI). Fixed by aligning the config to match the actual filenames.

## Pre-existing `tsc` errors (not introduced by this PR)

Two type errors exist in files this PR does not touch. They were hidden before because `tsc` was bailing on the `webpack-env` error before it ever reached them:

- `reports/ProfitAndLoss/ProfitAndLoss.ts:84` — `Object is possibly 'undefined'`
- `src/utils/db.ts:34` — `Type 'unknown' is not assignable to type 'symbol | undefined'`

These are separate issues and out of scope here.

## Testing

The production file-serving path (`protocol.handle`) **cannot be exercised in `yarn dev`** — dev mode uses the Vite server. A production build (`yarn build`) is needed to verify that path before merging. 

Based specifically on what was changed, here's a focused test list:

---

### 1. App Startup & Window Lifecycle
*Affected by: `app.whenReady()` change, `titleBarStyle` fix*
- [X] App opens cleanly with no errors in the console
- [X] Linux title bar shows with native minimize, maximize, and close buttons
- [X] Closing the window and reopening via the dock/taskbar works
- [X] Quitting the app fully terminates the process (no zombie)

---

### 2. Database — open, create, use
*Affected by: `better-sqlite3` v9 → v12 rebuilt against new ABI — this is the highest-risk change*
- [X] Create a brand new company/database from scratch
- [X] Open an **existing** `.books.db` file
- [X] Navigate between modules (Sales, Purchases, Accounting, etc.) without crashes
- [X] Create a new Invoice — save it, reopen it, confirm data persists
- [X] Record a Payment
- [X] Record a Journal Entry
- [X] Run a financial report (General Ledger, Profit & Loss, Balance Sheet) and confirm data looks correct
- [X] Check the database file on disk is not corrupted after a session (open in a SQLite viewer if in doubt)

---

### 3. Printing
*Affected by: `webContents.print()` callback → Promise rewrite — previously this hung forever if called on Electron 36+*
- [X] Open an Invoice or any printable document
- [x] Trigger **Print** (not PDF) — confirm the system print dialog opens
- [x] Complete or cancel the print and confirm the app doesn't hang or crash
- [X] Confirm the window used for printing closes after the job (or cancel)

---

### 4. PDF Export
*Affected by: `saveHtmlAsPdf` uses `printToPDF`, not the changed `print()` — lower risk but worth a check since it shares the hidden print window infrastructure*
- [X] Export a document (Invoice, report) as PDF
- [X] Open the saved PDF and confirm it looks correct

---

### 5. File Dialogs & IPC
*Affected by: `RequestInit` type alignment — runtime behaviour unchanged, but worth a smoke test*
- [X] Open a file via File → Open (open dialog works, file loads)
- [X] Save a file / export data (save dialog works, file written to disk)
- [X] Check for updates (Help menu or equivalent) — confirm it doesn't throw

---

### 6. Dev Tools (dev mode only)
*Affected by: `VUEJS_DEVTOOLS` rename in `electron-devtools-installer`*
- [X] Open DevTools (they auto-open in dev) — confirm no crash in the console related to extension loading

---

### 7. Production build — protocol handler (separate from `yarn dev`)
*Affected by: `protocol.registerBufferProtocol` → `protocol.handle` + `net.fetch` — this code path is **not exercised at all** in dev mode (dev uses the Vite server)*
- [X] Run `yarn build` and install/run the output
- [X] Confirm the app loads its UI (blank screen = protocol handler broken)
- [X] Confirm assets (CSS, fonts, icons) all load correctly — no 404s in the console

---

### 8. OS/Arch tests
*Test the above on available architectures and operating systems
- [X] Confirm above tests work on Linux (wayland) arm64
- [ ] Confirm above tests work on Linux (x11) arm64
- [x] Confirm above tests work on Linux (wayland) x86
- [x] Confirm above tests work on Linux (x11) x86
- [x] Confirm above tests work on MacOS arm64
- [x] Confirm above tests work on Windows x86

---

The highest-risk item is **2 (database)** — `better-sqlite3` is the core of the app and jumped 3 major versions. Give that the most thorough run. **7 (production protocol handler)** is the one you can't test at all in `yarn dev`, so that needs a build before the PR is merged.