### PR TITLE
feat(dashboard): customizable widget system with drag-and-drop layout and new widgets

### DIFF
--- a/backend/database/bespoke.ts
+++ b/backend/database/bespoke.ts
@@ -130,11 +130,78 @@ export class BespokeQueries {
     return { income, expense };
   }
 
+  static async getCashOnHand(db: DatabaseCore): Promise<{ total: number }> {
+    const cashAndBankAccounts = db.knex!('Account')
+      .select('name')
+      .where('accountType', 'in', ['Cash', 'Bank'])
+      .andWhere('isGroup', false);
+
+    const result = (await db.knex!('AccountingLedgerEntry')
+      .where('reverted', false)
+      .where('account', 'in', cashAndBankAccounts)
+      .sum({ debit: db.knex!.raw('cast(debit as real)') })
+      .sum({ credit: db.knex!.raw('cast(credit as real)') })
+      .first()) as { debit: number; credit: number } | undefined;
+
+    return { total: (result?.debit ?? 0) - (result?.credit ?? 0) };
+  }
+
+  static async getTopCustomers(
+    db: DatabaseCore,
+    fromDate: string,
+    toDate: string
+  ): Promise<{ party: string; total: number }[]> {
+    return (await db.knex!('SalesInvoice')
+      .select('party')
+      .sum({ total: db.knex!.raw('cast(baseGrandTotal as real)') })
+      .where('submitted', true)
+      .where('cancelled', false)
+      .whereBetween('date', [fromDate, toDate])
+      .groupBy('party')
+      .orderBy('total', 'desc')
+      .limit(5)) as { party: string; total: number }[];
+  }
+
+  static async getGrossMargin(
+    db: DatabaseCore,
+    fromDate: string,
+    toDate: string
+  ): Promise<{ income: number; cogs: number }> {
+    const incomeAccounts = db.knex!('Account')
+      .select('name')
+      .where('rootType', 'Income');
+
+    const cogsAccounts = db.knex!('Account')
+      .select('name')
+      .where('accountType', 'Cost of Goods Sold');
+
+    const incomeResult = (await db.knex!('AccountingLedgerEntry')
+      .where('reverted', false)
+      .where('account', 'in', incomeAccounts)
+      .whereBetween('date', [fromDate, toDate])
+      .sum({ credit: db.knex!.raw('cast(credit as real)') })
+      .sum({ debit: db.knex!.raw('cast(debit as real)') })
+      .first()) as { credit: number; debit: number } | undefined;
+
+    const cogsResult = (await db.knex!('AccountingLedgerEntry')
+      .where('reverted', false)
+      .where('account', 'in', cogsAccounts)
+      .whereBetween('date', [fromDate, toDate])
+      .sum({ debit: db.knex!.raw('cast(debit as real)') })
+      .sum({ credit: db.knex!.raw('cast(credit as real)') })
+      .first()) as { debit: number; credit: number } | undefined;
+
+    return {
+      income: (incomeResult?.credit ?? 0) - (incomeResult?.debit ?? 0),
+      cogs: (cogsResult?.debit ?? 0) - (cogsResult?.credit ?? 0),
+    };
+  }
+
   static async getTotalCreditAndDebit(db: DatabaseCore) {
     return (await db.knex!.raw(`
-    select 
-	    account, 
-      sum(cast(credit as real)) as totalCredit, 
+    select
+	    account,
+      sum(cast(credit as real)) as totalCredit,
       sum(cast(debit as real)) as totalDebit
     from AccountingLedgerEntry
     group by account

--- a/backend/database/bespoke.ts
+++ b/backend/database/bespoke.ts
@@ -162,6 +162,22 @@ export class BespokeQueries {
       .limit(5)) as { party: string; total: number }[];
   }
 
+  static async getTopSuppliers(
+    db: DatabaseCore,
+    fromDate: string,
+    toDate: string
+  ): Promise<{ party: string; total: number }[]> {
+    return (await db.knex!('PurchaseInvoice')
+      .select('party')
+      .sum({ total: db.knex!.raw('cast(baseGrandTotal as real)') })
+      .where('submitted', true)
+      .where('cancelled', false)
+      .whereBetween('date', [fromDate, toDate])
+      .groupBy('party')
+      .orderBy('total', 'desc')
+      .limit(5)) as { party: string; total: number }[];
+  }
+
   static async getGrossMargin(
     db: DatabaseCore,
     fromDate: string,

--- a/fyo/core/dbHandler.ts
+++ b/fyo/core/dbHandler.ts
@@ -7,12 +7,15 @@ import { translateSchema } from 'fyo/utils/translation';
 import { Field, RawValue, SchemaMap } from 'schemas/types';
 import { getMapFromList } from 'utils';
 import {
+  CashOnHand,
   Cashflow,
   DatabaseBase,
   DatabaseDemuxBase,
   GetAllOptions,
+  GrossMargin,
   IncomeExpense,
   QueryFilter,
+  TopCustomers,
   TopExpenses,
   TotalCreditAndDebit,
   TotalOutstanding,
@@ -305,6 +308,29 @@ export class DatabaseHandler extends DatabaseBase {
       fromDate,
       toDate
     )) as IncomeExpense;
+  }
+
+  async getCashOnHand(): Promise<CashOnHand> {
+    return (await this.#demux.callBespoke('getCashOnHand')) as CashOnHand;
+  }
+
+  async getTopCustomers(
+    fromDate: string,
+    toDate: string
+  ): Promise<TopCustomers> {
+    return (await this.#demux.callBespoke(
+      'getTopCustomers',
+      fromDate,
+      toDate
+    )) as TopCustomers;
+  }
+
+  async getGrossMargin(fromDate: string, toDate: string): Promise<GrossMargin> {
+    return (await this.#demux.callBespoke(
+      'getGrossMargin',
+      fromDate,
+      toDate
+    )) as GrossMargin;
   }
 
   async getTotalCreditAndDebit(): Promise<TotalCreditAndDebit[]> {

--- a/fyo/core/dbHandler.ts
+++ b/fyo/core/dbHandler.ts
@@ -16,6 +16,7 @@ import {
   IncomeExpense,
   QueryFilter,
   TopCustomers,
+  TopSuppliers,
   TopExpenses,
   TotalCreditAndDebit,
   TotalOutstanding,
@@ -323,6 +324,17 @@ export class DatabaseHandler extends DatabaseBase {
       fromDate,
       toDate
     )) as TopCustomers;
+  }
+
+  async getTopSuppliers(
+    fromDate: string,
+    toDate: string
+  ): Promise<TopSuppliers> {
+    return (await this.#demux.callBespoke(
+      'getTopSuppliers',
+      fromDate,
+      toDate
+    )) as TopSuppliers;
   }
 
   async getGrossMargin(fromDate: string, toDate: string): Promise<GrossMargin> {

--- a/models/baseModels/DashboardSettings.ts
+++ b/models/baseModels/DashboardSettings.ts
@@ -1,0 +1,6 @@
+import { Doc } from 'fyo/model/doc';
+
+export class DashboardSettings extends Doc {
+  widgetLayout?: string;
+  activeProfile?: string;
+}

--- a/models/index.ts
+++ b/models/index.ts
@@ -7,6 +7,7 @@ import { Defaults } from './baseModels/Defaults/Defaults';
 import { Item } from './baseModels/Item/Item';
 import { JournalEntry } from './baseModels/JournalEntry/JournalEntry';
 import { JournalEntryAccount } from './baseModels/JournalEntryAccount/JournalEntryAccount';
+import { DashboardSettings } from './baseModels/DashboardSettings';
 import { Misc } from './baseModels/Misc';
 import { Party } from './baseModels/Party/Party';
 import { LoyaltyProgram } from './baseModels/LoyaltyProgram/LoyaltyProgram';
@@ -71,6 +72,7 @@ export const models = {
   ItemEnquiry,
   JournalEntry,
   JournalEntryAccount,
+  DashboardSettings,
   Misc,
   Lead,
   Party,

--- a/models/types.ts
+++ b/models/types.ts
@@ -19,6 +19,7 @@ export enum ModelNameEnum {
   Color = 'Color',
   Currency = 'Currency',
   GetStarted = 'GetStarted',
+  DashboardSettings = 'DashboardSettings',
   Defaults = 'Defaults',
   Item = 'Item',
   ItemGroup = 'ItemGroup',

--- a/schemas/app/DashboardSettings.json
+++ b/schemas/app/DashboardSettings.json
@@ -16,8 +16,8 @@
       "fieldtype": "Select",
       "options": [
         { "value": "Freelancer", "label": "Freelancer" },
-        { "value": "Retailer", "label": "Retailer" },
-        { "value": "Service Business", "label": "Service Business" },
+        { "value": "Shop / Trader", "label": "Shop / Trader" },
+        { "value": "Small Business", "label": "Small Business" },
         { "value": "Custom", "label": "Custom" }
       ],
       "default": "Custom"

--- a/schemas/app/DashboardSettings.json
+++ b/schemas/app/DashboardSettings.json
@@ -1,0 +1,26 @@
+{
+  "name": "DashboardSettings",
+  "label": "Dashboard Settings",
+  "isSingle": true,
+  "isChild": false,
+  "fields": [
+    {
+      "fieldname": "widgetLayout",
+      "label": "Widget Layout",
+      "fieldtype": "Data",
+      "hidden": true
+    },
+    {
+      "fieldname": "activeProfile",
+      "label": "Active Profile",
+      "fieldtype": "Select",
+      "options": [
+        { "value": "Freelancer", "label": "Freelancer" },
+        { "value": "Retailer", "label": "Retailer" },
+        { "value": "Service Business", "label": "Service Business" },
+        { "value": "Custom", "label": "Custom" }
+      ],
+      "default": "Custom"
+    }
+  ]
+}

--- a/schemas/schemas.ts
+++ b/schemas/schemas.ts
@@ -13,6 +13,7 @@ import InvoiceItem from './app/InvoiceItem.json';
 import Item from './app/Item.json';
 import JournalEntry from './app/JournalEntry.json';
 import JournalEntryAccount from './app/JournalEntryAccount.json';
+import DashboardSettings from './app/DashboardSettings.json';
 import Misc from './app/Misc.json';
 import NumberSeries from './app/NumberSeries.json';
 import SerialNumberSeries from './app/SerialNumberSeries.json';
@@ -99,6 +100,7 @@ export const metaSchemas: SchemaStub[] = [
 ];
 
 export const appSchemas: Schema[] | SchemaStub[] = [
+  DashboardSettings as Schema,
   Misc as Schema,
   SetupWizard as Schema,
   GetStarted as Schema,

--- a/src/pages/Dashboard/BaseDashboardChart.vue
+++ b/src/pages/Dashboard/BaseDashboardChart.vue
@@ -36,6 +36,11 @@ export default defineComponent({
     // Calling setData() here guarantees data loads on every first mount.
     await this.setData();
   },
+  async activated() {
+    // Fires when the user navigates back to the Dashboard (keep-alive).
+    // Re-fetch so widgets always reflect the latest data.
+    await this.setData();
+  },
   methods: {
     async periodChange() {
       this.$emit('period-change', this.period);

--- a/src/pages/Dashboard/BaseDashboardChart.vue
+++ b/src/pages/Dashboard/BaseDashboardChart.vue
@@ -29,6 +29,13 @@ export default defineComponent({
       this.period = val;
     },
   },
+  async mounted() {
+    // `activated()` fires when the Dashboard page is re-navigated to (keep-alive),
+    // but NOT when a widget first mounts while the dashboard is already active
+    // (e.g. after a layout save makes a previously-hidden widget visible).
+    // Calling setData() here guarantees data loads on every first mount.
+    await this.setData();
+  },
   methods: {
     async periodChange() {
       this.$emit('period-change', this.period);

--- a/src/pages/Dashboard/CashOnHand.vue
+++ b/src/pages/Dashboard/CashOnHand.vue
@@ -25,7 +25,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { fyo } from 'src/initFyo';
 import { defineComponent } from 'vue';
 import BaseDashboardChart from './BaseDashboardChart.vue';

--- a/src/pages/Dashboard/CashOnHand.vue
+++ b/src/pages/Dashboard/CashOnHand.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="flex flex-col h-full">
+    <SectionHeader>
+      <template #title>{{ t`Cash on Hand` }}</template>
+    </SectionHeader>
+
+    <div class="mt-4 flex flex-col items-center justify-center flex-1 gap-1 py-6">
+      <p
+        class="text-4xl font-bold tabular-nums"
+        :class="total >= 0 ? 'text-gray-900 dark:text-white' : 'text-pink-500 dark:text-pink-400'"
+      >
+        {{ fyo.format(total, 'Currency') }}
+      </p>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        {{ t`Across all cash & bank accounts` }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { fyo } from 'src/initFyo';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import SectionHeader from './SectionHeader.vue';
+
+export default defineComponent({
+  name: 'CashOnHand',
+  components: { SectionHeader },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      total: 0 as number,
+    };
+  },
+  methods: {
+    async setData() {
+      const result = await fyo.db.getCashOnHand();
+      this.total = result?.total ?? 0;
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/CashOnHand.vue
+++ b/src/pages/Dashboard/CashOnHand.vue
@@ -4,10 +4,16 @@
       <template #title>{{ t`Cash on Hand` }}</template>
     </SectionHeader>
 
-    <div class="mt-4 flex flex-col items-center justify-center flex-1 gap-1 py-6">
+    <div
+      class="mt-4 flex flex-col items-center justify-center flex-1 gap-1 py-6"
+    >
       <p
         class="text-4xl font-bold tabular-nums"
-        :class="total >= 0 ? 'text-gray-900 dark:text-white' : 'text-pink-500 dark:text-pink-400'"
+        :class="
+          total >= 0
+            ? 'text-gray-900 dark:text-white'
+            : 'text-pink-500 dark:text-pink-400'
+        "
       >
         {{ fyo.format(total, 'Currency') }}
       </p>

--- a/src/pages/Dashboard/Cashflow.vue
+++ b/src/pages/Dashboard/Cashflow.vue
@@ -65,8 +65,8 @@ import { getMapFromList } from 'utils/index';
 import { PeriodKey } from 'src/utils/types';
 
 // Linting broken in this file cause of `extends: ...`
-/* 
-  eslint-disable @typescript-eslint/no-unsafe-argument, 
+/*
+  eslint-disable @typescript-eslint/no-unsafe-argument,
   @typescript-eslint/no-unsafe-return
 */
 
@@ -119,6 +119,14 @@ export default defineComponent({
         fontColor: this.darkMode ? uicolors.gray['400'] : undefined,
       };
     },
+  },
+  async mounted() {
+    // Base class mounted() already calls setData(); we only need to resolve
+    // hasData here so the chart switches from the gray placeholder to real
+    // colours when this widget first appears after a layout save.
+    if (!this.hasData) {
+      await this.setHasData();
+    }
   },
   async activated() {
     await this.setData();

--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -62,27 +62,31 @@
           </div>
 
           <!-- Side-by-side half pair -->
+          <!-- Each column is a strict w-1/2. The border lives on the bare
+               layout wrapper so its position never varies with wrapClass.
+               A child div carries the per-widget padding (wrapClass). -->
           <div v-else-if="row.type === 'half-pair'" class="flex w-full">
-            <div
-              class="w-full border-e dark:border-gray-800"
-              :class="WIDGET_META[row.left.id].wrapClass"
-            >
-              <component
-                :is="widgetComponent(row.left.id)"
-                :common-period="period"
-                :dark-mode="darkMode"
-                v-bind="widgetExtraProps(row.left.id)"
-                @period-change="handlePeriodChange"
-              />
+            <div class="w-1/2 border-e dark:border-gray-800">
+              <div class="h-full" :class="WIDGET_META[row.left.id].wrapClass">
+                <component
+                  :is="widgetComponent(row.left.id)"
+                  :common-period="period"
+                  :dark-mode="darkMode"
+                  v-bind="widgetExtraProps(row.left.id)"
+                  @period-change="handlePeriodChange"
+                />
+              </div>
             </div>
-            <div class="w-full" :class="WIDGET_META[row.right.id].wrapClass">
-              <component
-                :is="widgetComponent(row.right.id)"
-                :common-period="period"
-                :dark-mode="darkMode"
-                v-bind="widgetExtraProps(row.right.id)"
-                @period-change="handlePeriodChange"
-              />
+            <div class="w-1/2">
+              <div class="h-full" :class="WIDGET_META[row.right.id].wrapClass">
+                <component
+                  :is="widgetComponent(row.right.id)"
+                  :common-period="period"
+                  :dark-mode="darkMode"
+                  v-bind="widgetExtraProps(row.right.id)"
+                  @period-change="handlePeriodChange"
+                />
+              </div>
             </div>
           </div>
 
@@ -130,7 +134,10 @@ import OverdueInvoices from './OverdueInvoices.vue';
 import PeriodSelector from './PeriodSelector.vue';
 import ProfitAndLoss from './ProfitAndLoss.vue';
 import TopCustomers from './TopCustomers.vue';
+import TopSuppliers from './TopSuppliers.vue';
 import UnpaidInvoices from './UnpaidInvoices.vue';
+import InvoiceDrafts from './InvoiceDrafts.vue';
+import ReceivablesAging from './ReceivablesAging.vue';
 import UpcomingBills from './UpcomingBills.vue';
 import {
   buildWidgetRows,
@@ -155,6 +162,9 @@ const WIDGET_COMPONENTS: Record<WidgetKey, unknown> = {
   cashOnHand: CashOnHand,
   topCustomers: TopCustomers,
   grossMargin: GrossMargin,
+  topSuppliers: TopSuppliers,
+  invoiceDrafts: InvoiceDrafts,
+  receivablesAging: ReceivablesAging,
 };
 
 /** Extra props passed to specific widgets beyond commonPeriod / darkMode. */
@@ -181,6 +191,9 @@ export default defineComponent({
     CashOnHand,
     TopCustomers,
     GrossMargin,
+    InvoiceDrafts,
+    ReceivablesAging,
+    TopSuppliers,
   },
 
   props: {

--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -122,11 +122,16 @@ import { docsPathRef } from 'src/utils/refs';
 import { PeriodKey } from 'src/utils/types';
 import { defineComponent } from 'vue';
 import Cashflow from './Cashflow.vue';
+import CashOnHand from './CashOnHand.vue';
 import DashboardCustomizePanel from './DashboardCustomizePanel.vue';
 import Expenses from './Expenses.vue';
+import GrossMargin from './GrossMargin.vue';
+import OverdueInvoices from './OverdueInvoices.vue';
 import PeriodSelector from './PeriodSelector.vue';
 import ProfitAndLoss from './ProfitAndLoss.vue';
+import TopCustomers from './TopCustomers.vue';
 import UnpaidInvoices from './UnpaidInvoices.vue';
+import UpcomingBills from './UpcomingBills.vue';
 import {
   buildWidgetRows,
   DashboardProfile,
@@ -145,6 +150,11 @@ const WIDGET_COMPONENTS: Record<WidgetKey, unknown> = {
   purchaseInvoices: UnpaidInvoices,
   profitAndLoss: ProfitAndLoss,
   expenses: Expenses,
+  overdueInvoices: OverdueInvoices,
+  upcomingBills: UpcomingBills,
+  cashOnHand: CashOnHand,
+  topCustomers: TopCustomers,
+  grossMargin: GrossMargin,
 };
 
 /** Extra props passed to specific widgets beyond commonPeriod / darkMode. */
@@ -166,6 +176,11 @@ export default defineComponent({
     Expenses,
     PeriodSelector,
     UnpaidInvoices,
+    OverdueInvoices,
+    UpcomingBills,
+    CashOnHand,
+    TopCustomers,
+    GrossMargin,
   },
 
   props: {

--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -1,25 +1,29 @@
 <template>
   <div class="h-screen" style="width: var(--w-desk)">
     <PageHeader :title="t`Dashboard`">
-      <div
-        class="
-          border
-          dark:border-gray-900
-          rounded
-          bg-gray-50
-          dark:bg-gray-890
-          focus-within:bg-gray-100
-          dark:focus-within:bg-gray-900
-          flex
-          items-center
-        "
-      >
-        <PeriodSelector
-          class="px-3"
-          :value="period"
-          :options="['This Year', 'This Quarter', 'This Month', 'YTD']"
-          @change="(value) => (period = value)"
-        />
+      <div class="flex items-center gap-2">
+        <!-- Period selector -->
+        <div
+          class="border dark:border-gray-900 rounded bg-gray-50 dark:bg-gray-890
+                 focus-within:bg-gray-100 dark:focus-within:bg-gray-900 flex items-center"
+        >
+          <PeriodSelector
+            class="px-3"
+            :value="period"
+            :options="['This Year', 'This Quarter', 'This Month', 'YTD']"
+            @change="(value) => (period = value)"
+          />
+        </div>
+
+        <!-- Customize button -->
+        <button
+          class="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800
+                 text-gray-500 dark:text-gray-400"
+          :title="t`Customize Dashboard`"
+          @click="showCustomize = true"
+        >
+          <FeatherIcon name="settings" class="w-4 h-4" />
+        </button>
       </div>
     </PageHeader>
 
@@ -27,89 +31,197 @@
       class="no-scrollbar overflow-auto dark:bg-gray-875"
       style="height: calc(100vh - var(--h-row-largest) - 1px)"
     >
-      <div style="min-width: var(--w-desk-fixed)" class="overflow-auto">
-        <Cashflow
-          class="p-4"
-          :common-period="period"
-          :dark-mode="darkMode"
-          @period-change="handlePeriodChange"
-        />
-        <hr class="dark:border-gray-800" />
-        <div class="flex w-full">
-          <UnpaidInvoices
-            :schema-name="'SalesInvoice'"
-            :common-period="period"
-            :dark-mode="darkMode"
-            class="border-e dark:border-gray-800"
-            @period-change="handlePeriodChange"
-          />
-          <UnpaidInvoices
-            :schema-name="'PurchaseInvoice'"
-            :common-period="period"
-            :dark-mode="darkMode"
-            @period-change="handlePeriodChange"
-          />
-        </div>
-        <hr class="dark:border-gray-800" />
-        <div class="flex">
-          <ProfitAndLoss
-            class="w-full p-4 border-e dark:border-gray-800"
-            :common-period="period"
-            :dark-mode="darkMode"
-            @period-change="handlePeriodChange"
-          />
-          <Expenses
-            class="w-full p-4"
-            :common-period="period"
-            :dark-mode="darkMode"
-            @period-change="handlePeriodChange"
-          />
-        </div>
-        <hr class="dark:border-gray-800" />
+      <!-- Empty state: all widgets hidden -->
+      <div
+        v-if="visibleRows.length === 0"
+        class="h-full flex flex-col items-center justify-center gap-3
+               text-gray-500 dark:text-gray-400"
+      >
+        <FeatherIcon name="layout" class="w-10 h-10 opacity-30" />
+        <p class="text-sm">{{ t`No widgets are visible.` }}</p>
+        <button
+          class="text-sm text-blue-500 hover:underline"
+          @click="showCustomize = true"
+        >
+          {{ t`Customize Dashboard` }}
+        </button>
+      </div>
+
+      <!-- Widget canvas -->
+      <div v-else style="min-width: var(--w-desk-fixed)">
+        <template v-for="(row, idx) in visibleRows" :key="idx">
+          <!-- Full-width widget -->
+          <div v-if="row.type === 'full'" :class="WIDGET_META[row.widget.id].wrapClass">
+            <component
+              :is="widgetComponent(row.widget.id)"
+              :common-period="period"
+              :dark-mode="darkMode"
+              v-bind="widgetExtraProps(row.widget.id)"
+              @period-change="handlePeriodChange"
+            />
+          </div>
+
+          <!-- Side-by-side half pair -->
+          <div v-else-if="row.type === 'half-pair'" class="flex w-full">
+            <div
+              class="w-full border-e dark:border-gray-800"
+              :class="WIDGET_META[row.left.id].wrapClass"
+            >
+              <component
+                :is="widgetComponent(row.left.id)"
+                :common-period="period"
+                :dark-mode="darkMode"
+                v-bind="widgetExtraProps(row.left.id)"
+                @period-change="handlePeriodChange"
+              />
+            </div>
+            <div class="w-full" :class="WIDGET_META[row.right.id].wrapClass">
+              <component
+                :is="widgetComponent(row.right.id)"
+                :common-period="period"
+                :dark-mode="darkMode"
+                v-bind="widgetExtraProps(row.right.id)"
+                @period-change="handlePeriodChange"
+              />
+            </div>
+          </div>
+
+          <!-- Unpaired half-width widget — spans the full row -->
+          <div v-else :class="WIDGET_META[row.widget.id].wrapClass">
+            <component
+              :is="widgetComponent(row.widget.id)"
+              :common-period="period"
+              :dark-mode="darkMode"
+              v-bind="widgetExtraProps(row.widget.id)"
+              @period-change="handlePeriodChange"
+            />
+          </div>
+
+          <hr class="dark:border-gray-800" />
+        </template>
       </div>
     </div>
+
+    <!-- Customize panel (mounted only when open) -->
+    <DashboardCustomizePanel
+      v-if="showCustomize"
+      :layout="layout"
+      :current-profile="activeProfile"
+      @close="showCustomize = false"
+      @saved="onLayoutSaved"
+    />
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { ModelNameEnum } from 'models/types';
+import FeatherIcon from 'src/components/FeatherIcon.vue';
 import PageHeader from 'src/components/PageHeader.vue';
-import UnpaidInvoices from './UnpaidInvoices.vue';
+import { fyo } from 'src/initFyo';
+import { docsPathRef } from 'src/utils/refs';
+import { PeriodKey } from 'src/utils/types';
+import { defineComponent } from 'vue';
 import Cashflow from './Cashflow.vue';
+import DashboardCustomizePanel from './DashboardCustomizePanel.vue';
 import Expenses from './Expenses.vue';
 import PeriodSelector from './PeriodSelector.vue';
 import ProfitAndLoss from './ProfitAndLoss.vue';
-import { docsPathRef } from 'src/utils/refs';
+import UnpaidInvoices from './UnpaidInvoices.vue';
+import {
+  buildWidgetRows,
+  DashboardProfile,
+  DEFAULT_LAYOUT,
+  parseWidgetLayout,
+  WIDGET_META,
+  WidgetConfig,
+  WidgetKey,
+  WidgetRow,
+} from './types';
 
-export default {
+/** Maps a WidgetKey to the Vue component that renders it. */
+const WIDGET_COMPONENTS: Record<WidgetKey, unknown> = {
+  cashflow: Cashflow,
+  salesInvoices: UnpaidInvoices,
+  purchaseInvoices: UnpaidInvoices,
+  profitAndLoss: ProfitAndLoss,
+  expenses: Expenses,
+};
+
+/** Extra props passed to specific widgets beyond commonPeriod / darkMode. */
+const WIDGET_EXTRA_PROPS: Partial<Record<WidgetKey, Record<string, unknown>>> =
+  {
+    salesInvoices: { schemaName: 'SalesInvoice' },
+    purchaseInvoices: { schemaName: 'PurchaseInvoice' },
+  };
+
+export default defineComponent({
   name: 'Dashboard',
   components: {
     PageHeader,
+    FeatherIcon,
+    DashboardCustomizePanel,
+    // Registered here so Vue can resolve them inside <component :is="...">
     Cashflow,
     ProfitAndLoss,
     Expenses,
     PeriodSelector,
     UnpaidInvoices,
   },
+
   props: {
     darkMode: { type: Boolean, default: false },
   },
+
   data() {
-    return { period: 'This Year' };
+    return {
+      period: 'This Year' as PeriodKey,
+      layout: DEFAULT_LAYOUT.map((c) => ({ ...c })) as WidgetConfig[],
+      activeProfile: 'Custom' as DashboardProfile,
+      showCustomize: false,
+      WIDGET_META,
+    };
   },
-  activated() {
+
+  computed: {
+    visibleRows(): WidgetRow[] {
+      return buildWidgetRows(this.layout);
+    },
+  },
+
+  async activated() {
     docsPathRef.value = 'books/dashboard';
+    await this.loadLayout();
   },
+
   deactivated() {
     docsPathRef.value = '';
   },
-  methods: {
-    handlePeriodChange(period) {
-      if (period === this.period) {
-        return;
-      }
 
+  methods: {
+    async loadLayout() {
+      const doc = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
+      this.layout = parseWidgetLayout(doc.widgetLayout as string | undefined);
+      this.activeProfile =
+        (doc.activeProfile as DashboardProfile | undefined) ?? 'Custom';
+    },
+
+    widgetComponent(id: WidgetKey): unknown {
+      return WIDGET_COMPONENTS[id];
+    },
+
+    widgetExtraProps(id: WidgetKey): Record<string, unknown> {
+      return WIDGET_EXTRA_PROPS[id] ?? {};
+    },
+
+    handlePeriodChange(period: PeriodKey) {
+      if (period === this.period) return;
       this.period = '';
     },
+
+    onLayoutSaved(newLayout: WidgetConfig[], profile: DashboardProfile) {
+      this.layout = newLayout;
+      this.activeProfile = profile;
+    },
   },
-};
+});
 </script>

--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -4,8 +4,17 @@
       <div class="flex items-center gap-2">
         <!-- Period selector -->
         <div
-          class="border dark:border-gray-900 rounded bg-gray-50 dark:bg-gray-890
-                 focus-within:bg-gray-100 dark:focus-within:bg-gray-900 flex items-center"
+          class="
+            border
+            dark:border-gray-900
+            rounded
+            bg-gray-50
+            dark:bg-gray-890
+            focus-within:bg-gray-100
+            dark:focus-within:bg-gray-900
+            flex
+            items-center
+          "
         >
           <PeriodSelector
             class="px-3"
@@ -17,8 +26,14 @@
 
         <!-- Customize button -->
         <button
-          class="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800
-                 text-gray-500 dark:text-gray-400"
+          class="
+            p-1.5
+            rounded
+            hover:bg-gray-100
+            dark:hover:bg-gray-800
+            text-gray-500
+            dark:text-gray-400
+          "
           :title="t`Customize Dashboard`"
           @click="showCustomize = true"
         >
@@ -34,8 +49,15 @@
       <!-- Empty state: all widgets hidden -->
       <div
         v-if="visibleRows.length === 0"
-        class="h-full flex flex-col items-center justify-center gap-3
-               text-gray-500 dark:text-gray-400"
+        class="
+          h-full
+          flex flex-col
+          items-center
+          justify-center
+          gap-3
+          text-gray-500
+          dark:text-gray-400
+        "
       >
         <FeatherIcon name="layout" class="w-10 h-10 opacity-30" />
         <p class="text-sm">{{ t`No widgets are visible.` }}</p>
@@ -51,7 +73,10 @@
       <div v-else style="min-width: var(--w-desk-fixed)">
         <template v-for="(row, idx) in visibleRows" :key="idx">
           <!-- Full-width widget -->
-          <div v-if="row.type === 'full'" :class="WIDGET_META[row.widget.id].wrapClass">
+          <div
+            v-if="row.type === 'full'"
+            :class="WIDGET_META[row.widget.id].wrapClass"
+          >
             <component
               :is="widgetComponent(row.widget.id)"
               :common-period="period"

--- a/src/pages/Dashboard/DashboardCustomizePanel.vue
+++ b/src/pages/Dashboard/DashboardCustomizePanel.vue
@@ -1,9 +1,11 @@
 <template>
   <Modal :open-modal="true" @closemodal="$emit('close')">
     <div
-      class="p-6 flex flex-col gap-5 overflow-y-auto"
+      class="flex flex-col"
       style="width: 580px; max-height: 88vh"
     >
+      <!-- ── Top band (never scrolls) ───────────────────────────────────── -->
+      <div class="px-6 pt-6 pb-0 flex flex-col gap-5 shrink-0">
       <!-- ── 1. Header ───────────────────────────────────────────────────── -->
       <div>
         <h2 class="text-base font-semibold dark:text-white">
@@ -41,13 +43,16 @@
         </div>
       </div>
 
-      <!-- ── 3. Active Widgets canvas ───────────────────────────────────── -->
-      <div>
+      <!-- ── 3. Active Widgets label (pinned, not scrolled) ───────────────── -->
         <p
-          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
+          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
         >
           {{ t`Active Widgets` }}
         </p>
+      </div><!-- end top band -->
+
+      <!-- ── 3. Active Widgets canvas (this section scrolls independently) ── -->
+      <div class="overflow-y-auto flex-1 min-h-0 px-6 py-3">
 
         <!-- Canvas drop target (fallback) -->
         <div
@@ -337,8 +342,10 @@
             </template>
           </template>
         </div>
-      </div>
+      </div><!-- end canvas scroll area -->
 
+      <!-- ── Bottom band (never scrolls) ──────────────────────────────────── -->
+      <div class="px-6 pb-6 pt-4 flex flex-col gap-5 shrink-0 border-t dark:border-gray-800">
       <!-- ── 4. Hidden Widgets tray ─────────────────────────────────────── -->
       <div>
         <p
@@ -398,7 +405,7 @@
 
       <!-- ── 5. Footer ──────────────────────────────────────────────────── -->
       <div
-        class="flex justify-between items-center pt-2 border-t dark:border-gray-700"
+        class="flex justify-between items-center"
       >
         <button
           class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
@@ -413,6 +420,7 @@
           </Button>
         </div>
       </div>
+      </div><!-- end bottom band -->
     </div>
   </Modal>
 </template>

--- a/src/pages/Dashboard/DashboardCustomizePanel.vue
+++ b/src/pages/Dashboard/DashboardCustomizePanel.vue
@@ -1,59 +1,80 @@
 <template>
   <Modal :open-modal="true" @closemodal="$emit('close')">
-    <div
-      class="flex flex-col"
-      style="width: 580px; max-height: 88vh"
-    >
+    <div class="flex flex-col" style="width: 580px; max-height: 88vh">
       <!-- ── Top band (never scrolls) ───────────────────────────────────── -->
       <div class="px-6 pt-6 pb-0 flex flex-col gap-5 shrink-0">
-      <!-- ── 1. Header ───────────────────────────────────────────────────── -->
-      <div>
-        <h2 class="text-base font-semibold dark:text-white">
-          {{ t`Customize Dashboard` }}
-        </h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-          {{ t`Drag widgets to reorder the layout. Drop into Hidden to remove.` }}
-        </p>
-      </div>
-
-      <!-- ── 2. Preset profile cards ────────────────────────────────────── -->
-      <div>
-        <p
-          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
-        >
-          {{ t`Presets` }}
-        </p>
-        <div class="grid grid-cols-3 gap-2">
-          <button
-            v-for="profile in PRESET_PROFILES"
-            :key="profile"
-            class="rounded-lg border px-3 py-2 text-sm text-left transition-colors"
-            :class="
-              activeProfile === profile
-                ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300'
-                : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:text-gray-300 dark:hover:border-gray-500'
-            "
-            @click="applyProfile(profile)"
-          >
-            <div class="font-medium leading-snug">{{ profile }}</div>
-            <div class="text-xs text-gray-400 mt-0.5">
-              {{ PROFILE_LAYOUTS[profile].length }}&nbsp;{{ t`widgets` }}
-            </div>
-          </button>
+        <!-- ── 1. Header ───────────────────────────────────────────────────── -->
+        <div>
+          <h2 class="text-base font-semibold dark:text-white">
+            {{ t`Customize Dashboard` }}
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            {{
+              t`Drag widgets to reorder the layout. Drop into Hidden to remove.`
+            }}
+          </p>
         </div>
-      </div>
 
-      <!-- ── 3. Active Widgets label (pinned, not scrolled) ───────────────── -->
+        <!-- ── 2. Preset profile cards ────────────────────────────────────── -->
+        <div>
+          <p
+            class="
+              text-xs
+              font-medium
+              text-gray-500
+              dark:text-gray-400
+              uppercase
+              tracking-wider
+              mb-2
+            "
+          >
+            {{ t`Presets` }}
+          </p>
+          <div class="grid grid-cols-3 gap-2">
+            <button
+              v-for="profile in PRESET_PROFILES"
+              :key="profile"
+              class="
+                rounded-lg
+                border
+                px-3
+                py-2
+                text-sm text-left
+                transition-colors
+              "
+              :class="
+                activeProfile === profile
+                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:text-gray-300 dark:hover:border-gray-500'
+              "
+              @click="applyProfile(profile)"
+            >
+              <div class="font-medium leading-snug">{{ profile }}</div>
+              <div class="text-xs text-gray-400 mt-0.5">
+                {{ PROFILE_LAYOUTS[profile].length }}&nbsp;{{ t`widgets` }}
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <!-- ── 3. Active Widgets label (pinned, not scrolled) ───────────────── -->
         <p
-          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+          class="
+            text-xs
+            font-medium
+            text-gray-500
+            dark:text-gray-400
+            uppercase
+            tracking-wider
+          "
         >
           {{ t`Active Widgets` }}
         </p>
-      </div><!-- end top band -->
+      </div>
+      <!-- end top band -->
 
       <!-- ── 3. Active Widgets canvas (this section scrolls independently) ── -->
       <div class="overflow-y-auto flex-1 min-h-0 px-6 py-3">
-
         <!-- Canvas drop target (fallback) -->
         <div
           class="border-2 border-gray-200 dark:border-gray-700 rounded-xl p-1.5"
@@ -71,7 +92,20 @@
           <!-- Empty: nothing visible, dragging — full-area drop zone -->
           <div
             v-else-if="localVisibleOrder.length === 0 && isDragging"
-            class="h-24 flex items-center justify-center text-sm font-medium rounded-lg border-2 border-dashed border-blue-400 bg-blue-50 dark:bg-blue-950 text-blue-500 cursor-copy"
+            class="
+              h-24
+              flex
+              items-center
+              justify-center
+              text-sm
+              font-medium
+              rounded-lg
+              border-2 border-dashed border-blue-400
+              bg-blue-50
+              dark:bg-blue-950
+              text-blue-500
+              cursor-copy
+            "
             @dragenter.prevent="dropTargetIdx = 0"
             @dragover.prevent
             @drop.prevent.stop="commitDrop(0)"
@@ -90,7 +124,16 @@
               @drop.prevent.stop="commitDrop(0)"
             >
               <div
-                class="h-full border-2 border-dashed rounded-full flex items-center justify-center text-xs transition-colors"
+                class="
+                  h-full
+                  border-2 border-dashed
+                  rounded-full
+                  flex
+                  items-center
+                  justify-center
+                  text-xs
+                  transition-colors
+                "
                 :class="
                   dropTargetIdx === 0
                     ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-500'
@@ -106,7 +149,19 @@
               <div v-if="row.type === 'full'" class="p-1">
                 <div
                   draggable="true"
-                  class="flex items-center gap-2 border rounded-lg px-3 py-2.5 select-none transition-all bg-white dark:bg-gray-800"
+                  class="
+                    flex
+                    items-center
+                    gap-2
+                    border
+                    rounded-lg
+                    px-3
+                    py-2.5
+                    select-none
+                    transition-all
+                    bg-white
+                    dark:bg-gray-800
+                  "
                   :class="
                     draggingId === row.ids[0]
                       ? 'opacity-40 cursor-grabbing border-blue-300'
@@ -135,7 +190,17 @@
                     </p>
                   </div>
                   <span
-                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                    class="
+                      text-xs
+                      px-1.5
+                      py-0.5
+                      rounded
+                      bg-gray-100
+                      dark:bg-gray-750
+                      text-gray-500
+                      dark:text-gray-400
+                      shrink-0
+                    "
                   >
                     {{
                       WIDGET_META[row.ids[0]].width === 'full'
@@ -144,7 +209,12 @@
                     }}
                   </span>
                   <button
-                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    class="
+                      text-gray-300
+                      hover:text-red-400
+                      transition-colors
+                      shrink-0
+                    "
                     @click="hideWidget(row.ids[0])"
                   >
                     <FeatherIcon name="x" class="w-3.5 h-3.5" />
@@ -153,7 +223,10 @@
               </div>
 
               <!-- ── HALF-PAIR row ───────────────────────────────────── -->
-              <div v-else-if="row.type === 'half-pair'" class="flex gap-1.5 p-1">
+              <div
+                v-else-if="row.type === 'half-pair'"
+                class="flex gap-1.5 p-1"
+              >
                 <!-- Left card -->
                 <div
                   class="flex-1"
@@ -183,7 +256,17 @@
                     <!-- description intentionally omitted in half-pair to save space -->
                   </div>
                   <span
-                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                    class="
+                      text-xs
+                      px-1.5
+                      py-0.5
+                      rounded
+                      bg-gray-100
+                      dark:bg-gray-750
+                      text-gray-500
+                      dark:text-gray-400
+                      shrink-0
+                    "
                   >
                     {{
                       WIDGET_META[row.ids[0]].width === 'full'
@@ -192,7 +275,12 @@
                     }}
                   </span>
                   <button
-                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    class="
+                      text-gray-300
+                      hover:text-red-400
+                      transition-colors
+                      shrink-0
+                    "
                     @click="hideWidget(row.ids[0])"
                   >
                     <FeatherIcon name="x" class="w-3.5 h-3.5" />
@@ -228,7 +316,17 @@
                     <!-- description intentionally omitted in half-pair to save space -->
                   </div>
                   <span
-                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                    class="
+                      text-xs
+                      px-1.5
+                      py-0.5
+                      rounded
+                      bg-gray-100
+                      dark:bg-gray-750
+                      text-gray-500
+                      dark:text-gray-400
+                      shrink-0
+                    "
                   >
                     {{
                       WIDGET_META[row.ids[1]].width === 'full'
@@ -237,7 +335,12 @@
                     }}
                   </span>
                   <button
-                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    class="
+                      text-gray-300
+                      hover:text-red-400
+                      transition-colors
+                      shrink-0
+                    "
                     @click="hideWidget(row.ids[1])"
                   >
                     <FeatherIcon name="x" class="w-3.5 h-3.5" />
@@ -280,7 +383,17 @@
                     </p>
                   </div>
                   <span
-                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                    class="
+                      text-xs
+                      px-1.5
+                      py-0.5
+                      rounded
+                      bg-gray-100
+                      dark:bg-gray-750
+                      text-gray-500
+                      dark:text-gray-400
+                      shrink-0
+                    "
                   >
                     {{
                       WIDGET_META[row.ids[0]].width === 'full'
@@ -289,7 +402,12 @@
                     }}
                   </span>
                   <button
-                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    class="
+                      text-gray-300
+                      hover:text-red-400
+                      transition-colors
+                      shrink-0
+                    "
                     @click="hideWidget(row.ids[0])"
                   >
                     <FeatherIcon name="x" class="w-3.5 h-3.5" />
@@ -298,13 +416,23 @@
 
                 <!-- Pairing placeholder — also a live drop zone at row.endIdx -->
                 <div
-                  class="flex-1 border-2 border-dashed rounded-lg flex items-center justify-center text-xs py-2.5 transition-colors"
+                  class="
+                    flex-1
+                    border-2 border-dashed
+                    rounded-lg
+                    flex
+                    items-center
+                    justify-center
+                    text-xs
+                    py-2.5
+                    transition-colors
+                  "
                   :class="
                     dropTargetIdx === row.endIdx
                       ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-500 cursor-copy'
                       : isDragging
-                        ? 'border-blue-300 dark:border-blue-800 text-blue-400 dark:text-blue-600 cursor-copy'
-                        : 'border-gray-200 dark:border-gray-700 text-gray-400'
+                      ? 'border-blue-300 dark:border-blue-800 text-blue-400 dark:text-blue-600 cursor-copy'
+                      : 'border-gray-200 dark:border-gray-700 text-gray-400'
                   "
                   @dragenter.prevent="dropTargetIdx = row.endIdx"
                   @dragover.prevent
@@ -327,7 +455,16 @@
                 @drop.prevent.stop="commitDrop(row.endIdx)"
               >
                 <div
-                  class="h-full border-2 border-dashed rounded-full flex items-center justify-center text-xs transition-colors"
+                  class="
+                    h-full
+                    border-2 border-dashed
+                    rounded-full
+                    flex
+                    items-center
+                    justify-center
+                    text-xs
+                    transition-colors
+                  "
                   :class="
                     dropTargetIdx === row.endIdx
                       ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-500'
@@ -342,85 +479,140 @@
             </template>
           </template>
         </div>
-      </div><!-- end canvas scroll area -->
+      </div>
+      <!-- end canvas scroll area -->
 
       <!-- ── Bottom band (never scrolls) ──────────────────────────────────── -->
-      <div class="px-6 pb-6 pt-4 flex flex-col gap-5 shrink-0 border-t dark:border-gray-800">
-      <!-- ── 4. Hidden Widgets tray ─────────────────────────────────────── -->
-      <div>
-        <p
-          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
-        >
-          {{ t`Hidden` }}
-        </p>
-
-        <div
-          class="border-2 border-dashed rounded-xl p-2 min-h-14 flex flex-wrap gap-2 items-center transition-colors"
-          :class="
-            isDragging && dragOverHidden
-              ? 'border-red-400 dark:border-red-700 bg-red-50 dark:bg-red-950'
-              : 'border-gray-200 dark:border-gray-700'
-          "
-          @dragenter.prevent="dragOverHidden = true"
-          @dragover.prevent="dragOverHidden = true"
-          @dragleave="dragOverHidden = false"
-          @drop.prevent.stop="onHiddenDrop"
-        >
-          <template v-if="hiddenOrder.length > 0">
-            <div
-              v-for="id in hiddenOrder"
-              :key="id"
-              draggable="true"
-              class="flex items-center gap-1.5 border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-1.5 cursor-grab select-none bg-white dark:bg-gray-800 transition-all"
-              :class="
-                draggingId === id
-                  ? 'opacity-40 cursor-grabbing border-blue-300'
-                  : 'hover:border-blue-300 hover:shadow-sm'
-              "
-              @dragstart="startDrag(id, $event)"
-              @dragend="endDrag"
-            >
-              <FeatherIcon
-                :name="WIDGET_META[id].icon"
-                class="w-3.5 h-3.5 text-gray-400"
-              />
-              <span class="text-sm font-medium dark:text-white">
-                {{ WIDGET_META[id].label }}
-              </span>
-              <span
-                class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400"
-              >
-                {{ WIDGET_META[id].width === 'full' ? t`Full` : t`Half` }}
-              </span>
-            </div>
-          </template>
-
-          <span v-else class="text-sm text-gray-400 px-1">
-            {{
-              isDragging ? t`Drop here to hide` : t`All widgets are active`
-            }}
-          </span>
-        </div>
-      </div>
-
-      <!-- ── 5. Footer ──────────────────────────────────────────────────── -->
       <div
-        class="flex justify-between items-center"
+        class="
+          px-6
+          pb-6
+          pt-4
+          flex flex-col
+          gap-5
+          shrink-0
+          border-t
+          dark:border-gray-800
+        "
       >
-        <button
-          class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-          @click="resetToDefault"
-        >
-          {{ t`Reset to default` }}
-        </button>
-        <div class="flex gap-2">
-          <Button @click="$emit('close')">{{ t`Cancel` }}</Button>
-          <Button type="primary" :disabled="saving" @click="save">
-            {{ t`Save` }}
-          </Button>
+        <!-- ── 4. Hidden Widgets tray ─────────────────────────────────────── -->
+        <div>
+          <p
+            class="
+              text-xs
+              font-medium
+              text-gray-500
+              dark:text-gray-400
+              uppercase
+              tracking-wider
+              mb-2
+            "
+          >
+            {{ t`Hidden` }}
+          </p>
+
+          <div
+            class="
+              border-2 border-dashed
+              rounded-xl
+              p-2
+              min-h-14
+              flex flex-wrap
+              gap-2
+              items-center
+              transition-colors
+            "
+            :class="
+              isDragging && dragOverHidden
+                ? 'border-red-400 dark:border-red-700 bg-red-50 dark:bg-red-950'
+                : 'border-gray-200 dark:border-gray-700'
+            "
+            @dragenter.prevent="dragOverHidden = true"
+            @dragover.prevent="dragOverHidden = true"
+            @dragleave="dragOverHidden = false"
+            @drop.prevent.stop="onHiddenDrop"
+          >
+            <template v-if="hiddenOrder.length > 0">
+              <div
+                v-for="id in hiddenOrder"
+                :key="id"
+                draggable="true"
+                class="
+                  flex
+                  items-center
+                  gap-1.5
+                  border border-gray-200
+                  dark:border-gray-700
+                  rounded-lg
+                  px-2.5
+                  py-1.5
+                  cursor-grab
+                  select-none
+                  bg-white
+                  dark:bg-gray-800
+                  transition-all
+                "
+                :class="
+                  draggingId === id
+                    ? 'opacity-40 cursor-grabbing border-blue-300'
+                    : 'hover:border-blue-300 hover:shadow-sm'
+                "
+                @dragstart="startDrag(id, $event)"
+                @dragend="endDrag"
+              >
+                <FeatherIcon
+                  :name="WIDGET_META[id].icon"
+                  class="w-3.5 h-3.5 text-gray-400"
+                />
+                <span class="text-sm font-medium dark:text-white">
+                  {{ WIDGET_META[id].label }}
+                </span>
+                <span
+                  class="
+                    text-xs
+                    px-1.5
+                    py-0.5
+                    rounded
+                    bg-gray-100
+                    dark:bg-gray-750
+                    text-gray-500
+                    dark:text-gray-400
+                  "
+                >
+                  {{ WIDGET_META[id].width === 'full' ? t`Full` : t`Half` }}
+                </span>
+              </div>
+            </template>
+
+            <span v-else class="text-sm text-gray-400 px-1">
+              {{
+                isDragging ? t`Drop here to hide` : t`All widgets are active`
+              }}
+            </span>
+          </div>
+        </div>
+
+        <!-- ── 5. Footer ──────────────────────────────────────────────────── -->
+        <div class="flex justify-between items-center">
+          <button
+            class="
+              text-sm text-gray-500
+              hover:text-gray-700
+              dark:text-gray-400 dark:hover:text-gray-200
+            "
+            @click="resetToDefault"
+          >
+            {{ t`Reset to default` }}
+          </button>
+          <div class="flex gap-2">
+            <Button @click="$emit('close')">{{ t`Cancel` }}</Button>
+            <Button type="primary" :disabled="saving" @click="save">
+              {{ t`Save` }}
+            </Button>
+          </div>
         </div>
       </div>
-      </div><!-- end bottom band -->
+      <!-- end bottom band -->
     </div>
   </Modal>
 </template>
@@ -467,11 +659,9 @@ export default defineComponent({
   data() {
     return {
       // Ordered list of visible widget keys — the single source of truth.
-      localVisibleOrder: this.layout
-        .filter((c) => c.visible)
-        .map((c) => c.id) as WidgetKey[],
+      localVisibleOrder: this.layout.filter((c) => c.visible).map((c) => c.id),
 
-      activeProfile: this.currentProfile as DashboardProfile,
+      activeProfile: this.currentProfile,
 
       // Drag state
       draggingId: null as WidgetKey | null,

--- a/src/pages/Dashboard/DashboardCustomizePanel.vue
+++ b/src/pages/Dashboard/DashboardCustomizePanel.vue
@@ -1,17 +1,20 @@
 <template>
   <Modal :open-modal="true" @closemodal="$emit('close')">
-    <div class="p-6 w-96 flex flex-col gap-5">
-      <!-- Header -->
+    <div
+      class="p-6 flex flex-col gap-5 overflow-y-auto"
+      style="width: 580px; max-height: 88vh"
+    >
+      <!-- ── 1. Header ───────────────────────────────────────────────────── -->
       <div>
         <h2 class="text-base font-semibold dark:text-white">
           {{ t`Customize Dashboard` }}
         </h2>
         <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-          {{ t`Choose a preset or toggle widgets individually.` }}
+          {{ t`Drag widgets to reorder the layout. Drop into Hidden to remove.` }}
         </p>
       </div>
 
-      <!-- Preset profile cards -->
+      <!-- ── 2. Preset profile cards ────────────────────────────────────── -->
       <div>
         <p
           class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
@@ -38,73 +41,362 @@
         </div>
       </div>
 
-      <!-- Widget list -->
+      <!-- ── 3. Active Widgets canvas ───────────────────────────────────── -->
       <div>
         <p
           class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
         >
-          {{ t`Widgets` }}
+          {{ t`Active Widgets` }}
         </p>
-        <div class="flex flex-col gap-1.5">
+
+        <!-- Canvas drop target (fallback) -->
+        <div
+          class="border-2 border-gray-200 dark:border-gray-700 rounded-xl p-1.5"
+          @drop.prevent="onCanvasDrop"
+          @dragover.prevent
+        >
+          <!-- Empty: nothing visible, not dragging -->
           <div
-            v-for="(cfg, idx) in localLayout"
-            :key="cfg.id"
-            class="flex items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors"
-            :class="
-              cfg.visible
-                ? 'border-gray-200 dark:border-gray-700'
-                : 'border-dashed border-gray-200 dark:border-gray-750 opacity-50'
-            "
+            v-if="localVisibleOrder.length === 0 && !isDragging"
+            class="h-24 flex items-center justify-center text-sm text-gray-400"
           >
-            <!-- Visibility checkbox -->
-            <input
-              type="checkbox"
-              class="w-4 h-4 cursor-pointer accent-blue-500 shrink-0"
-              :checked="cfg.visible"
-              @change="toggleWidget(idx)"
-            />
-
-            <!-- Labels -->
-            <div class="flex-1 min-w-0">
-              <p class="text-sm font-medium dark:text-white truncate">
-                {{ WIDGET_META[cfg.id].label }}
-              </p>
-              <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
-                {{ WIDGET_META[cfg.id].description }}
-              </p>
-            </div>
-
-            <!-- Width badge -->
-            <span
-              class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 shrink-0"
-            >
-              {{
-                WIDGET_META[cfg.id].width === 'full' ? t`Full` : t`Half`
-              }}
-            </span>
-
-            <!-- Reorder buttons -->
-            <div class="flex flex-col gap-0.5 shrink-0">
-              <button
-                :disabled="idx === 0"
-                class="disabled:opacity-20 text-gray-400 hover:text-blue-500 dark:hover:text-blue-400"
-                @click="moveUp(idx)"
-              >
-                <FeatherIcon name="chevron-up" class="w-3.5 h-3.5" />
-              </button>
-              <button
-                :disabled="idx === localLayout.length - 1"
-                class="disabled:opacity-20 text-gray-400 hover:text-blue-500 dark:hover:text-blue-400"
-                @click="moveDown(idx)"
-              >
-                <FeatherIcon name="chevron-down" class="w-3.5 h-3.5" />
-              </button>
-            </div>
+            {{ t`No active widgets` }}
           </div>
+
+          <!-- Empty: nothing visible, dragging — full-area drop zone -->
+          <div
+            v-else-if="localVisibleOrder.length === 0 && isDragging"
+            class="h-24 flex items-center justify-center text-sm font-medium rounded-lg border-2 border-dashed border-blue-400 bg-blue-50 dark:bg-blue-950 text-blue-500 cursor-copy"
+            @dragenter.prevent="dropTargetIdx = 0"
+            @dragover.prevent
+            @drop.prevent.stop="commitDrop(0)"
+          >
+            {{ t`Drop here to add` }}
+          </div>
+
+          <!-- Populated canvas with interleaved drop zones and widget rows -->
+          <template v-else>
+            <!-- Drop zone BEFORE first row (index 0) -->
+            <div
+              class="mx-2 my-1 rounded-full overflow-hidden transition-all"
+              :class="isDragging ? 'h-8' : 'h-0'"
+              @dragenter.prevent="dropTargetIdx = 0"
+              @dragover.prevent
+              @drop.prevent.stop="commitDrop(0)"
+            >
+              <div
+                class="h-full border-2 border-dashed rounded-full flex items-center justify-center text-xs transition-colors"
+                :class="
+                  dropTargetIdx === 0
+                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-500'
+                    : 'border-gray-200 dark:border-gray-700 text-gray-400'
+                "
+              >
+                <span v-if="dropTargetIdx === 0">{{ t`Drop here` }}</span>
+              </div>
+            </div>
+
+            <template v-for="row in previewRows" :key="row.ids.join('-')">
+              <!-- ── FULL row ─────────────────────────────────────────── -->
+              <div v-if="row.type === 'full'" class="p-1">
+                <div
+                  draggable="true"
+                  class="flex items-center gap-2 border rounded-lg px-3 py-2.5 select-none transition-all bg-white dark:bg-gray-800"
+                  :class="
+                    draggingId === row.ids[0]
+                      ? 'opacity-40 cursor-grabbing border-blue-300'
+                      : 'cursor-grab border-gray-200 dark:border-gray-700 hover:border-blue-300 hover:shadow-sm'
+                  "
+                  @dragstart="startDrag(row.ids[0], $event)"
+                  @dragend="endDrag"
+                  @dragover.prevent
+                >
+                  <FeatherIcon
+                    name="menu"
+                    class="w-4 h-4 text-gray-300 shrink-0"
+                  />
+                  <FeatherIcon
+                    :name="WIDGET_META[row.ids[0]].icon"
+                    class="w-4 h-4 text-gray-400 shrink-0"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium dark:text-white truncate">
+                      {{ WIDGET_META[row.ids[0]].label }}
+                    </p>
+                    <p
+                      class="text-xs text-gray-500 dark:text-gray-400 truncate"
+                    >
+                      {{ WIDGET_META[row.ids[0]].description }}
+                    </p>
+                  </div>
+                  <span
+                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                  >
+                    {{
+                      WIDGET_META[row.ids[0]].width === 'full'
+                        ? t`Full`
+                        : t`Half`
+                    }}
+                  </span>
+                  <button
+                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    @click="hideWidget(row.ids[0])"
+                  >
+                    <FeatherIcon name="x" class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+
+              <!-- ── HALF-PAIR row ───────────────────────────────────── -->
+              <div v-else-if="row.type === 'half-pair'" class="flex gap-1.5 p-1">
+                <!-- Left card -->
+                <div
+                  class="flex-1"
+                  draggable="true"
+                  :class="[
+                    'flex items-center gap-2 border rounded-lg px-3 py-2.5 select-none transition-all bg-white dark:bg-gray-800',
+                    draggingId === row.ids[0]
+                      ? 'opacity-40 cursor-grabbing border-blue-300'
+                      : 'cursor-grab border-gray-200 dark:border-gray-700 hover:border-blue-300 hover:shadow-sm',
+                  ]"
+                  @dragstart="startDrag(row.ids[0], $event)"
+                  @dragend="endDrag"
+                  @dragover.prevent
+                >
+                  <FeatherIcon
+                    name="menu"
+                    class="w-4 h-4 text-gray-300 shrink-0"
+                  />
+                  <FeatherIcon
+                    :name="WIDGET_META[row.ids[0]].icon"
+                    class="w-4 h-4 text-gray-400 shrink-0"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium dark:text-white truncate">
+                      {{ WIDGET_META[row.ids[0]].label }}
+                    </p>
+                    <!-- description intentionally omitted in half-pair to save space -->
+                  </div>
+                  <span
+                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                  >
+                    {{
+                      WIDGET_META[row.ids[0]].width === 'full'
+                        ? t`Full`
+                        : t`Half`
+                    }}
+                  </span>
+                  <button
+                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    @click="hideWidget(row.ids[0])"
+                  >
+                    <FeatherIcon name="x" class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+
+                <!-- Right card -->
+                <div
+                  class="flex-1"
+                  draggable="true"
+                  :class="[
+                    'flex items-center gap-2 border rounded-lg px-3 py-2.5 select-none transition-all bg-white dark:bg-gray-800',
+                    draggingId === row.ids[1]
+                      ? 'opacity-40 cursor-grabbing border-blue-300'
+                      : 'cursor-grab border-gray-200 dark:border-gray-700 hover:border-blue-300 hover:shadow-sm',
+                  ]"
+                  @dragstart="startDrag(row.ids[1], $event)"
+                  @dragend="endDrag"
+                  @dragover.prevent
+                >
+                  <FeatherIcon
+                    name="menu"
+                    class="w-4 h-4 text-gray-300 shrink-0"
+                  />
+                  <FeatherIcon
+                    :name="WIDGET_META[row.ids[1]].icon"
+                    class="w-4 h-4 text-gray-400 shrink-0"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium dark:text-white truncate">
+                      {{ WIDGET_META[row.ids[1]].label }}
+                    </p>
+                    <!-- description intentionally omitted in half-pair to save space -->
+                  </div>
+                  <span
+                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                  >
+                    {{
+                      WIDGET_META[row.ids[1]].width === 'full'
+                        ? t`Full`
+                        : t`Half`
+                    }}
+                  </span>
+                  <button
+                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    @click="hideWidget(row.ids[1])"
+                  >
+                    <FeatherIcon name="x" class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+
+              <!-- ── HALF-SOLO row ───────────────────────────────────── -->
+              <div v-else class="flex gap-1.5 p-1">
+                <!-- Card -->
+                <div
+                  class="flex-1"
+                  draggable="true"
+                  :class="[
+                    'flex items-center gap-2 border rounded-lg px-3 py-2.5 select-none transition-all bg-white dark:bg-gray-800',
+                    draggingId === row.ids[0]
+                      ? 'opacity-40 cursor-grabbing border-blue-300'
+                      : 'cursor-grab border-gray-200 dark:border-gray-700 hover:border-blue-300 hover:shadow-sm',
+                  ]"
+                  @dragstart="startDrag(row.ids[0], $event)"
+                  @dragend="endDrag"
+                  @dragover.prevent
+                >
+                  <FeatherIcon
+                    name="menu"
+                    class="w-4 h-4 text-gray-300 shrink-0"
+                  />
+                  <FeatherIcon
+                    :name="WIDGET_META[row.ids[0]].icon"
+                    class="w-4 h-4 text-gray-400 shrink-0"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium dark:text-white truncate">
+                      {{ WIDGET_META[row.ids[0]].label }}
+                    </p>
+                    <p
+                      class="text-xs text-gray-500 dark:text-gray-400 truncate"
+                    >
+                      {{ WIDGET_META[row.ids[0]].description }}
+                    </p>
+                  </div>
+                  <span
+                    class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400 shrink-0"
+                  >
+                    {{
+                      WIDGET_META[row.ids[0]].width === 'full'
+                        ? t`Full`
+                        : t`Half`
+                    }}
+                  </span>
+                  <button
+                    class="text-gray-300 hover:text-red-400 transition-colors shrink-0"
+                    @click="hideWidget(row.ids[0])"
+                  >
+                    <FeatherIcon name="x" class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+
+                <!-- Pairing placeholder — also a live drop zone at row.endIdx -->
+                <div
+                  class="flex-1 border-2 border-dashed rounded-lg flex items-center justify-center text-xs py-2.5 transition-colors"
+                  :class="
+                    dropTargetIdx === row.endIdx
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-500 cursor-copy'
+                      : isDragging
+                        ? 'border-blue-300 dark:border-blue-800 text-blue-400 dark:text-blue-600 cursor-copy'
+                        : 'border-gray-200 dark:border-gray-700 text-gray-400'
+                  "
+                  @dragenter.prevent="dropTargetIdx = row.endIdx"
+                  @dragover.prevent
+                  @drop.prevent.stop="commitDrop(row.endIdx)"
+                >
+                  {{
+                    dropTargetIdx === row.endIdx
+                      ? t`Drop to pair`
+                      : t`Pair with a half widget`
+                  }}
+                </div>
+              </div>
+
+              <!-- Drop zone AFTER this row -->
+              <div
+                class="mx-2 my-1 rounded-full overflow-hidden transition-all"
+                :class="isDragging ? 'h-8' : 'h-0'"
+                @dragenter.prevent="dropTargetIdx = row.endIdx"
+                @dragover.prevent
+                @drop.prevent.stop="commitDrop(row.endIdx)"
+              >
+                <div
+                  class="h-full border-2 border-dashed rounded-full flex items-center justify-center text-xs transition-colors"
+                  :class="
+                    dropTargetIdx === row.endIdx
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-500'
+                      : 'border-gray-200 dark:border-gray-700 text-gray-400'
+                  "
+                >
+                  <span v-if="dropTargetIdx === row.endIdx">
+                    {{ t`Drop here` }}
+                  </span>
+                </div>
+              </div>
+            </template>
+          </template>
         </div>
       </div>
 
-      <!-- Footer -->
+      <!-- ── 4. Hidden Widgets tray ─────────────────────────────────────── -->
+      <div>
+        <p
+          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
+        >
+          {{ t`Hidden` }}
+        </p>
+
+        <div
+          class="border-2 border-dashed rounded-xl p-2 min-h-14 flex flex-wrap gap-2 items-center transition-colors"
+          :class="
+            isDragging && dragOverHidden
+              ? 'border-red-400 dark:border-red-700 bg-red-50 dark:bg-red-950'
+              : 'border-gray-200 dark:border-gray-700'
+          "
+          @dragenter.prevent="dragOverHidden = true"
+          @dragover.prevent="dragOverHidden = true"
+          @dragleave="dragOverHidden = false"
+          @drop.prevent.stop="onHiddenDrop"
+        >
+          <template v-if="hiddenOrder.length > 0">
+            <div
+              v-for="id in hiddenOrder"
+              :key="id"
+              draggable="true"
+              class="flex items-center gap-1.5 border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-1.5 cursor-grab select-none bg-white dark:bg-gray-800 transition-all"
+              :class="
+                draggingId === id
+                  ? 'opacity-40 cursor-grabbing border-blue-300'
+                  : 'hover:border-blue-300 hover:shadow-sm'
+              "
+              @dragstart="startDrag(id, $event)"
+              @dragend="endDrag"
+            >
+              <FeatherIcon
+                :name="WIDGET_META[id].icon"
+                class="w-3.5 h-3.5 text-gray-400"
+              />
+              <span class="text-sm font-medium dark:text-white">
+                {{ WIDGET_META[id].label }}
+              </span>
+              <span
+                class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-750 text-gray-500 dark:text-gray-400"
+              >
+                {{ WIDGET_META[id].width === 'full' ? t`Full` : t`Half` }}
+              </span>
+            </div>
+          </template>
+
+          <span v-else class="text-sm text-gray-400 px-1">
+            {{
+              isDragging ? t`Drop here to hide` : t`All widgets are active`
+            }}
+          </span>
+        </div>
+      </div>
+
+      <!-- ── 5. Footer ──────────────────────────────────────────────────── -->
       <div
         class="flex justify-between items-center pt-2 border-t dark:border-gray-700"
       >
@@ -133,13 +425,18 @@ import Modal from 'src/components/Modal.vue';
 import { fyo } from 'src/initFyo';
 import { defineComponent, PropType } from 'vue';
 import {
+  ALL_WIDGET_KEYS,
+  applyWidgetDrop,
+  buildPreviewRows,
   DashboardProfile,
   DEFAULT_LAYOUT,
+  PreviewRow,
   PRESET_PROFILES,
   PROFILE_LAYOUTS,
   profileToLayout,
   WIDGET_META,
   WidgetConfig,
+  WidgetKey,
 } from './types';
 
 export default defineComponent({
@@ -161,58 +458,137 @@ export default defineComponent({
 
   data() {
     return {
-      localLayout: this.layout.map((c) => ({ ...c })) as WidgetConfig[],
+      // Ordered list of visible widget keys — the single source of truth.
+      localVisibleOrder: this.layout
+        .filter((c) => c.visible)
+        .map((c) => c.id) as WidgetKey[],
+
       activeProfile: this.currentProfile as DashboardProfile,
+
+      // Drag state
+      draggingId: null as WidgetKey | null,
+      isDragging: false,
+      dropTargetIdx: null as number | null,
+      dragOverHidden: false,
+
       saving: false,
+
+      // Expose constants to the template
       WIDGET_META,
       PRESET_PROFILES,
       PROFILE_LAYOUTS,
     };
   },
 
+  computed: {
+    /** All widget keys that are NOT in localVisibleOrder. */
+    hiddenOrder(): WidgetKey[] {
+      const visibleSet = new Set(this.localVisibleOrder);
+      return ALL_WIDGET_KEYS.filter((id) => !visibleSet.has(id));
+    },
+
+    /** Rows for the layout preview, built from the shared pure function. */
+    previewRows(): PreviewRow[] {
+      return buildPreviewRows(this.localVisibleOrder);
+    },
+
+    /** Final layout array that will be persisted on save. */
+    computedLayout(): WidgetConfig[] {
+      return [
+        ...this.localVisibleOrder.map((id) => ({ id, visible: true })),
+        ...this.hiddenOrder.map((id) => ({ id, visible: false })),
+      ];
+    },
+  },
+
   methods: {
-    toggleWidget(idx: number) {
-      const cfg = this.localLayout[idx];
-      this.localLayout[idx] = { ...cfg, visible: !cfg.visible };
+    // ── Drag lifecycle ─────────────────────────────────────────────────────
+
+    startDrag(id: WidgetKey, event: DragEvent) {
+      this.draggingId = id;
+      this.isDragging = true;
+      event.dataTransfer?.setData('text/plain', id);
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = 'move';
+      }
+    },
+
+    endDrag() {
+      this.draggingId = null;
+      this.isDragging = false;
+      this.dropTargetIdx = null;
+      this.dragOverHidden = false;
+    },
+
+    // ── Drop handlers ──────────────────────────────────────────────────────
+
+    /** Insert draggingId at targetIdx, delegating to the pure helper. */
+    commitDrop(targetIdx: number) {
+      if (!this.draggingId) return;
+      this.localVisibleOrder = applyWidgetDrop(
+        this.localVisibleOrder,
+        this.draggingId,
+        targetIdx
+      );
+      this.activeProfile = 'Custom';
+      this.endDrag();
+    },
+
+    /** Drop on the hidden tray — remove from visible order. */
+    onHiddenDrop() {
+      if (!this.draggingId) return;
+      this.hideWidget(this.draggingId);
+      this.endDrag();
+    },
+
+    /**
+     * Fallback canvas drop (fires only when NOT caught by a specific zone,
+     * because zones use @drop.stop). Appends hidden widgets to the end.
+     */
+    onCanvasDrop() {
+      if (!this.draggingId) return;
+      if (!this.localVisibleOrder.includes(this.draggingId)) {
+        this.localVisibleOrder = [...this.localVisibleOrder, this.draggingId];
+        this.activeProfile = 'Custom';
+      }
+      this.endDrag();
+    },
+
+    // ── Widget visibility ──────────────────────────────────────────────────
+
+    hideWidget(id: WidgetKey) {
+      this.localVisibleOrder = this.localVisibleOrder.filter((k) => k !== id);
       this.activeProfile = 'Custom';
     },
 
-    moveUp(idx: number) {
-      if (idx === 0) return;
-      const copy = [...this.localLayout];
-      [copy[idx - 1], copy[idx]] = [copy[idx], copy[idx - 1]];
-      this.localLayout = copy;
-      this.activeProfile = 'Custom';
-    },
-
-    moveDown(idx: number) {
-      if (idx === this.localLayout.length - 1) return;
-      const copy = [...this.localLayout];
-      [copy[idx], copy[idx + 1]] = [copy[idx + 1], copy[idx]];
-      this.localLayout = copy;
-      this.activeProfile = 'Custom';
-    },
+    // ── Profile presets ────────────────────────────────────────────────────
 
     applyProfile(profile: Exclude<DashboardProfile, 'Custom'>) {
       this.activeProfile = profile;
-      this.localLayout = profileToLayout(profile);
+      const layout = profileToLayout(profile);
+      this.localVisibleOrder = layout.filter((c) => c.visible).map((c) => c.id);
     },
 
     resetToDefault() {
+      this.localVisibleOrder = DEFAULT_LAYOUT.filter((c) => c.visible).map(
+        (c) => c.id
+      );
       this.activeProfile = 'Custom';
-      this.localLayout = DEFAULT_LAYOUT.map((c) => ({ ...c }));
     },
+
+    // ── Persistence ────────────────────────────────────────────────────────
 
     async save() {
       this.saving = true;
       try {
+        const finalLayout = this.computedLayout;
         const doc = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
         await doc.setMultiple({
-          widgetLayout: JSON.stringify(this.localLayout),
+          widgetLayout: JSON.stringify(finalLayout),
           activeProfile: this.activeProfile,
         });
         await doc.sync();
-        this.$emit('saved', [...this.localLayout], this.activeProfile);
+        this.$emit('saved', finalLayout, this.activeProfile);
         this.$emit('close');
       } finally {
         this.saving = false;

--- a/src/pages/Dashboard/DashboardCustomizePanel.vue
+++ b/src/pages/Dashboard/DashboardCustomizePanel.vue
@@ -1,0 +1,223 @@
+<template>
+  <Modal :open-modal="true" @closemodal="$emit('close')">
+    <div class="p-6 w-96 flex flex-col gap-5">
+      <!-- Header -->
+      <div>
+        <h2 class="text-base font-semibold dark:text-white">
+          {{ t`Customize Dashboard` }}
+        </h2>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+          {{ t`Choose a preset or toggle widgets individually.` }}
+        </p>
+      </div>
+
+      <!-- Preset profile cards -->
+      <div>
+        <p
+          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
+        >
+          {{ t`Presets` }}
+        </p>
+        <div class="grid grid-cols-3 gap-2">
+          <button
+            v-for="profile in PRESET_PROFILES"
+            :key="profile"
+            class="rounded-lg border px-3 py-2 text-sm text-left transition-colors"
+            :class="
+              activeProfile === profile
+                ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300'
+                : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:text-gray-300 dark:hover:border-gray-500'
+            "
+            @click="applyProfile(profile)"
+          >
+            <div class="font-medium leading-snug">{{ profile }}</div>
+            <div class="text-xs text-gray-400 mt-0.5">
+              {{ PROFILE_LAYOUTS[profile].length }}&nbsp;{{ t`widgets` }}
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <!-- Widget list -->
+      <div>
+        <p
+          class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2"
+        >
+          {{ t`Widgets` }}
+        </p>
+        <div class="flex flex-col gap-1.5">
+          <div
+            v-for="(cfg, idx) in localLayout"
+            :key="cfg.id"
+            class="flex items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors"
+            :class="
+              cfg.visible
+                ? 'border-gray-200 dark:border-gray-700'
+                : 'border-dashed border-gray-200 dark:border-gray-750 opacity-50'
+            "
+          >
+            <!-- Visibility checkbox -->
+            <input
+              type="checkbox"
+              class="w-4 h-4 cursor-pointer accent-blue-500 shrink-0"
+              :checked="cfg.visible"
+              @change="toggleWidget(idx)"
+            />
+
+            <!-- Labels -->
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium dark:text-white truncate">
+                {{ WIDGET_META[cfg.id].label }}
+              </p>
+              <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
+                {{ WIDGET_META[cfg.id].description }}
+              </p>
+            </div>
+
+            <!-- Width badge -->
+            <span
+              class="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 shrink-0"
+            >
+              {{
+                WIDGET_META[cfg.id].width === 'full' ? t`Full` : t`Half`
+              }}
+            </span>
+
+            <!-- Reorder buttons -->
+            <div class="flex flex-col gap-0.5 shrink-0">
+              <button
+                :disabled="idx === 0"
+                class="disabled:opacity-20 text-gray-400 hover:text-blue-500 dark:hover:text-blue-400"
+                @click="moveUp(idx)"
+              >
+                <FeatherIcon name="chevron-up" class="w-3.5 h-3.5" />
+              </button>
+              <button
+                :disabled="idx === localLayout.length - 1"
+                class="disabled:opacity-20 text-gray-400 hover:text-blue-500 dark:hover:text-blue-400"
+                @click="moveDown(idx)"
+              >
+                <FeatherIcon name="chevron-down" class="w-3.5 h-3.5" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div
+        class="flex justify-between items-center pt-2 border-t dark:border-gray-700"
+      >
+        <button
+          class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          @click="resetToDefault"
+        >
+          {{ t`Reset to default` }}
+        </button>
+        <div class="flex gap-2">
+          <Button @click="$emit('close')">{{ t`Cancel` }}</Button>
+          <Button type="primary" :disabled="saving" @click="save">
+            {{ t`Save` }}
+          </Button>
+        </div>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script lang="ts">
+import { ModelNameEnum } from 'models/types';
+import Button from 'src/components/Button.vue';
+import FeatherIcon from 'src/components/FeatherIcon.vue';
+import Modal from 'src/components/Modal.vue';
+import { fyo } from 'src/initFyo';
+import { defineComponent, PropType } from 'vue';
+import {
+  DashboardProfile,
+  DEFAULT_LAYOUT,
+  PRESET_PROFILES,
+  PROFILE_LAYOUTS,
+  profileToLayout,
+  WIDGET_META,
+  WidgetConfig,
+} from './types';
+
+export default defineComponent({
+  name: 'DashboardCustomizePanel',
+  components: { Modal, Button, FeatherIcon },
+
+  props: {
+    layout: {
+      type: Array as PropType<WidgetConfig[]>,
+      required: true,
+    },
+    currentProfile: {
+      type: String as PropType<DashboardProfile>,
+      default: 'Custom',
+    },
+  },
+
+  emits: ['close', 'saved'],
+
+  data() {
+    return {
+      localLayout: this.layout.map((c) => ({ ...c })) as WidgetConfig[],
+      activeProfile: this.currentProfile as DashboardProfile,
+      saving: false,
+      WIDGET_META,
+      PRESET_PROFILES,
+      PROFILE_LAYOUTS,
+    };
+  },
+
+  methods: {
+    toggleWidget(idx: number) {
+      const cfg = this.localLayout[idx];
+      this.localLayout[idx] = { ...cfg, visible: !cfg.visible };
+      this.activeProfile = 'Custom';
+    },
+
+    moveUp(idx: number) {
+      if (idx === 0) return;
+      const copy = [...this.localLayout];
+      [copy[idx - 1], copy[idx]] = [copy[idx], copy[idx - 1]];
+      this.localLayout = copy;
+      this.activeProfile = 'Custom';
+    },
+
+    moveDown(idx: number) {
+      if (idx === this.localLayout.length - 1) return;
+      const copy = [...this.localLayout];
+      [copy[idx], copy[idx + 1]] = [copy[idx + 1], copy[idx]];
+      this.localLayout = copy;
+      this.activeProfile = 'Custom';
+    },
+
+    applyProfile(profile: Exclude<DashboardProfile, 'Custom'>) {
+      this.activeProfile = profile;
+      this.localLayout = profileToLayout(profile);
+    },
+
+    resetToDefault() {
+      this.activeProfile = 'Custom';
+      this.localLayout = DEFAULT_LAYOUT.map((c) => ({ ...c }));
+    },
+
+    async save() {
+      this.saving = true;
+      try {
+        const doc = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
+        await doc.setMultiple({
+          widgetLayout: JSON.stringify(this.localLayout),
+          activeProfile: this.activeProfile,
+        });
+        await doc.sync();
+        this.$emit('saved', [...this.localLayout], this.activeProfile);
+        this.$emit('close');
+      } finally {
+        this.saving = false;
+      }
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/GrossMargin.vue
+++ b/src/pages/Dashboard/GrossMargin.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="flex flex-col h-full">
+    <SectionHeader>
+      <template #title>{{ t`Gross Margin` }}</template>
+      <template #action>
+        <PeriodSelector
+          :value="period"
+          :options="periodOptions"
+          @change="(v) => (period = v)"
+        />
+      </template>
+    </SectionHeader>
+
+    <div v-if="income > 0 || cogs > 0" class="mt-4 flex flex-col gap-4">
+      <!-- Big % number -->
+      <div class="flex flex-col items-center py-3">
+        <p
+          class="text-5xl font-bold tabular-nums"
+          :class="
+            marginPct >= 50
+              ? 'text-green-500 dark:text-green-400'
+              : marginPct >= 20
+              ? 'text-blue-500 dark:text-blue-400'
+              : 'text-pink-500 dark:text-pink-400'
+          "
+        >
+          {{ marginPct }}<span class="text-2xl">%</span>
+        </p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          {{ t`Gross Margin` }}
+        </p>
+      </div>
+
+      <!-- Revenue / COGS row -->
+      <div
+        class="flex justify-between border-t dark:border-gray-800 pt-3 text-sm"
+      >
+        <div>
+          <p class="text-gray-500 dark:text-gray-400">{{ t`Revenue` }}</p>
+          <p class="font-semibold dark:text-white mt-0.5">
+            {{ fyo.format(income, 'Currency') }}
+          </p>
+        </div>
+        <div class="text-right">
+          <p class="text-gray-500 dark:text-gray-400">{{ t`Cost of Goods Sold` }}</p>
+          <p class="font-semibold dark:text-white mt-0.5">
+            {{ fyo.format(cogs, 'Currency') }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="flex-1 flex items-center justify-center py-10"
+    >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t`No transactions yet` }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { fyo } from 'src/initFyo';
+import { getDatesAndPeriodList } from 'src/utils/misc';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import PeriodSelector from './PeriodSelector.vue';
+import SectionHeader from './SectionHeader.vue';
+
+export default defineComponent({
+  name: 'GrossMargin',
+  components: { SectionHeader, PeriodSelector },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      income: 0 as number,
+      cogs: 0 as number,
+      periodOptions: ['This Year', 'This Quarter', 'This Month', 'YTD'],
+    };
+  },
+  computed: {
+    marginPct(): number {
+      if (this.income <= 0) return 0;
+      return Math.round(((this.income - this.cogs) / this.income) * 100);
+    },
+  },
+  methods: {
+    async setData() {
+      const { fromDate, toDate } = getDatesAndPeriodList(this.period);
+      const result = await fyo.db.getGrossMargin(
+        fromDate.toISO(),
+        toDate.toISO()
+      );
+      this.income = result?.income ?? 0;
+      this.cogs = result?.cogs ?? 0;
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/GrossMargin.vue
+++ b/src/pages/Dashboard/GrossMargin.vue
@@ -42,7 +42,9 @@
           </p>
         </div>
         <div class="text-right">
-          <p class="text-gray-500 dark:text-gray-400">{{ t`Cost of Goods Sold` }}</p>
+          <p class="text-gray-500 dark:text-gray-400">
+            {{ t`Cost of Goods Sold` }}
+          </p>
           <p class="font-semibold dark:text-white mt-0.5">
             {{ fyo.format(cogs, 'Currency') }}
           </p>
@@ -50,10 +52,7 @@
       </div>
     </div>
 
-    <div
-      v-else
-      class="flex-1 flex items-center justify-center py-10"
-    >
+    <div v-else class="flex-1 flex items-center justify-center py-10">
       <span class="text-sm text-gray-500 dark:text-gray-400">
         {{ t`No transactions yet` }}
       </span>
@@ -70,6 +69,7 @@ import BaseDashboardChart from './BaseDashboardChart.vue';
 import PeriodSelector from './PeriodSelector.vue';
 import SectionHeader from './SectionHeader.vue';
 
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 export default defineComponent({
   name: 'GrossMargin',
   components: { SectionHeader, PeriodSelector },

--- a/src/pages/Dashboard/GrossMargin.vue
+++ b/src/pages/Dashboard/GrossMargin.vue
@@ -61,7 +61,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { fyo } from 'src/initFyo';
 import { getDatesAndPeriodList } from 'src/utils/misc';
 import { defineComponent } from 'vue';

--- a/src/pages/Dashboard/InvoiceDrafts.vue
+++ b/src/pages/Dashboard/InvoiceDrafts.vue
@@ -59,7 +59,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { ModelNameEnum } from 'models/types';
 import { fyo } from 'src/initFyo';
 import { routeTo } from 'src/utils/ui';

--- a/src/pages/Dashboard/InvoiceDrafts.vue
+++ b/src/pages/Dashboard/InvoiceDrafts.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="flex flex-col h-full">
+    <SectionHeader>
+      <template #title>{{ t`Draft Invoices` }}</template>
+      <template #action>
+        <button
+          v-if="count > 0"
+          class="text-xs text-blue-500 dark:text-blue-400 hover:underline font-medium"
+          @click="openDraftList"
+        >
+          {{ t`View All` }}
+        </button>
+      </template>
+    </SectionHeader>
+
+    <div v-if="count > 0" class="mt-4 flex flex-1 items-center justify-center gap-0">
+      <!-- Count stat -->
+      <div class="flex flex-col items-center flex-1 py-6">
+        <p class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white">
+          {{ count }}
+        </p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          {{ t`Unsent Invoices` }}
+        </p>
+      </div>
+
+      <!-- Vertical divider -->
+      <div class="w-px self-stretch bg-gray-200 dark:bg-gray-700 my-6" />
+
+      <!-- Total value stat -->
+      <div class="flex flex-col items-center flex-1 py-6">
+        <p class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white">
+          {{ fyo.format(totalValue, 'Currency') }}
+        </p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          {{ t`Total Value` }}
+        </p>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="flex-1 flex items-center justify-center py-10"
+    >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t`No draft invoices` }} ✓
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { ModelNameEnum } from 'models/types';
+import { fyo } from 'src/initFyo';
+import { routeTo } from 'src/utils/ui';
+import { safeParseFloat } from 'utils/index';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import SectionHeader from './SectionHeader.vue';
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+export default defineComponent({
+  name: 'InvoiceDrafts',
+  components: { SectionHeader },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      count: 0 as number,
+      totalValue: 0 as number,
+    };
+  },
+  methods: {
+    async setData() {
+      const raw = await fyo.db.getAllRaw(ModelNameEnum.SalesInvoice, {
+        fields: ['name', 'baseGrandTotal'],
+        filters: { submitted: false, cancelled: false },
+      });
+
+      this.count = raw.length;
+      this.totalValue = raw.reduce(
+        (sum, r) => sum + safeParseFloat(r.baseGrandTotal),
+        0
+      );
+    },
+    async openDraftList() {
+      await routeTo({
+        path: `/list/${ModelNameEnum.SalesInvoice}/Draft Invoices`,
+        query: {
+          filters: JSON.stringify({ submitted: false, cancelled: false }),
+        },
+      });
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/InvoiceDrafts.vue
+++ b/src/pages/Dashboard/InvoiceDrafts.vue
@@ -15,7 +15,7 @@
 
     <div v-if="count > 0" class="mt-4 flex flex-1 items-center justify-center gap-0">
       <!-- Count stat -->
-      <div class="flex flex-col items-center flex-1 py-6">
+      <div class="flex flex-col items-center flex-1 py-3">
         <p class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white">
           {{ count }}
         </p>
@@ -25,10 +25,10 @@
       </div>
 
       <!-- Vertical divider -->
-      <div class="w-px self-stretch bg-gray-200 dark:bg-gray-700 my-6" />
+      <div class="w-px self-stretch bg-gray-200 dark:bg-gray-700 my-3" />
 
       <!-- Total value stat -->
-      <div class="flex flex-col items-center flex-1 py-6">
+      <div class="flex flex-col items-center flex-1 py-3">
         <p class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white">
           {{ fyo.format(totalValue, 'Currency') }}
         </p>

--- a/src/pages/Dashboard/InvoiceDrafts.vue
+++ b/src/pages/Dashboard/InvoiceDrafts.vue
@@ -5,7 +5,12 @@
       <template #action>
         <button
           v-if="count > 0"
-          class="text-xs text-blue-500 dark:text-blue-400 hover:underline font-medium"
+          class="
+            text-xs text-blue-500
+            dark:text-blue-400
+            hover:underline
+            font-medium
+          "
           @click="openDraftList"
         >
           {{ t`View All` }}
@@ -13,10 +18,15 @@
       </template>
     </SectionHeader>
 
-    <div v-if="count > 0" class="mt-4 flex flex-1 items-center justify-center gap-0">
+    <div
+      v-if="count > 0"
+      class="mt-4 flex flex-1 items-center justify-center gap-0"
+    >
       <!-- Count stat -->
       <div class="flex flex-col items-center flex-1 py-3">
-        <p class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white">
+        <p
+          class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white"
+        >
           {{ count }}
         </p>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
@@ -29,7 +39,9 @@
 
       <!-- Total value stat -->
       <div class="flex flex-col items-center flex-1 py-3">
-        <p class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white">
+        <p
+          class="text-4xl font-bold tabular-nums text-gray-900 dark:text-white"
+        >
           {{ fyo.format(totalValue, 'Currency') }}
         </p>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
@@ -38,10 +50,7 @@
       </div>
     </div>
 
-    <div
-      v-else
-      class="flex-1 flex items-center justify-center py-10"
-    >
+    <div v-else class="flex-1 flex items-center justify-center py-10">
       <span class="text-sm text-gray-500 dark:text-gray-400">
         {{ t`No draft invoices` }} ✓
       </span>

--- a/src/pages/Dashboard/OverdueInvoices.vue
+++ b/src/pages/Dashboard/OverdueInvoices.vue
@@ -67,7 +67,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { DateTime } from 'luxon';
 import { ModelNameEnum } from 'models/types';
 import { fyo } from 'src/initFyo';

--- a/src/pages/Dashboard/OverdueInvoices.vue
+++ b/src/pages/Dashboard/OverdueInvoices.vue
@@ -3,12 +3,13 @@
     <SectionHeader>
       <template #title>{{ t`Overdue Invoices` }}</template>
       <template #action>
-        <span
+        <button
           v-if="overdueList.length"
-          class="text-xs font-semibold px-2 py-0.5 rounded-full bg-pink-100 dark:bg-pink-900 text-pink-600 dark:text-pink-300"
+          class="text-xs text-blue-500 dark:text-blue-400 hover:underline font-medium"
+          @click="openInvoiceList"
         >
-          {{ overdueList.length }}
-        </span>
+          {{ t`View All` }}
+        </button>
       </template>
     </SectionHeader>
 
@@ -77,7 +78,7 @@ export default defineComponent({
   },
   methods: {
     async setData() {
-      const cutoff = DateTime.now().minus({ days: 30 });
+      const cutoff = DateTime.utc().minus({ days: 30 });
       const raw = await fyo.db.getAllRaw(ModelNameEnum.SalesInvoice, {
         fields: ['name', 'party', 'date', 'outstandingAmount'],
         filters: {
@@ -86,11 +87,11 @@ export default defineComponent({
           date: ['<', cutoff.toISO()],
         },
         orderBy: 'date',
-        order: 'asc',
-        limit: 100,
+        order: 'desc',
+        limit: 5,
       });
 
-      const now = DateTime.now();
+      const now = DateTime.utc();
       this.overdueList = raw
         .map((r) => ({
           name: r.name as string,
@@ -106,6 +107,17 @@ export default defineComponent({
     },
     async openInvoice(name: string) {
       await routeTo(`/edit/${ModelNameEnum.SalesInvoice}/${name}`);
+    },
+    async openInvoiceList() {
+      const filters = JSON.stringify({
+        submitted: 1,
+        cancelled: 0,
+        outstandingAmount: ['>', 0],
+      });
+      await routeTo({
+        path: `/list/${ModelNameEnum.SalesInvoice}/Overdue Invoices`,
+        query: { filters },
+      });
     },
   },
 });

--- a/src/pages/Dashboard/OverdueInvoices.vue
+++ b/src/pages/Dashboard/OverdueInvoices.vue
@@ -5,7 +5,12 @@
       <template #action>
         <button
           v-if="overdueList.length"
-          class="text-xs text-blue-500 dark:text-blue-400 hover:underline font-medium"
+          class="
+            text-xs text-blue-500
+            dark:text-blue-400
+            hover:underline
+            font-medium
+          "
           @click="openInvoiceList"
         >
           {{ t`View All` }}
@@ -17,12 +22,27 @@
       <div
         v-for="inv in overdueList"
         :key="inv.name"
-        class="flex items-center justify-between py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded px-1 -mx-1"
+        class="
+          flex
+          items-center
+          justify-between
+          py-2
+          cursor-pointer
+          hover:bg-gray-50
+          dark:hover:bg-gray-800
+          rounded
+          px-1
+          -mx-1
+        "
         @click="openInvoice(inv.name)"
       >
         <div class="min-w-0">
-          <p class="text-sm font-medium dark:text-white truncate">{{ inv.name }}</p>
-          <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ inv.party }}</p>
+          <p class="text-sm font-medium dark:text-white truncate">
+            {{ inv.name }}
+          </p>
+          <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {{ inv.party }}
+          </p>
         </div>
         <div class="text-right shrink-0 ms-3">
           <p class="text-sm font-semibold text-pink-500 dark:text-pink-400">
@@ -100,7 +120,9 @@ export default defineComponent({
           outstandingAmount: safeParseFloat(r.outstandingAmount),
           daysOverdue: Math.max(
             0,
-            Math.floor(now.diff(DateTime.fromISO(r.date as string), 'days').days)
+            Math.floor(
+              now.diff(DateTime.fromISO(r.date as string), 'days').days
+            )
           ),
         }))
         .filter((r) => r.outstandingAmount > 0);

--- a/src/pages/Dashboard/OverdueInvoices.vue
+++ b/src/pages/Dashboard/OverdueInvoices.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="flex flex-col w-full p-4">
+    <SectionHeader>
+      <template #title>{{ t`Overdue Invoices` }}</template>
+      <template #action>
+        <span
+          v-if="overdueList.length"
+          class="text-xs font-semibold px-2 py-0.5 rounded-full bg-pink-100 dark:bg-pink-900 text-pink-600 dark:text-pink-300"
+        >
+          {{ overdueList.length }}
+        </span>
+      </template>
+    </SectionHeader>
+
+    <div class="mt-3 flex flex-col divide-y dark:divide-gray-800">
+      <div
+        v-for="inv in overdueList"
+        :key="inv.name"
+        class="flex items-center justify-between py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded px-1 -mx-1"
+        @click="openInvoice(inv.name)"
+      >
+        <div class="min-w-0">
+          <p class="text-sm font-medium dark:text-white truncate">{{ inv.name }}</p>
+          <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ inv.party }}</p>
+        </div>
+        <div class="text-right shrink-0 ms-3">
+          <p class="text-sm font-semibold text-pink-500 dark:text-pink-400">
+            {{ fyo.format(inv.outstandingAmount, 'Currency') }}
+          </p>
+          <p class="text-xs text-gray-400 dark:text-gray-500">
+            {{ inv.daysOverdue }}&nbsp;{{ t`days overdue` }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="!overdueList.length"
+      class="flex-1 flex items-center justify-center py-10"
+    >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t`No overdue invoices` }} 🎉
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { DateTime } from 'luxon';
+import { ModelNameEnum } from 'models/types';
+import { fyo } from 'src/initFyo';
+import { safeParseFloat } from 'utils/index';
+import { routeTo } from 'src/utils/ui';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import SectionHeader from './SectionHeader.vue';
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+export default defineComponent({
+  name: 'OverdueInvoices',
+  components: { SectionHeader },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      overdueList: [] as {
+        name: string;
+        party: string;
+        date: string;
+        outstandingAmount: number;
+        daysOverdue: number;
+      }[],
+    };
+  },
+  methods: {
+    async setData() {
+      const cutoff = DateTime.now().minus({ days: 30 });
+      const raw = await fyo.db.getAllRaw(ModelNameEnum.SalesInvoice, {
+        fields: ['name', 'party', 'date', 'outstandingAmount'],
+        filters: {
+          submitted: true,
+          cancelled: false,
+          date: ['<', cutoff.toISO()],
+        },
+        orderBy: 'date',
+        order: 'asc',
+        limit: 100,
+      });
+
+      const now = DateTime.now();
+      this.overdueList = raw
+        .map((r) => ({
+          name: r.name as string,
+          party: r.party as string,
+          date: r.date as string,
+          outstandingAmount: safeParseFloat(r.outstandingAmount),
+          daysOverdue: Math.max(
+            0,
+            Math.floor(now.diff(DateTime.fromISO(r.date as string), 'days').days)
+          ),
+        }))
+        .filter((r) => r.outstandingAmount > 0);
+    },
+    async openInvoice(name: string) {
+      await routeTo(`/edit/${ModelNameEnum.SalesInvoice}/${name}`);
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/ReceivablesAging.vue
+++ b/src/pages/Dashboard/ReceivablesAging.vue
@@ -15,15 +15,48 @@
         </span>
       </div>
 
-      <!-- Segmented stacked bar -->
-      <div class="flex h-2 w-full rounded-full overflow-hidden">
-        <div
-          v-for="bucket in buckets"
-          :key="bucket.label"
-          v-show="bucket.amount > 0"
-          :style="{ width: bucketPct(bucket.amount) + '%' }"
-          :class="bucket.barClass"
-        />
+      <!-- Segmented stacked bar with hover tooltip -->
+      <div class="relative" @mouseleave="hoveredBucket = null">
+        <div class="flex h-3 w-full rounded-full overflow-hidden">
+          <div
+            v-for="bucket in visibleBuckets"
+            :key="bucket.label"
+            :style="{ width: bucketPct(bucket.amount) + '%' }"
+            :class="[
+              bucket.barClass,
+              'cursor-pointer transition-opacity duration-150',
+              hoveredBucket && hoveredBucket.label !== bucket.label
+                ? 'opacity-30'
+                : 'opacity-100',
+            ]"
+            @mouseenter="onBarHover(bucket, $event)"
+          />
+        </div>
+
+        <!-- Hover tooltip -->
+        <transition name="ra-fade">
+          <div
+            v-if="hoveredBucket"
+            class="absolute z-50 pointer-events-none"
+            :style="tooltipStyle"
+          >
+            <div
+              class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg px-3 py-2 text-xs whitespace-nowrap"
+            >
+              <p :class="[hoveredBucket.labelClass, 'font-semibold mb-1']">
+                {{ hoveredBucket.label }}
+              </p>
+              <p class="text-gray-700 dark:text-gray-300 font-medium">
+                {{ fyo.format(hoveredBucket.amount, 'Currency') }}
+              </p>
+              <p class="text-gray-500 dark:text-gray-400 mt-0.5">
+                {{ hoveredBucket.count }}
+                {{ t`invoices` }} &middot;
+                {{ bucketPct(hoveredBucket.amount) }}%
+              </p>
+            </div>
+          </div>
+        </transition>
       </div>
 
       <!-- 2×2 bucket cards grid -->
@@ -31,12 +64,12 @@
         <div
           v-for="bucket in buckets"
           :key="bucket.label"
-          class="rounded-lg bg-gray-50 dark:bg-gray-800 p-2.5"
+          :class="['rounded-lg p-2.5 border', bucket.cardBgClass]"
         >
           <p :class="[bucket.labelClass, 'text-xs font-medium']">
             {{ bucket.label }}
           </p>
-          <p class="text-sm font-semibold dark:text-white">
+          <p class="text-sm font-semibold dark:text-white mt-0.5">
             {{ fyo.format(bucket.amount, 'Currency') }}
           </p>
           <p class="text-xs text-gray-400 dark:text-gray-500">
@@ -46,10 +79,7 @@
       </div>
     </div>
 
-    <div
-      v-else
-      class="flex-1 flex items-center justify-center py-10"
-    >
+    <div v-else class="flex-1 flex items-center justify-center py-10">
       <span class="text-sm text-gray-500 dark:text-gray-400">
         {{ t`No outstanding invoices` }} 🎉
       </span>
@@ -75,6 +105,7 @@ type AgingBucket = {
   count: number;
   barClass: string;
   labelClass: string;
+  cardBgClass: string;
 };
 
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
@@ -87,6 +118,8 @@ export default defineComponent({
   },
   data() {
     return {
+      hoveredBucket: null as AgingBucket | null,
+      tooltipStyle: {} as Record<string, string>,
       buckets: [
         {
           label: '0–30 days',
@@ -96,6 +129,8 @@ export default defineComponent({
           count: 0,
           barClass: 'bg-blue-400 dark:bg-blue-500',
           labelClass: 'text-blue-600 dark:text-blue-400',
+          cardBgClass:
+            'bg-blue-50 border-blue-100 dark:bg-blue-950/40 dark:border-blue-900/50',
         },
         {
           label: '31–60 days',
@@ -105,6 +140,8 @@ export default defineComponent({
           count: 0,
           barClass: 'bg-yellow-400 dark:bg-yellow-500',
           labelClass: 'text-yellow-600 dark:text-yellow-400',
+          cardBgClass:
+            'bg-yellow-50 border-yellow-100 dark:bg-yellow-950/40 dark:border-yellow-900/50',
         },
         {
           label: '61–90 days',
@@ -114,6 +151,8 @@ export default defineComponent({
           count: 0,
           barClass: 'bg-orange-400 dark:bg-orange-500',
           labelClass: 'text-orange-600 dark:text-orange-400',
+          cardBgClass:
+            'bg-orange-50 border-orange-100 dark:bg-orange-950/40 dark:border-orange-900/50',
         },
         {
           label: '90+ days',
@@ -123,6 +162,8 @@ export default defineComponent({
           count: 0,
           barClass: 'bg-pink-400 dark:bg-pink-500',
           labelClass: 'text-pink-600 dark:text-pink-400',
+          cardBgClass:
+            'bg-pink-50 border-pink-100 dark:bg-pink-950/40 dark:border-pink-900/50',
         },
       ] as AgingBucket[],
     };
@@ -134,10 +175,30 @@ export default defineComponent({
     hasData(): boolean {
       return this.totalOutstanding > 0;
     },
+    visibleBuckets(): AgingBucket[] {
+      return this.buckets.filter((b) => b.amount > 0);
+    },
   },
   methods: {
     bucketPct(amount: number): number {
       return Math.round((amount / (this.totalOutstanding || 1)) * 100);
+    },
+    onBarHover(bucket: AgingBucket, event: MouseEvent) {
+      this.hoveredBucket = bucket;
+      const bar = (event.currentTarget as HTMLElement).closest(
+        '.relative'
+      ) as HTMLElement | null;
+      if (!bar) return;
+      const barRect = bar.getBoundingClientRect();
+      const segRect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      // Center the tooltip over the hovered segment, clamped within the bar
+      const segMidX = segRect.left + segRect.width / 2 - barRect.left;
+      this.tooltipStyle = {
+        bottom: '100%',
+        marginBottom: '6px',
+        left: `${segMidX}px`,
+        transform: 'translateX(-50%)',
+      };
     },
     async setData() {
       // Reset all buckets
@@ -178,3 +239,14 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.ra-fade-enter-active,
+.ra-fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+.ra-fade-enter-from,
+.ra-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/pages/Dashboard/ReceivablesAging.vue
+++ b/src/pages/Dashboard/ReceivablesAging.vue
@@ -41,7 +41,18 @@
             :style="tooltipStyle"
           >
             <div
-              class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg px-3 py-2 text-xs whitespace-nowrap"
+              class="
+                bg-white
+                dark:bg-gray-900
+                border border-gray-200
+                dark:border-gray-700
+                rounded-lg
+                shadow-lg
+                px-3
+                py-2
+                text-xs
+                whitespace-nowrap
+              "
             >
               <p :class="[hoveredBucket.labelClass, 'font-semibold mb-1']">
                 {{ hoveredBucket.label }}
@@ -108,7 +119,11 @@ type AgingBucket = {
   cardBgClass: string;
 };
 
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/*
+  eslint-disable @typescript-eslint/no-unsafe-argument,
+  @typescript-eslint/no-unsafe-return,
+  @typescript-eslint/restrict-plus-operands
+*/
 export default defineComponent({
   name: 'ReceivablesAging',
   components: { SectionHeader },
@@ -185,12 +200,14 @@ export default defineComponent({
     },
     onBarHover(bucket: AgingBucket, event: MouseEvent) {
       this.hoveredBucket = bucket;
-      const bar = (event.currentTarget as HTMLElement).closest(
+      const bar = (event.currentTarget as HTMLElement).closest<HTMLElement>(
         '.relative'
-      ) as HTMLElement | null;
+      );
       if (!bar) return;
       const barRect = bar.getBoundingClientRect();
-      const segRect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      const segRect = (
+        event.currentTarget as HTMLElement
+      ).getBoundingClientRect();
       // Center the tooltip over the hovered segment, clamped within the bar
       const segMidX = segRect.left + segRect.width / 2 - barRect.left;
       this.tooltipStyle = {
@@ -226,8 +243,7 @@ export default defineComponent({
 
         const bucket = this.buckets.find(
           (b) =>
-            daysOld >= b.minDays &&
-            (b.maxDays === null || daysOld <= b.maxDays)
+            daysOld >= b.minDays && (b.maxDays === null || daysOld <= b.maxDays)
         );
 
         if (bucket) {

--- a/src/pages/Dashboard/ReceivablesAging.vue
+++ b/src/pages/Dashboard/ReceivablesAging.vue
@@ -99,7 +99,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { DateTime } from 'luxon';
 import { ModelNameEnum } from 'models/types';
 import { fyo } from 'src/initFyo';

--- a/src/pages/Dashboard/ReceivablesAging.vue
+++ b/src/pages/Dashboard/ReceivablesAging.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="flex flex-col w-full p-4">
+    <SectionHeader>
+      <template #title>{{ t`Receivables Aging` }}</template>
+    </SectionHeader>
+
+    <div v-if="hasData" class="mt-4 flex flex-col gap-3 flex-1">
+      <!-- Total outstanding line -->
+      <div class="flex items-center justify-between">
+        <span class="text-xs text-gray-500 dark:text-gray-400">
+          {{ t`Total Outstanding` }}
+        </span>
+        <span class="text-sm font-semibold dark:text-white">
+          {{ fyo.format(totalOutstanding, 'Currency') }}
+        </span>
+      </div>
+
+      <!-- Segmented stacked bar -->
+      <div class="flex h-2 w-full rounded-full overflow-hidden">
+        <div
+          v-for="bucket in buckets"
+          :key="bucket.label"
+          v-show="bucket.amount > 0"
+          :style="{ width: bucketPct(bucket.amount) + '%' }"
+          :class="bucket.barClass"
+        />
+      </div>
+
+      <!-- 2×2 bucket cards grid -->
+      <div class="grid grid-cols-2 gap-2 mt-2">
+        <div
+          v-for="bucket in buckets"
+          :key="bucket.label"
+          class="rounded-lg bg-gray-50 dark:bg-gray-800 p-2.5"
+        >
+          <p :class="[bucket.labelClass, 'text-xs font-medium']">
+            {{ bucket.label }}
+          </p>
+          <p class="text-sm font-semibold dark:text-white">
+            {{ fyo.format(bucket.amount, 'Currency') }}
+          </p>
+          <p class="text-xs text-gray-400 dark:text-gray-500">
+            {{ bucket.count }} {{ t`invoices` }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="flex-1 flex items-center justify-center py-10"
+    >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t`No outstanding invoices` }} 🎉
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { DateTime } from 'luxon';
+import { ModelNameEnum } from 'models/types';
+import { fyo } from 'src/initFyo';
+import { safeParseFloat } from 'utils/index';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import SectionHeader from './SectionHeader.vue';
+
+type AgingBucket = {
+  label: string;
+  minDays: number;
+  maxDays: number | null;
+  amount: number;
+  count: number;
+  barClass: string;
+  labelClass: string;
+};
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+export default defineComponent({
+  name: 'ReceivablesAging',
+  components: { SectionHeader },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      buckets: [
+        {
+          label: '0–30 days',
+          minDays: 0,
+          maxDays: 30,
+          amount: 0,
+          count: 0,
+          barClass: 'bg-blue-400 dark:bg-blue-500',
+          labelClass: 'text-blue-600 dark:text-blue-400',
+        },
+        {
+          label: '31–60 days',
+          minDays: 31,
+          maxDays: 60,
+          amount: 0,
+          count: 0,
+          barClass: 'bg-yellow-400 dark:bg-yellow-500',
+          labelClass: 'text-yellow-600 dark:text-yellow-400',
+        },
+        {
+          label: '61–90 days',
+          minDays: 61,
+          maxDays: 90,
+          amount: 0,
+          count: 0,
+          barClass: 'bg-orange-400 dark:bg-orange-500',
+          labelClass: 'text-orange-600 dark:text-orange-400',
+        },
+        {
+          label: '90+ days',
+          minDays: 91,
+          maxDays: null,
+          amount: 0,
+          count: 0,
+          barClass: 'bg-pink-400 dark:bg-pink-500',
+          labelClass: 'text-pink-600 dark:text-pink-400',
+        },
+      ] as AgingBucket[],
+    };
+  },
+  computed: {
+    totalOutstanding(): number {
+      return this.buckets.reduce((sum, b) => sum + b.amount, 0);
+    },
+    hasData(): boolean {
+      return this.totalOutstanding > 0;
+    },
+  },
+  methods: {
+    bucketPct(amount: number): number {
+      return Math.round((amount / (this.totalOutstanding || 1)) * 100);
+    },
+    async setData() {
+      // Reset all buckets
+      for (const bucket of this.buckets) {
+        bucket.amount = 0;
+        bucket.count = 0;
+      }
+
+      const raw = await fyo.db.getAllRaw(ModelNameEnum.SalesInvoice, {
+        fields: ['date', 'outstandingAmount'],
+        filters: { submitted: true, cancelled: false },
+      });
+
+      const now = DateTime.now();
+
+      for (const r of raw) {
+        const outstanding = safeParseFloat(r.outstandingAmount);
+        if (outstanding <= 0) {
+          continue;
+        }
+
+        const daysOld = Math.floor(
+          now.diff(DateTime.fromISO(r.date as string), 'days').days
+        );
+
+        const bucket = this.buckets.find(
+          (b) =>
+            daysOld >= b.minDays &&
+            (b.maxDays === null || daysOld <= b.maxDays)
+        );
+
+        if (bucket) {
+          bucket.amount += outstanding;
+          bucket.count += 1;
+        }
+      }
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/TopCustomers.vue
+++ b/src/pages/Dashboard/TopCustomers.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="flex flex-col w-full p-4">
+    <SectionHeader>
+      <template #title>{{ t`Top Customers` }}</template>
+      <template #action>
+        <PeriodSelector :value="period" @change="(v) => (period = v)" />
+      </template>
+    </SectionHeader>
+
+    <div v-if="customers.length" class="mt-3 flex flex-col gap-3">
+      <div v-for="(c, i) in customers" :key="c.party" class="flex items-center gap-3">
+        <!-- rank -->
+        <span class="text-xs font-bold text-gray-400 dark:text-gray-500 w-4 shrink-0">
+          {{ i + 1 }}
+        </span>
+        <!-- name + bar -->
+        <div class="flex-1 min-w-0">
+          <div class="flex justify-between items-baseline mb-0.5">
+            <span class="text-sm font-medium dark:text-white truncate">{{ c.party }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400 shrink-0 ms-2">
+              {{ fyo.format(c.total, 'Currency') }}
+            </span>
+          </div>
+          <div class="w-full h-1.5 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+            <div
+              class="h-full rounded-full bg-blue-500 dark:bg-blue-600 transition-all"
+              :style="{ width: barWidth(c.total) + '%' }"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="flex-1 flex items-center justify-center py-10"
+    >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t`No sales in this period` }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { fyo } from 'src/initFyo';
+import { getDatesAndPeriodList } from 'src/utils/misc';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import PeriodSelector from './PeriodSelector.vue';
+import SectionHeader from './SectionHeader.vue';
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+export default defineComponent({
+  name: 'TopCustomers',
+  components: { SectionHeader, PeriodSelector },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      customers: [] as { party: string; total: number }[],
+    };
+  },
+  computed: {
+    maxTotal(): number {
+      return this.customers[0]?.total ?? 1;
+    },
+  },
+  methods: {
+    async setData() {
+      const { fromDate, toDate } = getDatesAndPeriodList(this.period);
+      this.customers = await fyo.db.getTopCustomers(
+        fromDate.toISO(),
+        toDate.toISO()
+      );
+    },
+    barWidth(total: number): number {
+      return Math.round((total / (this.maxTotal || 1)) * 100);
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/TopCustomers.vue
+++ b/src/pages/Dashboard/TopCustomers.vue
@@ -8,22 +8,54 @@
     </SectionHeader>
 
     <div v-if="customers.length" class="mt-3 flex flex-col gap-3">
-      <div v-for="(c, i) in customers" :key="c.party" class="flex items-center gap-3">
+      <div
+        v-for="(c, i) in customers"
+        :key="c.party"
+        class="flex items-center gap-3"
+      >
         <!-- rank -->
-        <span class="text-xs font-bold text-gray-400 dark:text-gray-500 w-4 shrink-0">
+        <span
+          class="
+            text-xs
+            font-bold
+            text-gray-400
+            dark:text-gray-500
+            w-4
+            shrink-0
+          "
+        >
           {{ i + 1 }}
         </span>
         <!-- name + bar -->
         <div class="flex-1 min-w-0">
           <div class="flex justify-between items-baseline mb-0.5">
-            <span class="text-sm font-medium dark:text-white truncate">{{ c.party }}</span>
-            <span class="text-xs text-gray-500 dark:text-gray-400 shrink-0 ms-2">
+            <span class="text-sm font-medium dark:text-white truncate">{{
+              c.party
+            }}</span>
+            <span
+              class="text-xs text-gray-500 dark:text-gray-400 shrink-0 ms-2"
+            >
               {{ fyo.format(c.total, 'Currency') }}
             </span>
           </div>
-          <div class="w-full h-1.5 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+          <div
+            class="
+              w-full
+              h-1.5
+              bg-gray-100
+              dark:bg-gray-800
+              rounded-full
+              overflow-hidden
+            "
+          >
             <div
-              class="h-full rounded-full bg-blue-500 dark:bg-blue-600 transition-all"
+              class="
+                h-full
+                rounded-full
+                bg-blue-500
+                dark:bg-blue-600
+                transition-all
+              "
               :style="{ width: barWidth(c.total) + '%' }"
             />
           </div>
@@ -31,10 +63,7 @@
       </div>
     </div>
 
-    <div
-      v-else
-      class="flex-1 flex items-center justify-center py-10"
-    >
+    <div v-else class="flex-1 flex items-center justify-center py-10">
       <span class="text-sm text-gray-500 dark:text-gray-400">
         {{ t`No sales in this period` }}
       </span>
@@ -51,7 +80,10 @@ import BaseDashboardChart from './BaseDashboardChart.vue';
 import PeriodSelector from './PeriodSelector.vue';
 import SectionHeader from './SectionHeader.vue';
 
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/*
+  eslint-disable @typescript-eslint/no-unsafe-argument,
+  @typescript-eslint/no-unsafe-return
+*/
 export default defineComponent({
   name: 'TopCustomers',
   components: { SectionHeader, PeriodSelector },

--- a/src/pages/Dashboard/TopCustomers.vue
+++ b/src/pages/Dashboard/TopCustomers.vue
@@ -72,7 +72,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { fyo } from 'src/initFyo';
 import { getDatesAndPeriodList } from 'src/utils/misc';
 import { defineComponent } from 'vue';

--- a/src/pages/Dashboard/TopSuppliers.vue
+++ b/src/pages/Dashboard/TopSuppliers.vue
@@ -8,22 +8,54 @@
     </SectionHeader>
 
     <div v-if="suppliers.length" class="mt-3 flex flex-col gap-3">
-      <div v-for="(s, i) in suppliers" :key="s.party" class="flex items-center gap-3">
+      <div
+        v-for="(s, i) in suppliers"
+        :key="s.party"
+        class="flex items-center gap-3"
+      >
         <!-- rank -->
-        <span class="text-xs font-bold text-gray-400 dark:text-gray-500 w-4 shrink-0">
+        <span
+          class="
+            text-xs
+            font-bold
+            text-gray-400
+            dark:text-gray-500
+            w-4
+            shrink-0
+          "
+        >
           {{ i + 1 }}
         </span>
         <!-- name + bar -->
         <div class="flex-1 min-w-0">
           <div class="flex justify-between items-baseline mb-0.5">
-            <span class="text-sm font-medium dark:text-white truncate">{{ s.party }}</span>
-            <span class="text-xs text-gray-500 dark:text-gray-400 shrink-0 ms-2">
+            <span class="text-sm font-medium dark:text-white truncate">{{
+              s.party
+            }}</span>
+            <span
+              class="text-xs text-gray-500 dark:text-gray-400 shrink-0 ms-2"
+            >
               {{ fyo.format(s.total, 'Currency') }}
             </span>
           </div>
-          <div class="w-full h-1.5 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+          <div
+            class="
+              w-full
+              h-1.5
+              bg-gray-100
+              dark:bg-gray-800
+              rounded-full
+              overflow-hidden
+            "
+          >
             <div
-              class="h-full rounded-full bg-orange-500 dark:bg-orange-600 transition-all"
+              class="
+                h-full
+                rounded-full
+                bg-orange-500
+                dark:bg-orange-600
+                transition-all
+              "
               :style="{ width: barWidth(s.total) + '%' }"
             />
           </div>
@@ -31,10 +63,7 @@
       </div>
     </div>
 
-    <div
-      v-else
-      class="flex-1 flex items-center justify-center py-10"
-    >
+    <div v-else class="flex-1 flex items-center justify-center py-10">
       <span class="text-sm text-gray-500 dark:text-gray-400">
         {{ t`No purchases in this period` }}
       </span>
@@ -51,7 +80,10 @@ import BaseDashboardChart from './BaseDashboardChart.vue';
 import PeriodSelector from './PeriodSelector.vue';
 import SectionHeader from './SectionHeader.vue';
 
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/*
+  eslint-disable @typescript-eslint/no-unsafe-argument,
+  @typescript-eslint/no-unsafe-return
+*/
 export default defineComponent({
   name: 'TopSuppliers',
   components: { SectionHeader, PeriodSelector },

--- a/src/pages/Dashboard/TopSuppliers.vue
+++ b/src/pages/Dashboard/TopSuppliers.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="flex flex-col w-full p-4">
+    <SectionHeader>
+      <template #title>{{ t`Top Suppliers` }}</template>
+      <template #action>
+        <PeriodSelector :value="period" @change="(v) => (period = v)" />
+      </template>
+    </SectionHeader>
+
+    <div v-if="suppliers.length" class="mt-3 flex flex-col gap-3">
+      <div v-for="(s, i) in suppliers" :key="s.party" class="flex items-center gap-3">
+        <!-- rank -->
+        <span class="text-xs font-bold text-gray-400 dark:text-gray-500 w-4 shrink-0">
+          {{ i + 1 }}
+        </span>
+        <!-- name + bar -->
+        <div class="flex-1 min-w-0">
+          <div class="flex justify-between items-baseline mb-0.5">
+            <span class="text-sm font-medium dark:text-white truncate">{{ s.party }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400 shrink-0 ms-2">
+              {{ fyo.format(s.total, 'Currency') }}
+            </span>
+          </div>
+          <div class="w-full h-1.5 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+            <div
+              class="h-full rounded-full bg-orange-500 dark:bg-orange-600 transition-all"
+              :style="{ width: barWidth(s.total) + '%' }"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="flex-1 flex items-center justify-center py-10"
+    >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t`No purchases in this period` }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { fyo } from 'src/initFyo';
+import { getDatesAndPeriodList } from 'src/utils/misc';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import PeriodSelector from './PeriodSelector.vue';
+import SectionHeader from './SectionHeader.vue';
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+export default defineComponent({
+  name: 'TopSuppliers',
+  components: { SectionHeader, PeriodSelector },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      suppliers: [] as { party: string; total: number }[],
+    };
+  },
+  computed: {
+    maxTotal(): number {
+      return this.suppliers[0]?.total ?? 1;
+    },
+  },
+  methods: {
+    async setData() {
+      const { fromDate, toDate } = getDatesAndPeriodList(this.period);
+      this.suppliers = await fyo.db.getTopSuppliers(
+        fromDate.toISO(),
+        toDate.toISO()
+      );
+    },
+    barWidth(total: number): number {
+      return Math.round((total / (this.maxTotal || 1)) * 100);
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/TopSuppliers.vue
+++ b/src/pages/Dashboard/TopSuppliers.vue
@@ -72,7 +72,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { fyo } from 'src/initFyo';
 import { getDatesAndPeriodList } from 'src/utils/misc';
 import { defineComponent } from 'vue';

--- a/src/pages/Dashboard/UpcomingBills.vue
+++ b/src/pages/Dashboard/UpcomingBills.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="flex flex-col w-full p-4">
+    <SectionHeader>
+      <template #title>{{ t`Upcoming Bills` }}</template>
+      <template #action>
+        <span
+          v-if="billList.length"
+          class="text-xs font-semibold px-2 py-0.5 rounded-full bg-orange-100 dark:bg-orange-900 text-orange-600 dark:text-orange-300"
+        >
+          {{ billList.length }}
+        </span>
+      </template>
+    </SectionHeader>
+
+    <div class="mt-3 flex flex-col divide-y dark:divide-gray-800">
+      <div
+        v-for="bill in billList"
+        :key="bill.name"
+        class="flex items-center justify-between py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded px-1 -mx-1"
+        @click="openBill(bill.name)"
+      >
+        <div class="min-w-0">
+          <p class="text-sm font-medium dark:text-white truncate">{{ bill.name }}</p>
+          <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ bill.party }}</p>
+        </div>
+        <div class="text-right shrink-0 ms-3">
+          <p class="text-sm font-semibold text-orange-500 dark:text-orange-400">
+            {{ fyo.format(bill.outstandingAmount, 'Currency') }}
+          </p>
+          <p class="text-xs text-gray-400 dark:text-gray-500">
+            {{ bill.daysAgo }}&nbsp;{{ t`days ago` }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="!billList.length"
+      class="flex-1 flex items-center justify-center py-10"
+    >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t`No upcoming bills` }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { t } from 'fyo';
+import { DateTime } from 'luxon';
+import { ModelNameEnum } from 'models/types';
+import { fyo } from 'src/initFyo';
+import { safeParseFloat } from 'utils/index';
+import { routeTo } from 'src/utils/ui';
+import { defineComponent } from 'vue';
+import BaseDashboardChart from './BaseDashboardChart.vue';
+import SectionHeader from './SectionHeader.vue';
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+export default defineComponent({
+  name: 'UpcomingBills',
+  components: { SectionHeader },
+  extends: BaseDashboardChart,
+  props: {
+    darkMode: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      billList: [] as {
+        name: string;
+        party: string;
+        date: string;
+        outstandingAmount: number;
+        daysAgo: number;
+      }[],
+    };
+  },
+  methods: {
+    async setData() {
+      const now = DateTime.now();
+      const fromDate = now.minus({ days: 30 });
+      const raw = await fyo.db.getAllRaw(ModelNameEnum.PurchaseInvoice, {
+        fields: ['name', 'party', 'date', 'outstandingAmount'],
+        filters: {
+          submitted: true,
+          cancelled: false,
+          date: ['>=', fromDate.toISO(), '<=', now.toISO()],
+        },
+        orderBy: 'date',
+        order: 'asc',
+        limit: 100,
+      });
+
+      this.billList = raw
+        .map((r) => ({
+          name: r.name as string,
+          party: r.party as string,
+          date: r.date as string,
+          outstandingAmount: safeParseFloat(r.outstandingAmount),
+          daysAgo: Math.max(
+            0,
+            Math.floor(now.diff(DateTime.fromISO(r.date as string), 'days').days)
+          ),
+        }))
+        .filter((r) => r.outstandingAmount > 0);
+    },
+    async openBill(name: string) {
+      await routeTo(`/edit/${ModelNameEnum.PurchaseInvoice}/${name}`);
+    },
+  },
+});
+</script>

--- a/src/pages/Dashboard/UpcomingBills.vue
+++ b/src/pages/Dashboard/UpcomingBills.vue
@@ -3,12 +3,13 @@
     <SectionHeader>
       <template #title>{{ t`Upcoming Bills` }}</template>
       <template #action>
-        <span
+        <button
           v-if="billList.length"
-          class="text-xs font-semibold px-2 py-0.5 rounded-full bg-orange-100 dark:bg-orange-900 text-orange-600 dark:text-orange-300"
+          class="text-xs text-blue-500 dark:text-blue-400 hover:underline font-medium"
+          @click="openBillList"
         >
-          {{ billList.length }}
-        </span>
+          {{ t`View All` }}
+        </button>
       </template>
     </SectionHeader>
 
@@ -77,7 +78,7 @@ export default defineComponent({
   },
   methods: {
     async setData() {
-      const now = DateTime.now();
+      const now = DateTime.utc();
       const fromDate = now.minus({ days: 30 });
       const raw = await fyo.db.getAllRaw(ModelNameEnum.PurchaseInvoice, {
         fields: ['name', 'party', 'date', 'outstandingAmount'],
@@ -88,7 +89,7 @@ export default defineComponent({
         },
         orderBy: 'date',
         order: 'asc',
-        limit: 100,
+        limit: 5,
       });
 
       this.billList = raw
@@ -106,6 +107,17 @@ export default defineComponent({
     },
     async openBill(name: string) {
       await routeTo(`/edit/${ModelNameEnum.PurchaseInvoice}/${name}`);
+    },
+    async openBillList() {
+      const filters = JSON.stringify({
+        submitted: 1,
+        cancelled: 0,
+        outstandingAmount: ['>', 0],
+      });
+      await routeTo({
+        path: `/list/${ModelNameEnum.PurchaseInvoice}/Upcoming Bills`,
+        query: { filters },
+      });
     },
   },
 });

--- a/src/pages/Dashboard/UpcomingBills.vue
+++ b/src/pages/Dashboard/UpcomingBills.vue
@@ -67,7 +67,6 @@
 </template>
 
 <script lang="ts">
-import { t } from 'fyo';
 import { DateTime } from 'luxon';
 import { ModelNameEnum } from 'models/types';
 import { fyo } from 'src/initFyo';

--- a/src/pages/Dashboard/UpcomingBills.vue
+++ b/src/pages/Dashboard/UpcomingBills.vue
@@ -5,7 +5,12 @@
       <template #action>
         <button
           v-if="billList.length"
-          class="text-xs text-blue-500 dark:text-blue-400 hover:underline font-medium"
+          class="
+            text-xs text-blue-500
+            dark:text-blue-400
+            hover:underline
+            font-medium
+          "
           @click="openBillList"
         >
           {{ t`View All` }}
@@ -17,12 +22,27 @@
       <div
         v-for="bill in billList"
         :key="bill.name"
-        class="flex items-center justify-between py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded px-1 -mx-1"
+        class="
+          flex
+          items-center
+          justify-between
+          py-2
+          cursor-pointer
+          hover:bg-gray-50
+          dark:hover:bg-gray-800
+          rounded
+          px-1
+          -mx-1
+        "
         @click="openBill(bill.name)"
       >
         <div class="min-w-0">
-          <p class="text-sm font-medium dark:text-white truncate">{{ bill.name }}</p>
-          <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ bill.party }}</p>
+          <p class="text-sm font-medium dark:text-white truncate">
+            {{ bill.name }}
+          </p>
+          <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {{ bill.party }}
+          </p>
         </div>
         <div class="text-right shrink-0 ms-3">
           <p class="text-sm font-semibold text-orange-500 dark:text-orange-400">
@@ -100,7 +120,9 @@ export default defineComponent({
           outstandingAmount: safeParseFloat(r.outstandingAmount),
           daysAgo: Math.max(
             0,
-            Math.floor(now.diff(DateTime.fromISO(r.date as string), 'days').days)
+            Math.floor(
+              now.diff(DateTime.fromISO(r.date as string), 'days').days
+            )
           ),
         }))
         .filter((r) => r.outstandingAmount > 0);

--- a/src/pages/Dashboard/types.ts
+++ b/src/pages/Dashboard/types.ts
@@ -4,7 +4,12 @@ export type WidgetKey =
   | 'salesInvoices'
   | 'purchaseInvoices'
   | 'profitAndLoss'
-  | 'expenses';
+  | 'expenses'
+  | 'overdueInvoices'
+  | 'upcomingBills'
+  | 'cashOnHand'
+  | 'topCustomers'
+  | 'grossMargin';
 
 export type DashboardProfile =
   | 'Freelancer'
@@ -69,6 +74,46 @@ export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
     wrapClass: 'p-4',
     icon: 'pie-chart',
   },
+  overdueInvoices: {
+    id: 'overdueInvoices',
+    label: 'Overdue Invoices',
+    description: 'Sales invoices overdue by 30+ days',
+    width: 'half',
+    wrapClass: '',
+    icon: 'alert-circle',
+  },
+  upcomingBills: {
+    id: 'upcomingBills',
+    label: 'Upcoming Bills',
+    description: 'Unpaid purchase invoices from last 30 days',
+    width: 'half',
+    wrapClass: '',
+    icon: 'clock',
+  },
+  cashOnHand: {
+    id: 'cashOnHand',
+    label: 'Cash on Hand',
+    description: 'Total balance across cash & bank accounts',
+    width: 'half',
+    wrapClass: 'p-4',
+    icon: 'dollar-sign',
+  },
+  topCustomers: {
+    id: 'topCustomers',
+    label: 'Top Customers',
+    description: 'Top 5 customers by revenue this period',
+    width: 'half',
+    wrapClass: '',
+    icon: 'users',
+  },
+  grossMargin: {
+    id: 'grossMargin',
+    label: 'Gross Margin',
+    description: 'Revenue minus cost of goods sold (%)',
+    width: 'half',
+    wrapClass: 'p-4',
+    icon: 'percent',
+  },
 };
 
 export const ALL_WIDGET_KEYS: WidgetKey[] = [
@@ -77,6 +122,11 @@ export const ALL_WIDGET_KEYS: WidgetKey[] = [
   'purchaseInvoices',
   'profitAndLoss',
   'expenses',
+  'overdueInvoices',
+  'upcomingBills',
+  'cashOnHand',
+  'topCustomers',
+  'grossMargin',
 ];
 
 // ── Stored config shape ──────────────────────────────────────────────────────
@@ -85,9 +135,17 @@ export interface WidgetConfig {
   visible: boolean;
 }
 
+const ORIGINAL_WIDGET_KEYS = new Set<WidgetKey>([
+  'cashflow',
+  'salesInvoices',
+  'purchaseInvoices',
+  'profitAndLoss',
+  'expenses',
+]);
+
 export const DEFAULT_LAYOUT: WidgetConfig[] = ALL_WIDGET_KEYS.map((id) => ({
   id,
-  visible: true,
+  visible: ORIGINAL_WIDGET_KEYS.has(id),
 }));
 
 // ── Profile presets ──────────────────────────────────────────────────────────
@@ -101,15 +159,17 @@ export const PROFILE_LAYOUTS: Record<
 > = {
   // Freelancers care about outstanding invoices and overall P&L; cashflow
   // chart is rarely meaningful without regular bank reconciliation.
-  Freelancer: ['salesInvoices', 'purchaseInvoices', 'profitAndLoss'],
+  Freelancer: ['salesInvoices', 'overdueInvoices', 'profitAndLoss', 'grossMargin'],
   // Retailers need tight cashflow visibility alongside both invoice streams.
-  Retailer: ['cashflow', 'salesInvoices', 'purchaseInvoices', 'expenses'],
+  Retailer: ['cashflow', 'cashOnHand', 'salesInvoices', 'purchaseInvoices', 'upcomingBills', 'expenses'],
   // Service businesses lead with cashflow and profitability.
   'Service Business': [
     'cashflow',
+    'cashOnHand',
     'salesInvoices',
-    'profitAndLoss',
-    'expenses',
+    'overdueInvoices',
+    'topCustomers',
+    'grossMargin',
   ],
 };
 

--- a/src/pages/Dashboard/types.ts
+++ b/src/pages/Dashboard/types.ts
@@ -1,0 +1,175 @@
+// ── Widget identity ─────────────────────────────────────────────────────────
+export type WidgetKey =
+  | 'cashflow'
+  | 'salesInvoices'
+  | 'purchaseInvoices'
+  | 'profitAndLoss'
+  | 'expenses';
+
+export type DashboardProfile =
+  | 'Freelancer'
+  | 'Retailer'
+  | 'Service Business'
+  | 'Custom';
+
+// ── Per-widget metadata ──────────────────────────────────────────────────────
+export interface WidgetMeta {
+  id: WidgetKey;
+  label: string;
+  description: string;
+  /** 'full' spans the entire row; 'half' widgets pair up side-by-side. */
+  width: 'full' | 'half';
+  /**
+   * CSS class applied to the wrapper <div> in Dashboard.vue.
+   * Components with their own internal padding (UnpaidInvoices) leave this empty.
+   */
+  wrapClass: string;
+}
+
+export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
+  cashflow: {
+    id: 'cashflow',
+    label: 'Cashflow',
+    description: 'Monthly inflow and outflow',
+    width: 'full',
+    wrapClass: 'p-4',
+  },
+  salesInvoices: {
+    id: 'salesInvoices',
+    label: 'Sales Invoices',
+    description: 'Paid and unpaid sales invoices',
+    width: 'half',
+    wrapClass: '', // UnpaidInvoices applies its own p-4
+  },
+  purchaseInvoices: {
+    id: 'purchaseInvoices',
+    label: 'Purchase Invoices',
+    description: 'Paid and unpaid purchase invoices',
+    width: 'half',
+    wrapClass: '', // UnpaidInvoices applies its own p-4
+  },
+  profitAndLoss: {
+    id: 'profitAndLoss',
+    label: 'Profit & Loss',
+    description: 'Net income by period',
+    width: 'half',
+    wrapClass: 'p-4',
+  },
+  expenses: {
+    id: 'expenses',
+    label: 'Top Expenses',
+    description: 'Top expense categories',
+    width: 'half',
+    wrapClass: 'p-4',
+  },
+};
+
+export const ALL_WIDGET_KEYS: WidgetKey[] = [
+  'cashflow',
+  'salesInvoices',
+  'purchaseInvoices',
+  'profitAndLoss',
+  'expenses',
+];
+
+// ── Stored config shape ──────────────────────────────────────────────────────
+export interface WidgetConfig {
+  id: WidgetKey;
+  visible: boolean;
+}
+
+export const DEFAULT_LAYOUT: WidgetConfig[] = ALL_WIDGET_KEYS.map((id) => ({
+  id,
+  visible: true,
+}));
+
+// ── Profile presets ──────────────────────────────────────────────────────────
+/**
+ * Ordered list of visible widget IDs for each built-in profile.
+ * Widgets not listed are appended as hidden.
+ */
+export const PROFILE_LAYOUTS: Record<
+  Exclude<DashboardProfile, 'Custom'>,
+  WidgetKey[]
+> = {
+  // Freelancers care about outstanding invoices and overall P&L; cashflow
+  // chart is rarely meaningful without regular bank reconciliation.
+  Freelancer: ['salesInvoices', 'purchaseInvoices', 'profitAndLoss'],
+  // Retailers need tight cashflow visibility alongside both invoice streams.
+  Retailer: ['cashflow', 'salesInvoices', 'purchaseInvoices', 'expenses'],
+  // Service businesses lead with cashflow and profitability.
+  'Service Business': [
+    'cashflow',
+    'salesInvoices',
+    'profitAndLoss',
+    'expenses',
+  ],
+};
+
+export const PRESET_PROFILES: ReadonlyArray<Exclude<DashboardProfile, 'Custom'>> =
+  ['Freelancer', 'Retailer', 'Service Business'];
+
+export function profileToLayout(
+  profile: Exclude<DashboardProfile, 'Custom'>
+): WidgetConfig[] {
+  const ordered = PROFILE_LAYOUTS[profile];
+  const visibleSet = new Set(ordered);
+  return [
+    ...ordered.map((id) => ({ id, visible: true })),
+    ...ALL_WIDGET_KEYS.filter((id) => !visibleSet.has(id)).map((id) => ({
+      id,
+      visible: false,
+    })),
+  ];
+}
+
+// ── Serialization ────────────────────────────────────────────────────────────
+export function parseWidgetLayout(raw: string | undefined): WidgetConfig[] {
+  if (!raw) return DEFAULT_LAYOUT.map((c) => ({ ...c }));
+  try {
+    const saved = JSON.parse(raw) as WidgetConfig[];
+    const savedIds = new Set(saved.map((c) => c.id));
+    // Forward-compat: any widget key added after the user last saved gets
+    // appended as visible so it doesn't silently disappear.
+    const unseen = ALL_WIDGET_KEYS.filter((id) => !savedIds.has(id)).map(
+      (id) => ({ id, visible: true })
+    );
+    return [...saved, ...unseen];
+  } catch {
+    return DEFAULT_LAYOUT.map((c) => ({ ...c }));
+  }
+}
+
+// ── Layout engine ────────────────────────────────────────────────────────────
+/**
+ * Groups the ordered visible-widget list into render rows.
+ * Two adjacent half-width widgets form a side-by-side pair; a lone
+ * half-width widget spans the full row instead.
+ */
+export type WidgetRow =
+  | { type: 'full'; widget: WidgetConfig }
+  | { type: 'half-pair'; left: WidgetConfig; right: WidgetConfig }
+  | { type: 'half-solo'; widget: WidgetConfig };
+
+export function buildWidgetRows(configs: WidgetConfig[]): WidgetRow[] {
+  const visible = configs.filter((c) => c.visible);
+  const rows: WidgetRow[] = [];
+  let i = 0;
+  while (i < visible.length) {
+    const meta = WIDGET_META[visible[i].id];
+    if (meta.width === 'full') {
+      rows.push({ type: 'full', widget: visible[i] });
+      i++;
+    } else {
+      const next = visible[i + 1];
+      if (next && WIDGET_META[next.id].width === 'half') {
+        rows.push({ type: 'half-pair', left: visible[i], right: next });
+        i += 2;
+      } else {
+        rows.push({ type: 'half-solo', widget: visible[i] });
+        i++;
+      }
+    }
+  }
+  return rows;
+}

--- a/src/pages/Dashboard/types.ts
+++ b/src/pages/Dashboard/types.ts
@@ -9,7 +9,10 @@ export type WidgetKey =
   | 'upcomingBills'
   | 'cashOnHand'
   | 'topCustomers'
-  | 'grossMargin';
+  | 'grossMargin'
+  | 'topSuppliers'
+  | 'invoiceDrafts'
+  | 'receivablesAging';
 
 export type DashboardProfile =
   | 'Freelancer'
@@ -114,6 +117,30 @@ export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
     wrapClass: 'p-4',
     icon: 'percent',
   },
+  topSuppliers: {
+    id: 'topSuppliers',
+    label: 'Top Suppliers',
+    description: 'Top 5 suppliers by purchase spend this period',
+    width: 'half',
+    wrapClass: '',
+    icon: 'truck',
+  },
+  invoiceDrafts: {
+    id: 'invoiceDrafts',
+    label: 'Draft Invoices',
+    description: 'Unsubmitted invoices not yet sent to clients',
+    width: 'half',
+    wrapClass: 'p-4',
+    icon: 'edit-3',
+  },
+  receivablesAging: {
+    id: 'receivablesAging',
+    label: 'Receivables Aging',
+    description: 'Outstanding invoices bucketed by age',
+    width: 'half',
+    wrapClass: '',
+    icon: 'layers',
+  },
 };
 
 export const ALL_WIDGET_KEYS: WidgetKey[] = [
@@ -127,6 +154,9 @@ export const ALL_WIDGET_KEYS: WidgetKey[] = [
   'cashOnHand',
   'topCustomers',
   'grossMargin',
+  'topSuppliers',
+  'invoiceDrafts',
+  'receivablesAging',
 ];
 
 // ── Stored config shape ──────────────────────────────────────────────────────
@@ -162,6 +192,7 @@ export const PROFILE_LAYOUTS: Record<
   // omitted — pure service providers have no COGS, so it reads 100% or empty.
   Freelancer: [
     'cashOnHand',
+    'invoiceDrafts',
     'salesInvoices',
     'overdueInvoices',
     'upcomingBills',
@@ -176,6 +207,7 @@ export const PROFILE_LAYOUTS: Record<
     'grossMargin',
     'salesInvoices',
     'purchaseInvoices',
+    'topSuppliers',
     'upcomingBills',
     'expenses',
   ],
@@ -188,6 +220,7 @@ export const PROFILE_LAYOUTS: Record<
     'profitAndLoss',
     'salesInvoices',
     'overdueInvoices',
+    'receivablesAging',
     'topCustomers',
     'expenses',
   ],

--- a/src/pages/Dashboard/types.ts
+++ b/src/pages/Dashboard/types.ts
@@ -13,8 +13,8 @@ export type WidgetKey =
 
 export type DashboardProfile =
   | 'Freelancer'
-  | 'Retailer'
-  | 'Service Business'
+  | 'Shop / Trader'
+  | 'Small Business'
   | 'Custom';
 
 // ── Per-widget metadata ──────────────────────────────────────────────────────
@@ -157,24 +157,44 @@ export const PROFILE_LAYOUTS: Record<
   Exclude<DashboardProfile, 'Custom'>,
   WidgetKey[]
 > = {
-  // Freelancers care about outstanding invoices and overall P&L; cashflow
-  // chart is rarely meaningful without regular bank reconciliation.
-  Freelancer: ['salesInvoices', 'overdueInvoices', 'profitAndLoss', 'grossMargin'],
-  // Retailers need tight cashflow visibility alongside both invoice streams.
-  Retailer: ['cashflow', 'cashOnHand', 'salesInvoices', 'purchaseInvoices', 'upcomingBills', 'expenses'],
-  // Service businesses lead with cashflow and profitability.
-  'Service Business': [
-    'cashflow',
+  // Freelancers are AR-anxious: solo income earners whose #1 concern is
+  // getting paid and knowing they can cover upcoming bills. grossMargin is
+  // omitted — pure service providers have no COGS, so it reads 100% or empty.
+  Freelancer: [
     'cashOnHand',
     'salesInvoices',
     'overdueInvoices',
-    'topCustomers',
+    'upcomingBills',
+    'profitAndLoss',
+  ],
+  // Shop / Trader: anyone who buys things to sell things (retailer, wholesaler,
+  // small manufacturer, trader). The buy-sell cycle makes gross margin and
+  // purchase tracking the core need, alongside cashflow for stock funding.
+  'Shop / Trader': [
+    'cashflow',
+    'cashOnHand',
     'grossMargin',
+    'salesInvoices',
+    'purchaseInvoices',
+    'upcomingBills',
+    'expenses',
+  ],
+  // Small Business: any multi-person operation that needs the full financial
+  // picture — agency, firm, growing shop, contractor company. Prioritises the
+  // executive overview: cashflow shape, P&L health, collections, and key clients.
+  'Small Business': [
+    'cashflow',
+    'cashOnHand',
+    'profitAndLoss',
+    'salesInvoices',
+    'overdueInvoices',
+    'topCustomers',
+    'expenses',
   ],
 };
 
 export const PRESET_PROFILES: ReadonlyArray<Exclude<DashboardProfile, 'Custom'>> =
-  ['Freelancer', 'Retailer', 'Service Business'];
+  ['Freelancer', 'Shop / Trader', 'Small Business'];
 
 export function profileToLayout(
   profile: Exclude<DashboardProfile, 'Custom'>

--- a/src/pages/Dashboard/types.ts
+++ b/src/pages/Dashboard/types.ts
@@ -24,6 +24,8 @@ export interface WidgetMeta {
    * Components with their own internal padding (UnpaidInvoices) leave this empty.
    */
   wrapClass: string;
+  /** Feather icon name shown in the customize panel. */
+  icon: string;
 }
 
 export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
@@ -33,6 +35,7 @@ export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
     description: 'Monthly inflow and outflow',
     width: 'full',
     wrapClass: 'p-4',
+    icon: 'trending-up',
   },
   salesInvoices: {
     id: 'salesInvoices',
@@ -40,6 +43,7 @@ export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
     description: 'Paid and unpaid sales invoices',
     width: 'half',
     wrapClass: '', // UnpaidInvoices applies its own p-4
+    icon: 'file-text',
   },
   purchaseInvoices: {
     id: 'purchaseInvoices',
@@ -47,6 +51,7 @@ export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
     description: 'Paid and unpaid purchase invoices',
     width: 'half',
     wrapClass: '', // UnpaidInvoices applies its own p-4
+    icon: 'shopping-cart',
   },
   profitAndLoss: {
     id: 'profitAndLoss',
@@ -54,6 +59,7 @@ export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
     description: 'Net income by period',
     width: 'half',
     wrapClass: 'p-4',
+    icon: 'bar-chart-2',
   },
   expenses: {
     id: 'expenses',
@@ -61,6 +67,7 @@ export const WIDGET_META: Record<WidgetKey, WidgetMeta> = {
     description: 'Top expense categories',
     width: 'half',
     wrapClass: 'p-4',
+    icon: 'pie-chart',
   },
 };
 
@@ -138,6 +145,69 @@ export function parseWidgetLayout(raw: string | undefined): WidgetConfig[] {
   } catch {
     return DEFAULT_LAYOUT.map((c) => ({ ...c }));
   }
+}
+
+// ── Customizer helpers ───────────────────────────────────────────────────────
+
+/**
+ * The discriminated row shape used by the drag-and-drop customiser preview.
+ * `endIdx` is the insertion index (into the visible-order array) that the
+ * drop zone placed *after* this row should target.
+ */
+export type PreviewRow =
+  | { type: 'full'; ids: [WidgetKey]; endIdx: number }
+  | { type: 'half-pair'; ids: [WidgetKey, WidgetKey]; endIdx: number }
+  | { type: 'half-solo'; ids: [WidgetKey]; endIdx: number };
+
+/**
+ * Converts an ordered list of visible widget keys into preview rows,
+ * pairing adjacent half-width widgets exactly as the dashboard renderer
+ * does, and attaching the drop-zone insertion index for each row.
+ */
+export function buildPreviewRows(visibleOrder: WidgetKey[]): PreviewRow[] {
+  const result: PreviewRow[] = [];
+  let i = 0;
+  while (i < visibleOrder.length) {
+    const id = visibleOrder[i];
+    if (WIDGET_META[id].width === 'full') {
+      result.push({ type: 'full', ids: [id], endIdx: i + 1 });
+      i += 1;
+    } else {
+      const nextId = visibleOrder[i + 1];
+      if (nextId !== undefined && WIDGET_META[nextId].width === 'half') {
+        result.push({ type: 'half-pair', ids: [id, nextId], endIdx: i + 2 });
+        i += 2;
+      } else {
+        result.push({ type: 'half-solo', ids: [id], endIdx: i + 1 });
+        i += 1;
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Pure logic behind the customiser's commitDrop operation.
+ *
+ * Inserts `draggedId` at `targetIdx` in `visibleOrder`.  If the widget was
+ * already visible, it is first removed from its current position, and
+ * `targetIdx` is adjusted so the final position matches the user's intent.
+ * If it was hidden (not present in `visibleOrder`), it is simply inserted.
+ */
+export function applyWidgetDrop(
+  visibleOrder: WidgetKey[],
+  draggedId: WidgetKey,
+  targetIdx: number
+): WidgetKey[] {
+  const order = [...visibleOrder];
+  const currentIdx = order.indexOf(draggedId);
+  if (currentIdx !== -1) {
+    order.splice(currentIdx, 1);
+    // Removal shifts every subsequent index left by 1.
+    if (currentIdx < targetIdx) targetIdx--;
+  }
+  order.splice(targetIdx, 0, draggedId);
+  return order;
 }
 
 // ── Layout engine ────────────────────────────────────────────────────────────

--- a/tests/testDashboardSettings.spec.ts
+++ b/tests/testDashboardSettings.spec.ts
@@ -389,7 +389,7 @@ test('DashboardSettings: getDoc returns a doc with correct defaults', async (t) 
     'Custom',
     'activeProfile defaults to Custom'
   );
-  t.equal(doc.widgetLayout, undefined, 'widgetLayout starts as undefined');
+  t.equal(doc.widgetLayout, null, 'widgetLayout starts as null');
   t.end();
 });
 

--- a/tests/testDashboardSettings.spec.ts
+++ b/tests/testDashboardSettings.spec.ts
@@ -9,6 +9,8 @@
 import { ModelNameEnum } from 'models/types';
 import {
   ALL_WIDGET_KEYS,
+  applyWidgetDrop,
+  buildPreviewRows,
   buildWidgetRows,
   DEFAULT_LAYOUT,
   parseWidgetLayout,
@@ -17,6 +19,7 @@ import {
   profileToLayout,
   WIDGET_META,
   WidgetConfig,
+  WidgetKey,
 } from 'src/pages/Dashboard/types';
 import test from 'tape';
 import { closeTestFyo, getTestFyo, setupTestFyo } from './helpers';
@@ -192,11 +195,171 @@ test('WIDGET_META: every WidgetKey has a complete entry', (t) => {
     t.ok(meta.description, `${key}: has description`);
     t.ok(meta.width === 'full' || meta.width === 'half', `${key}: valid width`);
     t.equal(typeof meta.wrapClass, 'string', `${key}: wrapClass is a string`);
+    t.ok(meta.icon, `${key}: has icon`);
+    t.equal(typeof meta.icon, 'string', `${key}: icon is a string`);
   }
   t.end();
 });
 
-// ── 5. Integration: DashboardSettings singleton in an in-memory DB ──────────
+// ── 5. buildPreviewRows ──────────────────────────────────────────────────────
+
+test('buildPreviewRows: empty list → no rows', (t) => {
+  t.deepEqual(buildPreviewRows([]), [], 'empty input gives empty output');
+  t.end();
+});
+
+test('buildPreviewRows: single full widget → endIdx=1', (t) => {
+  const rows = buildPreviewRows(['cashflow']);
+  t.equal(rows.length, 1);
+  t.equal(rows[0].type, 'full');
+  t.equal(rows[0].endIdx, 1, 'full row endIdx is 1');
+  t.deepEqual(rows[0].ids, ['cashflow']);
+  t.end();
+});
+
+test('buildPreviewRows: half-pair → endIdx=2', (t) => {
+  const rows = buildPreviewRows(['salesInvoices', 'purchaseInvoices']);
+  t.equal(rows.length, 1);
+  t.equal(rows[0].type, 'half-pair');
+  t.equal(rows[0].endIdx, 2, 'half-pair row consumes 2 widgets');
+  t.deepEqual(rows[0].ids, ['salesInvoices', 'purchaseInvoices']);
+  t.end();
+});
+
+test('buildPreviewRows: half-solo → endIdx=1', (t) => {
+  const rows = buildPreviewRows(['profitAndLoss']);
+  t.equal(rows.length, 1);
+  t.equal(rows[0].type, 'half-solo');
+  t.equal(rows[0].endIdx, 1);
+  t.end();
+});
+
+test('buildPreviewRows: mixed sequence has correct cumulative endIdx values', (t) => {
+  // cashflow(full) | salesInvoices+purchaseInvoices(pair) | profitAndLoss(solo)
+  // indices:  0          1              2                       3
+  // endIdx:   1                         3                       4
+  const rows = buildPreviewRows([
+    'cashflow',
+    'salesInvoices',
+    'purchaseInvoices',
+    'profitAndLoss',
+  ]);
+  t.equal(rows.length, 3);
+  t.equal(rows[0].type, 'full');
+  t.equal(rows[0].endIdx, 1, 'full endIdx=1');
+  t.equal(rows[1].type, 'half-pair');
+  t.equal(rows[1].endIdx, 3, 'pair endIdx=3 (consumed 2 slots)');
+  t.equal(rows[2].type, 'half-solo');
+  t.equal(rows[2].endIdx, 4, 'solo endIdx=4');
+  t.end();
+});
+
+test('buildPreviewRows: drop at half-solo endIdx pairs the widgets', (t) => {
+  // profitAndLoss is alone; dropping expenses at endIdx=1 should make them pair
+  const before: WidgetKey[] = ['profitAndLoss'];
+  const soloRows = buildPreviewRows(before);
+  t.equal(soloRows[0].type, 'half-solo');
+  const pairTarget = soloRows[0].endIdx; // = 1
+
+  // Simulate dropping expenses (currently hidden) at that index
+  const after = applyWidgetDrop(before, 'expenses', pairTarget);
+  t.deepEqual(
+    after,
+    ['profitAndLoss', 'expenses'],
+    'expenses inserted after solo'
+  );
+
+  const afterRows = buildPreviewRows(after);
+  t.equal(afterRows.length, 1, 'now a single row');
+  t.equal(afterRows[0].type, 'half-pair', 'they now form a half-pair');
+  t.end();
+});
+
+// ── 6. applyWidgetDrop ───────────────────────────────────────────────────────
+
+test('applyWidgetDrop: inserting a hidden widget at the start', (t) => {
+  const result = applyWidgetDrop(
+    ['salesInvoices', 'profitAndLoss'],
+    'cashflow',
+    0
+  );
+  t.deepEqual(result, ['cashflow', 'salesInvoices', 'profitAndLoss']);
+  t.end();
+});
+
+test('applyWidgetDrop: inserting a hidden widget in the middle', (t) => {
+  const result = applyWidgetDrop(
+    ['cashflow', 'profitAndLoss'],
+    'salesInvoices',
+    1
+  );
+  t.deepEqual(result, ['cashflow', 'salesInvoices', 'profitAndLoss']);
+  t.end();
+});
+
+test('applyWidgetDrop: inserting a hidden widget at the end', (t) => {
+  const result = applyWidgetDrop(
+    ['cashflow', 'salesInvoices'],
+    'profitAndLoss',
+    2
+  );
+  t.deepEqual(result, ['cashflow', 'salesInvoices', 'profitAndLoss']);
+  t.end();
+});
+
+test('applyWidgetDrop: moving a widget earlier (from index 2 to 0)', (t) => {
+  const order: WidgetKey[] = ['salesInvoices', 'profitAndLoss', 'cashflow'];
+  const result = applyWidgetDrop(order, 'cashflow', 0);
+  t.deepEqual(result, ['cashflow', 'salesInvoices', 'profitAndLoss']);
+  t.end();
+});
+
+test('applyWidgetDrop: moving a widget later (from index 0 to last)', (t) => {
+  const order: WidgetKey[] = ['cashflow', 'salesInvoices', 'profitAndLoss'];
+  // targetIdx=3 means "after all three"; after removal of cashflow at 0,
+  // the array has length 2 and targetIdx adjusts to 2.
+  const result = applyWidgetDrop(order, 'cashflow', 3);
+  t.deepEqual(result, ['salesInvoices', 'profitAndLoss', 'cashflow']);
+  t.end();
+});
+
+test('applyWidgetDrop: dropping at the same position is a no-op', (t) => {
+  const order: WidgetKey[] = ['cashflow', 'salesInvoices', 'profitAndLoss'];
+  // Dropping cashflow at idx=0 (before itself): currentIdx=0, targetIdx=0.
+  // After splice(0,1): order=['salesInvoices','profitAndLoss'], currentIdx(0) is NOT < targetIdx(0),
+  // so no adjustment; splice(0,0,'cashflow') → ['cashflow','salesInvoices','profitAndLoss']
+  const result = applyWidgetDrop(order, 'cashflow', 0);
+  t.deepEqual(
+    result,
+    ['cashflow', 'salesInvoices', 'profitAndLoss'],
+    'order unchanged'
+  );
+  t.end();
+});
+
+test('applyWidgetDrop: dropping widget at its own endIdx is also a no-op', (t) => {
+  // cashflow is at index 0, endIdx of its row = 1.
+  // Dropping at 1: currentIdx=0, after removal targetIdx adjusts to 0 (0 < 1 → 1-1=0),
+  // then splice(0,0,'cashflow') → same order.
+  const order: WidgetKey[] = ['cashflow', 'salesInvoices'];
+  const result = applyWidgetDrop(order, 'cashflow', 1);
+  t.deepEqual(
+    result,
+    ['cashflow', 'salesInvoices'],
+    'same order when dropped just after self'
+  );
+  t.end();
+});
+
+test('applyWidgetDrop: does not mutate the original array', (t) => {
+  const original: WidgetKey[] = ['cashflow', 'salesInvoices', 'profitAndLoss'];
+  const copy = [...original];
+  applyWidgetDrop(original, 'cashflow', 2);
+  t.deepEqual(original, copy, 'original array is unchanged');
+  t.end();
+});
+
+// ── 7. Integration: DashboardSettings singleton in an in-memory DB ──────────
 
 const fyo = getTestFyo();
 setupTestFyo(fyo, __filename);

--- a/tests/testDashboardSettings.spec.ts
+++ b/tests/testDashboardSettings.spec.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for the dashboard widget system.
+ *
+ * Two layers:
+ *   1. Pure-function tests for types.ts (no DB, no fyo)
+ *   2. Integration tests for the DashboardSettings singleton (in-memory SQLite)
+ */
+
+import { ModelNameEnum } from 'models/types';
+import {
+  ALL_WIDGET_KEYS,
+  buildWidgetRows,
+  DEFAULT_LAYOUT,
+  parseWidgetLayout,
+  PRESET_PROFILES,
+  PROFILE_LAYOUTS,
+  profileToLayout,
+  WIDGET_META,
+  WidgetConfig,
+} from 'src/pages/Dashboard/types';
+import test from 'tape';
+import { closeTestFyo, getTestFyo, setupTestFyo } from './helpers';
+
+// ── 1. parseWidgetLayout ────────────────────────────────────────────────────
+
+test('parseWidgetLayout: undefined → default layout', (t) => {
+  const result = parseWidgetLayout(undefined);
+  t.deepEqual(result, DEFAULT_LAYOUT, 'matches DEFAULT_LAYOUT');
+  t.notEqual(result, DEFAULT_LAYOUT, 'returns a copy, not the same reference');
+  t.end();
+});
+
+test('parseWidgetLayout: invalid JSON → default layout', (t) => {
+  const result = parseWidgetLayout('not valid json {{');
+  t.deepEqual(result, DEFAULT_LAYOUT, 'falls back to DEFAULT_LAYOUT');
+  t.end();
+});
+
+test('parseWidgetLayout: valid JSON round-trips correctly', (t) => {
+  const saved: WidgetConfig[] = [
+    { id: 'salesInvoices', visible: true },
+    { id: 'cashflow', visible: false },
+    { id: 'purchaseInvoices', visible: true },
+    { id: 'profitAndLoss', visible: true },
+    { id: 'expenses', visible: true },
+  ];
+  const result = parseWidgetLayout(JSON.stringify(saved));
+  t.equal(result[0].id, 'salesInvoices', 'order preserved');
+  t.equal(result[1].visible, false, 'visibility preserved');
+  t.end();
+});
+
+test('parseWidgetLayout: forward-compat — unknown ids in saved are kept, missing keys are appended', (t) => {
+  // Simulate a save that is missing 'expenses' (added in a later release)
+  const partialSave: WidgetConfig[] = ALL_WIDGET_KEYS.filter(
+    (id) => id !== 'expenses'
+  ).map((id) => ({ id, visible: true }));
+
+  const result = parseWidgetLayout(JSON.stringify(partialSave));
+  const resultIds = result.map((c) => c.id);
+
+  t.ok(resultIds.includes('expenses'), "'expenses' appended when missing");
+  t.equal(
+    result.find((c) => c.id === 'expenses')?.visible,
+    true,
+    'newly-appended widget defaults to visible'
+  );
+  t.equal(
+    result.length,
+    ALL_WIDGET_KEYS.length,
+    'length matches ALL_WIDGET_KEYS'
+  );
+  t.end();
+});
+
+// ── 2. profileToLayout ──────────────────────────────────────────────────────
+
+test('profileToLayout: every preset contains all widget keys', (t) => {
+  for (const profile of PRESET_PROFILES) {
+    const layout = profileToLayout(profile);
+    const ids = layout.map((c) => c.id);
+    t.equal(
+      ids.length,
+      ALL_WIDGET_KEYS.length,
+      `${profile}: layout has all keys`
+    );
+    for (const key of ALL_WIDGET_KEYS) {
+      t.ok(ids.includes(key), `${profile}: contains '${key}'`);
+    }
+  }
+  t.end();
+});
+
+test('profileToLayout: visible widgets come first, in profile order', (t) => {
+  for (const profile of PRESET_PROFILES) {
+    const layout = profileToLayout(profile);
+    const visibleIds = layout.filter((c) => c.visible).map((c) => c.id);
+    t.deepEqual(
+      visibleIds,
+      PROFILE_LAYOUTS[profile],
+      `${profile}: visible order matches PROFILE_LAYOUTS`
+    );
+  }
+  t.end();
+});
+
+test('profileToLayout: Freelancer hides Cashflow', (t) => {
+  const layout = profileToLayout('Freelancer');
+  const cashflow = layout.find((c) => c.id === 'cashflow');
+  t.equal(cashflow?.visible, false, 'cashflow hidden for Freelancer');
+  t.end();
+});
+
+// ── 3. buildWidgetRows ──────────────────────────────────────────────────────
+
+test('buildWidgetRows: empty visible list → no rows', (t) => {
+  const rows = buildWidgetRows(
+    ALL_WIDGET_KEYS.map((id) => ({ id, visible: false }))
+  );
+  t.equal(rows.length, 0, 'no rows when all hidden');
+  t.end();
+});
+
+test('buildWidgetRows: single full-width widget → one full row', (t) => {
+  const rows = buildWidgetRows([{ id: 'cashflow', visible: true }]);
+  t.equal(rows.length, 1);
+  t.equal(rows[0].type, 'full');
+  if (rows[0].type === 'full') {
+    t.equal(rows[0].widget.id, 'cashflow');
+  }
+  t.end();
+});
+
+test('buildWidgetRows: two adjacent half-width widgets → one half-pair row', (t) => {
+  const rows = buildWidgetRows([
+    { id: 'salesInvoices', visible: true },
+    { id: 'purchaseInvoices', visible: true },
+  ]);
+  t.equal(rows.length, 1);
+  t.equal(rows[0].type, 'half-pair');
+  if (rows[0].type === 'half-pair') {
+    t.equal(rows[0].left.id, 'salesInvoices');
+    t.equal(rows[0].right.id, 'purchaseInvoices');
+  }
+  t.end();
+});
+
+test('buildWidgetRows: lone half-width widget → half-solo row', (t) => {
+  const rows = buildWidgetRows([{ id: 'profitAndLoss', visible: true }]);
+  t.equal(rows.length, 1);
+  t.equal(rows[0].type, 'half-solo');
+  if (rows[0].type === 'half-solo') {
+    t.equal(rows[0].widget.id, 'profitAndLoss');
+  }
+  t.end();
+});
+
+test('buildWidgetRows: mixed layout builds correct row sequence', (t) => {
+  // cashflow (full) + salesInvoices + purchaseInvoices (pair) + profitAndLoss (solo)
+  const rows = buildWidgetRows([
+    { id: 'cashflow', visible: true },
+    { id: 'salesInvoices', visible: true },
+    { id: 'purchaseInvoices', visible: true },
+    { id: 'profitAndLoss', visible: true },
+  ]);
+  t.equal(rows.length, 3, 'three rows');
+  t.equal(rows[0].type, 'full', 'first row is full');
+  t.equal(rows[1].type, 'half-pair', 'second row is half-pair');
+  t.equal(rows[2].type, 'half-solo', 'third row is half-solo (unpaired half)');
+  t.end();
+});
+
+test('buildWidgetRows: hidden widgets are excluded', (t) => {
+  const rows = buildWidgetRows([
+    { id: 'cashflow', visible: false },
+    { id: 'salesInvoices', visible: true },
+    { id: 'purchaseInvoices', visible: false },
+  ]);
+  // cashflow hidden, purchaseInvoices hidden → only salesInvoices visible → half-solo
+  t.equal(rows.length, 1);
+  t.equal(rows[0].type, 'half-solo');
+  t.end();
+});
+
+// ── 4. WIDGET_META completeness ─────────────────────────────────────────────
+
+test('WIDGET_META: every WidgetKey has a complete entry', (t) => {
+  for (const key of ALL_WIDGET_KEYS) {
+    const meta = WIDGET_META[key];
+    t.ok(meta, `${key}: entry exists`);
+    t.ok(meta.label, `${key}: has label`);
+    t.ok(meta.description, `${key}: has description`);
+    t.ok(meta.width === 'full' || meta.width === 'half', `${key}: valid width`);
+    t.equal(typeof meta.wrapClass, 'string', `${key}: wrapClass is a string`);
+  }
+  t.end();
+});
+
+// ── 5. Integration: DashboardSettings singleton in an in-memory DB ──────────
+
+const fyo = getTestFyo();
+setupTestFyo(fyo, __filename);
+
+test('DashboardSettings: schema is registered', (t) => {
+  t.ok(
+    fyo.schemaMap[ModelNameEnum.DashboardSettings],
+    'schema exists in schemaMap'
+  );
+  t.equal(
+    fyo.schemaMap[ModelNameEnum.DashboardSettings]?.isSingle,
+    true,
+    'schema is a singleton'
+  );
+  t.end();
+});
+
+test('DashboardSettings: getDoc returns a doc with correct defaults', async (t) => {
+  const doc = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
+  t.equal(
+    doc.schemaName,
+    ModelNameEnum.DashboardSettings,
+    'schemaName matches'
+  );
+  t.equal(
+    doc.activeProfile ?? 'Custom',
+    'Custom',
+    'activeProfile defaults to Custom'
+  );
+  t.equal(doc.widgetLayout, undefined, 'widgetLayout starts as undefined');
+  t.end();
+});
+
+test('DashboardSettings: setMultiple + sync persists values', async (t) => {
+  const layout: WidgetConfig[] = profileToLayout('Freelancer');
+  const doc = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
+
+  await doc.setMultiple({
+    widgetLayout: JSON.stringify(layout),
+    activeProfile: 'Freelancer',
+  });
+  await doc.sync();
+
+  // Re-fetch (cache will return the same doc, but values are updated)
+  const reloaded = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
+  t.equal(reloaded.activeProfile, 'Freelancer', 'activeProfile persisted');
+  t.ok(reloaded.widgetLayout, 'widgetLayout was saved');
+
+  const parsed = parseWidgetLayout(reloaded.widgetLayout as string);
+  const visibleIds = parsed.filter((c) => c.visible).map((c) => c.id);
+  t.deepEqual(
+    visibleIds,
+    PROFILE_LAYOUTS['Freelancer'],
+    'parsed layout matches Freelancer profile'
+  );
+  t.end();
+});
+
+test('DashboardSettings: saving Custom layout round-trips correctly', async (t) => {
+  const customLayout: WidgetConfig[] = [
+    { id: 'profitAndLoss', visible: true },
+    { id: 'cashflow', visible: false },
+    { id: 'salesInvoices', visible: true },
+    { id: 'purchaseInvoices', visible: false },
+    { id: 'expenses', visible: true },
+  ];
+
+  const doc = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
+  await doc.setMultiple({
+    widgetLayout: JSON.stringify(customLayout),
+    activeProfile: 'Custom',
+  });
+  await doc.sync();
+
+  const reloaded = await fyo.doc.getDoc(ModelNameEnum.DashboardSettings);
+  const parsed = parseWidgetLayout(reloaded.widgetLayout as string);
+
+  t.equal(parsed[0].id, 'profitAndLoss', 'custom order preserved (first)');
+  t.equal(parsed[1].visible, false, 'cashflow still hidden');
+  t.equal(reloaded.activeProfile, 'Custom', 'profile is Custom');
+  t.end();
+});
+
+closeTestFyo(fyo, __filename);

--- a/utils/db/types.ts
+++ b/utils/db/types.ts
@@ -108,3 +108,4 @@ export type TotalCreditAndDebit = {
 export type CashOnHand = { total: number };
 export type TopCustomers = { party: string; total: number }[];
 export type GrossMargin = { income: number; cogs: number };
+export type TopSuppliers = { party: string; total: number }[];

--- a/utils/db/types.ts
+++ b/utils/db/types.ts
@@ -43,7 +43,7 @@ export abstract class DatabaseBase {
 
   // Delete
   abstract delete(schemaName: string, name: string): Promise<void>;
-  
+
   abstract deleteAll(schemaName:string, filters:QueryFilter): Promise<number>;
 
   // Other
@@ -105,3 +105,6 @@ export type TotalCreditAndDebit = {
   totalCredit: number;
   totalDebit: number;
 };
+export type CashOnHand = { total: number };
+export type TopCustomers = { party: string; total: number }[];
+export type GrossMargin = { income: number; cogs: number };


### PR DESCRIPTION
## What this PR does

The dashboard previously displayed a fixed set of 5 widgets with no way to show, hide, or reorder them. This PR replaces that with a fully customizable layout system:

- Users open a **Customize panel** (⚙ gear icon in the dashboard header) to manage their layout
- Widgets can be **dragged and dropped** into any position in a live preview that mirrors the real dashboard layout (full-width rows and side-by-side half-width pairs)
- Widgets can be **hidden** by dragging them to a tray or clicking ✕ — hidden widgets can be dragged back into the layout at any time
- **Three built-in profile presets** let users apply a sensible starting layout based on their business type
- Layout is **persisted per company file** in a new `DashboardSettings` singleton backed by SQLite, so each file keeps its own preferences

Existing users who haven't touched Customize will see no change — the default layout is the same 5 original widgets.

---

## New widgets (8 added, opt-in via Customize)

| Widget | Width | Description |
|---|---|---|
| **Overdue Invoices** | half | Sales invoices with outstanding amounts 30+ days old, sorted by most recently overdue; each row links to the invoice editor |
| **Upcoming Bills** | half | Unpaid purchase invoices from the last 30 days, sorted oldest-first so the most urgent surface at the top |
| **Cash on Hand** | half | Real-time total across all Cash and Bank accounts; turns pink when negative |
| **Top Customers** | half | Top 5 parties by revenue for the selected period, with a relative bar to compare magnitudes |
| **Top Suppliers** | half | Top 5 suppliers by purchase spend for the selected period, with a relative bar |
| **Gross Margin** | half | (Revenue − COGS) / Revenue %, color-coded by health (green / blue / pink), with raw figures below |
| **Draft Invoices** | half | Count and total value of unsubmitted sales invoices not yet sent to clients |
| **Receivables Aging** | half | Outstanding sales invoices bucketed by age (0–30 / 31–60 / 61–90 / 90+ days) as a segmented bar with hover tooltips |

---

## Profile presets

| Preset | Rationale | Visible widgets |
|---|---|---|
| **Freelancer** | AR-anxious solo earner; no COGS so Gross Margin is omitted | Cash on Hand, Draft Invoices, Sales Invoices, Overdue Invoices, Upcoming Bills, Profit & Loss |
| **Shop / Trader** | Buy-sell cycle; gross margin and purchase tracking are the core need | Cashflow, Cash on Hand, Gross Margin, Sales Invoices, Purchase Invoices, Top Suppliers, Upcoming Bills, Top Expenses |
| **Small Business** | Multi-person operation needing the full executive picture | Cashflow, Cash on Hand, Profit & Loss, Sales Invoices, Overdue Invoices, Receivables Aging, Top Customers, Top Expenses |

---

## Screenshots

### Dashboard — default view

<img width="2500" height="1774" alt="Screenshot From 2026-05-09 08-08-32" src="https://github.com/user-attachments/assets/79272e74-1598-4059-a229-88022d35d602" />

### Customize panel — preset cards

<img width="2644" height="1852" alt="Screenshot From 2026-05-09 08-10-35" src="https://github.com/user-attachments/assets/b802f3cb-9c98-43e7-a856-df4f023bec01" />

### New widgets in use

<img width="2644" height="1852" alt="Screenshot From 2026-05-09 08-14-47" src="https://github.com/user-attachments/assets/3a4ef5dd-7295-4014-9aa9-5def90851668" />

<img width="2644" height="1852" alt="Screenshot From 2026-05-09 08-30-38" src="https://github.com/user-attachments/assets/4f61444e-b55e-476a-914c-1fb6e4fe47f0" />

### Empty state

<img width="2644" height="1852" alt="Screenshot From 2026-05-09 08-15-19" src="https://github.com/user-attachments/assets/e836e9c2-5f06-4c17-adf1-70b7171d7372" />

---

## Technical details

### New files

| File | Purpose |
|---|---|
| `schemas/app/DashboardSettings.json` | `isSingle` schema with `widgetLayout` (Text) and `activeProfile` (Select) fields |
| `models/baseModels/DashboardSettings.ts` | Model class for the singleton |
| `src/pages/Dashboard/types.ts` | `WidgetKey` union, `WIDGET_META`, preset layouts, `parseWidgetLayout`, `buildWidgetRows`, `buildPreviewRows`, `applyWidgetDrop` |
| `src/pages/Dashboard/DashboardCustomizePanel.vue` | Drag-and-drop customize panel |
| `src/pages/Dashboard/CashOnHand.vue` | New widget |
| `src/pages/Dashboard/GrossMargin.vue` | New widget |
| `src/pages/Dashboard/InvoiceDrafts.vue` | New widget |
| `src/pages/Dashboard/OverdueInvoices.vue` | New widget |
| `src/pages/Dashboard/TopCustomers.vue` | New widget |
| `src/pages/Dashboard/TopSuppliers.vue` | New widget |
| `src/pages/Dashboard/UpcomingBills.vue` | New widget |
| `src/pages/Dashboard/ReceivablesAging.vue` | New widget |
| `tests/testDashboardSettings.spec.ts` | 113 passing assertions (pure-function + DB round-trip) |

### Modified files

| File | Change |
|---|---|
| `src/pages/Dashboard/Dashboard.vue` | Refactored to render rows dynamically from saved layout; empty state added |
| `src/pages/Dashboard/BaseDashboardChart.vue` | Added `mounted()` + `activated()` hooks so widgets load on first render and on navigation-back |
| `src/pages/Dashboard/Cashflow.vue` | Added `mounted()` to call `setHasData()` (required alongside the base hook) |
| `backend/database/bespoke.ts` | Added `getCashOnHand`, `getTopCustomers`, `getTopSuppliers`, `getGrossMargin` |
| `fyo/core/dbHandler.ts` | Wired new bespoke queries |
| `utils/db/types.ts` | Added types for new bespoke queries |
| `models/index.ts`, `models/types.ts` | Registered `DashboardSettings` |
| `schemas/schemas.ts` | Registered `DashboardSettings` schema |

### Backwards compatibility

- The default layout is identical to the original 5-widget dashboard — existing users see no change until they open Customize
- `parseWidgetLayout` is forward-compatible: any widget key added in a future release that isn't present in a user's saved layout is appended as visible rather than silently disappearing

---

## Tests

```
yarn test tests/testDashboardSettings.spec.ts
```

113 passing assertions across:
- `parseWidgetLayout` (undefined, invalid JSON, valid round-trip, forward-compat for new keys)
- `profileToLayout` (all three presets produce correct ordered + hidden tail)
- `buildWidgetRows` (full, half-pair, half-solo, mixed sequences)
- `buildPreviewRows` and `applyWidgetDrop` (insertion, reorder, same-position no-op, immutability)
- `WIDGET_META` completeness (all 13 keys have label, description, width, wrapClass, icon)
- `DashboardSettings` DB round-trip (save and reload layout + profile via in-memory SQLite)