### PR TITLE
fix: correctly migrate AccountingLedgerEntry dates for UTC+ timezones

### DIFF
--- a/backend/patches/index.ts
+++ b/backend/patches/index.ts
@@ -6,6 +6,7 @@ import testPatch from './testPatch';
 import updateSchemas from './updateSchemas';
 import setPaymentReferenceType from './setPaymentReferenceType';
 import fixLedgerDateTime from './v0_21_0/fixLedgerDateTime';
+import fixLedgerDateTimeRerun from './v0_37_0/fixLedgerDateTimeRerun';
 import fixItemHSNField from './fixItemHSNField';
 import createPaymentMethods from './createPaymentMethods';
 
@@ -41,6 +42,11 @@ export default [
     name: 'fixLedgerDateTime',
     version: '0.21.2',
     patch: fixLedgerDateTime,
+  },
+  {
+    name: 'fixLedgerDateTimeRerun',
+    version: '0.37.0',
+    patch: fixLedgerDateTimeRerun,
   },
   { name: 'fixItemHSNField', version: '0.24.0', patch: fixItemHSNField },
   {

--- a/backend/patches/v0_21_0/fixLedgerDateTime.ts
+++ b/backend/patches/v0_21_0/fixLedgerDateTime.ts
@@ -1,40 +1,48 @@
 import { DatabaseManager } from '../../database/manager';
 
-/* eslint-disable */
 async function execute(dm: DatabaseManager) {
+  const sourceTables = [
+    'PurchaseInvoice',
+    'SalesInvoice',
+    'JournalEntry',
+    'Payment',
+    'StockMovement',
+    'StockTransfer',
+  ];
 
-    const sourceTables = [
-        "PurchaseInvoice", 
-        "SalesInvoice", 
-        "JournalEntry",
-        "Payment", 
-        "StockMovement", 
-        "StockTransfer"
-    ];
+  const entries = (await dm.db!.knex!('AccountingLedgerEntry').select(
+    'name',
+    'date',
+    'referenceName'
+  )) as Array<{ name: string; date: string; referenceName: string }>;
 
-    await dm.db!.knex!('AccountingLedgerEntry')
-        .select('name', 'date', 'referenceName')
-        .then((trx: Array<{name: string; date: Date; referenceName: string;}> ) => {
-            trx.forEach(async entry => {
+  for (const entry of entries) {
+    for (const table of sourceTables) {
+      const resp = (await dm.db!
+        .knex!.select('name', 'date')
+        .from(table)
+        .where({ name: entry.referenceName })) as Array<{
+        name: string;
+        date: string;
+      }>;
 
-                sourceTables.forEach(async table => {
-                    await dm.db!.knex!
-                    .select('name','date')
-                    .from(table)
-                    .where({ name: entry['referenceName'] })
-                    .then(async (resp: Array<{name: string; date: Date;}>) => {
-                        if (resp.length !== 0) {
-                            
-                            const dateTimeValue = new Date(resp[0]['date']);
-                            await dm.db!.knex!('AccountingLedgerEntry')
-                            .where({ name: entry['name'] })
-                            .update({ date: dateTimeValue.toISOString() });
-                        }
-                    })
-                });
-            });
-        });
+      if (resp.length !== 0) {
+        // Source table dates are stored as plain 'YYYY-MM-DD' strings.
+        // new Date('YYYY-MM-DD') is parsed as UTC midnight per ISO 8601,
+        // so toISOString() yields 'YYYY-MM-DDT00:00:00.000Z'.
+        // This ensures the stored datetime always uses UTC midnight so that
+        // SQLite date comparisons and report range-key extraction both work
+        // correctly for UTC+ timezone users.
+        const dateTimeValue = new Date(resp[0].date);
+        await dm.db!.knex!('AccountingLedgerEntry')
+          .where({ name: entry.name })
+          .update({ date: dateTimeValue.toISOString() });
+
+        // Date found in this source table; no need to check the rest.
+        break;
+      }
+    }
+  }
 }
 
 export default { execute, beforeMigrate: true };
-/* eslint-enable */

--- a/backend/patches/v0_37_0/fixLedgerDateTimeRerun.ts
+++ b/backend/patches/v0_37_0/fixLedgerDateTimeRerun.ts
@@ -1,0 +1,63 @@
+import { DatabaseManager } from '../../database/manager';
+
+/**
+ * Re-runs the fixLedgerDateTime migration for users who already had the
+ * original v0.21.2 patch recorded as executed. That patch used forEach with
+ * async callbacks, which fires promises without awaiting them, so it completed
+ * silently without updating any data.
+ *
+ * Root cause: AccountingLedgerEntry.date was stored as local midnight for
+ * UTC+ timezone users (e.g. UTC+8). Local midnight on 2023-01-01 in UTC+8 is
+ * 2022-12-31T16:00:00.000Z. SQLite's string comparison then places
+ * "2022-12-31T16:00:00.000Z" < "2023-01-01", so those entries are filtered
+ * into the wrong year in P&L and other account reports.
+ *
+ * Fix: overwrite every AccountingLedgerEntry.date with the UTC midnight of the
+ * corresponding source document's date field (stored as a plain YYYY-MM-DD
+ * string). new Date('YYYY-MM-DD') is parsed as UTC midnight per ISO 8601, so
+ * toISOString() always yields 'YYYY-MM-DDT00:00:00.000Z', which compares
+ * correctly against plain date strings and is consistent across all timezones.
+ */
+async function execute(dm: DatabaseManager) {
+  const sourceTables = [
+    'PurchaseInvoice',
+    'SalesInvoice',
+    'JournalEntry',
+    'Payment',
+    'StockMovement',
+    'StockTransfer',
+  ];
+
+  const entries = (await dm.db!.knex!('AccountingLedgerEntry').select(
+    'name',
+    'date',
+    'referenceName'
+  )) as Array<{ name: string; date: string; referenceName: string }>;
+
+  for (const entry of entries) {
+    for (const table of sourceTables) {
+      const resp = (await dm
+        .db!.knex!.select('name', 'date')
+        .from(table)
+        .where({ name: entry.referenceName })) as Array<{
+        name: string;
+        date: string;
+      }>;
+
+      if (resp.length !== 0) {
+        // Source table dates are stored as plain 'YYYY-MM-DD' strings.
+        // Parsing with new Date() treats them as UTC midnight (ISO 8601),
+        // and toISOString() produces 'YYYY-MM-DDT00:00:00.000Z'.
+        const dateTimeValue = new Date(resp[0].date);
+        await dm.db!.knex!('AccountingLedgerEntry')
+          .where({ name: entry.name })
+          .update({ date: dateTimeValue.toISOString() });
+
+        // Date found in this source table; no need to check the rest.
+        break;
+      }
+    }
+  }
+}
+
+export default { execute, beforeMigrate: true };

--- a/models/Transactional/LedgerPosting.ts
+++ b/models/Transactional/LedgerPosting.ts
@@ -105,8 +105,6 @@ export class LedgerPosting {
       return map[account];
     }
 
-    // end ugly timezone fix code
-
     const ledgerEntry = this.fyo.doc.getNewDoc(
       ModelNameEnum.AccountingLedgerEntry,
       {


### PR DESCRIPTION
**This is a draft PR — feedback, discussion, and testing are very welcome.**
>
> I ran into issue #819 and may have traced it down to the root cause. I'm not deeply familiar with all the internals of this issue, so I'd especially appreciate a second set of eyes on the patch logic and the version number chosen for the rerun patch. If you're a UTC+ timezone user who has been affected, testing against a real database with pre-existing entries would be incredibly helpful in confirming the fix works end-to-end.


**Fixes #819 — P&L report shows entries in the wrong year for UTC+ timezone users**

### Root cause

`AccountingLedgerEntry.date` is a `Datetime` field serialised by calling `Date.prototype.toISOString()`. For a UTC+ user (e.g. Malaysia, UTC+8), local midnight on `2023-01-01` is `2022-12-31T16:00:00.000Z` in UTC. SQLite stores that literal string, and the P&L filter

```/dev/null/sql.sql#L1-1
WHERE date >= '2023-01-01'
```

is a plain string comparison: `"2022-12-31T16:00:00.000Z" < "2023-01-01"` → the entry is silently placed in **2022** instead of 2023.

### What was already partially in place

`timezoneDateTimeAdjuster` (added Feb 2024 in `LedgerPosting`) correctly forces every **new** ledger entry to UTC midnight (`"2023-01-01T00:00:00.000Z"`), whose UTC date string always matches the user's intended date. The `fixLedgerDateTime` migration patch was meant to backfill existing entries with the same fix — but it contained a critical async bug.

### The broken patch

```/dev/null/broken.ts#L1-7
// forEach ignores the Promise returned by async callbacks.
// The outer await only waits for the SELECT, not the UPDATEs.
trx.forEach(async entry => {
  sourceTables.forEach(async table => {
    await knex('AccountingLedgerEntry').update(...)  // never actually awaited
  });
});
```

No exception was thrown, so the patch was recorded as `failed: false` in the `PatchRun` table and will never retry.

### Changes

| File | Change |
|---|---|
| `backend/patches/v0_21_0/fixLedgerDateTime.ts` | Rewrote with `for...of` + `await` — fixes new installs upgrading from old versions |
| `backend/patches/v0_37_0/fixLedgerDateTimeRerun.ts` | New patch, new name (`fixLedgerDateTimeRerun`) at `v0.37.0` — runs for users who already had the broken patch silently execute |
| `backend/patches/index.ts` | Registers the new patch |
| `models/Transactional/LedgerPosting.ts` | Removes orphaned `// end ugly timezone fix code` comment |

### Why a new patch name?

The patch runner only re-executes a patch if it previously recorded `failed: true`. Since the broken patch recorded `failed: false`, it will never retry under the same name. A new name (`fixLedgerDateTimeRerun`) at `v0.37.0` ensures every user whose DB version is ≤ `0.37.0` — i.e. everyone currently running the app — gets the migration applied on their next launch.

### Who is affected

Only **UTC+ timezone** users (UTC+8, UTC+5:30, etc.) with entries created before the `timezoneDateTimeAdjuster` was introduced. UTC and UTC− users were never affected because their local midnight falls on the same or a later UTC day, so the stored string already compared correctly.