### PR TITLE
feat: add optional governed AI (MCP) access via Kriya

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,5 +60,6 @@ module.exports = {
     'postcss.config.js',
     'src/components/**/*.vue', // Incrementally fix these
     'electron-builder.ts',
+    'kriya-mcp/', // optional governed-MCP exec; run via ts-node, not part of the typed app build
   ],
 };

--- a/kriya-mcp/.mcp.json
+++ b/kriya-mcp/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "//": "TEMPLATE — copy the mcpServers.frappe-books block into your assistant's MCP config and replace /ABSOLUTE/PATH/TO/books with your Frappe Books checkout. Claude Desktop (macOS): ~/Library/Application Support/Claude/claude_desktop_config.json. Set FRAPPE_BOOKS_DEMO=1 (instead of FRAPPE_BOOKS_DB) to try it against a throwaway in-memory company. See README.md.",
+  "mcpServers": {
+    "frappe-books": {
+      "command": "kriya-mcp",
+      "args": [
+        "--persistent",
+        "--name", "frappe-books",
+        "--exec", "bash /ABSOLUTE/PATH/TO/books/kriya-mcp/run.sh",
+        "--tools", "/ABSOLUTE/PATH/TO/books/kriya-mcp/tools.json",
+        "--policy", "/ABSOLUTE/PATH/TO/books/kriya-mcp/agent-policy.yaml",
+        "--approval", "gui",
+        "--actor", "claude-desktop"
+      ],
+      "env": {
+        "FRAPPE_BOOKS_DB": "/ABSOLUTE/PATH/TO/your-company.books.db"
+      }
+    }
+  }
+}

--- a/kriya-mcp/README.md
+++ b/kriya-mcp/README.md
@@ -1,0 +1,97 @@
+# Governed AI access for Frappe Books (optional)
+
+This folder lets an AI assistant (Claude Desktop, Cursor, …) safely **operate** Frappe Books — not
+by screen-scraping or opening the raw SQLite file, but by exposing Books' *existing* actions as a
+**governed [MCP](https://modelcontextprotocol.io) server**.
+
+It is **optional and off by default**, adds **no dependency** to the app, and **changes nothing** in
+it. If you never wire it into an assistant, none of this runs.
+
+> Why this exists: Frappe Books is local-first with no API, so until now there was no *safe* way to
+> let an assistant do things in it. This gives the agent a narrow, permissioned, audited door instead
+> of ungoverned database access — and it reuses the **same** in-process `fyo` layer the UI uses, so an
+> AI tool-call runs the identical `Doc.sync()` / `.submit()` a human action does.
+
+---
+
+## What you get
+
+- 🔒 **Permissions** — the agent can only call allow-listed actions (everything else denied).
+- ✋ **Human approval** — creating a financial document, **submitting one (which posts double-entry
+  ledger entries — the money moment)**, and anything destructive pause for a one-click yes/no.
+- 🧾 **Signed audit log** — every executed action is an Ed25519-signed receipt you can replay.
+- 💸 **Budget cap** — at most N actions per rolling minute.
+
+## How it works
+
+```
+  Claude Desktop ──MCP/stdio──▶  kriya-mcp  ──one JSON line per action──▶  run.sh → kriya-exec.ts
+  (the agent)                    (governor)                                (Books' headless fyo layer)
+                                    │                                          │
+                          policy ▸ approval ▸ budget ▸ audit            new Fyo({…isElectron:false})
+                          (agent-policy.yaml)                            getNewDoc().sync()/.submit() → .books.db
+```
+
+- **`kriya-exec.ts`** builds a headless `Fyo` exactly the way Books' own test harness does
+  (`new Fyo({ DatabaseDemux: DatabaseManager, AuthDemux: DummyAuthDemux, isElectron: false })`), opens
+  your company file, and dispatches each action to the same `fyo.doc.getNewDoc(...).sync()/.submit()`
+  and `fyo.db.*` calls the app uses. No GUI, no rewrite, no `kriya` dependency in this repo.
+- **`run.sh`** runs it via Books' own **Electron-as-Node + ts-node + tsconfig-paths** runner (so the
+  `fyo`/`backend`/`models` path aliases and the Electron-ABI `better-sqlite3` resolve).
+- **`kriya-mcp`** (the open-source [`kriya`](https://crates.io/crates/kriya) crate) is the external
+  governor: it speaks MCP to the assistant and enforces every gate before forwarding a cleared action.
+
+## Enable it
+
+1. **Install Books' deps** (from the repo root, if you haven't): `yarn install`
+   (its `postinstall` builds `better-sqlite3` for Electron's ABI, which `run.sh` then uses).
+2. **Install the governor:** `cargo install kriya` (provides `kriya-mcp` on your PATH).
+3. **Point it at your data:** set `FRAPPE_BOOKS_DB` to your company `.books.db`, or
+   `FRAPPE_BOOKS_DEMO=1` for a throwaway in-memory company (seeded with a chart of accounts).
+4. **Try the handler directly first** (no governor, demo company):
+   ```bash
+   FRAPPE_BOOKS_DEMO=1 printf '%s\n' \
+     '{"action":"create_party","params":{"name":"Acme Corp","role":"Customer"}}' \
+     '{"action":"list_documents","params":{"schemaName":"Party"}}' \
+   | bash kriya-mcp/run.sh
+   ```
+5. **Wire it into your assistant:** copy the `mcpServers.frappe-books` block from [`.mcp.json`](.mcp.json)
+   into your assistant's MCP config (Claude Desktop on macOS:
+   `~/Library/Application Support/Claude/claude_desktop_config.json`), replacing the placeholders.
+   Restart and ask: *"What's my outstanding receivable this quarter?"*
+
+## Governance model
+
+| Tier | Actions | Policy |
+|---|---|---|
+| Read / report | `list_documents`, `get_document`, `get_outstanding`, `get_cashflow`, `get_income_and_expenses` | allow |
+| Routine record-keeping | `create_party`, `create_item`, `create_account` | allow + audit |
+| Financial document / ledger / destructive | `create_sales_invoice`, `create_payment`, **`submit_document`** (posts the ledger), `cancel_document`, `delete_document` | **human approval** + audit |
+| Anything else | — | **denied** |
+
+Edit [`agent-policy.yaml`](agent-policy.yaml) to tighten/loosen (e.g. `allow: false` to forbid, or
+drop `require_approval` to run audited). The exposed surface is in [`tools.json`](tools.json).
+
+## Notes for agents
+
+- **Money is in major currency units** (Books uses `pesa` decimals, e.g. `100` or `100.50`): item
+  `rate`, payment `amount`, invoice line `rate`.
+- **IDs auto-generate**; numbered docs (invoices/payments) get their series number on creation.
+- **Foreign keys are enforced** — create the `Party`, `Account`, and `Item` before referencing them in
+  an invoice (`account` is the receivable, e.g. `Debtors`; the item's income/expense account auto-resolves).
+- **`submit_document` is the money moment** — it posts the double-entry `AccountingLedgerEntry` rows;
+  the policy gates it behind human approval.
+- `backup_database` / `restore_database` are intentionally **not** exposed (they need the GUI dialog).
+
+## Approval on each OS · audit log
+
+`--approval gui` is a native macOS dialog (works under Claude Desktop's no-terminal host). On
+Linux/Windows, run `kriya-mcp` from a terminal with `--approval tty`, or keep the default and know
+approval-required actions safely **deny** when no human can be asked. Executed actions are signed into
+`$TMPDIR/kriya-audit.jsonl` (override with `--audit-log`).
+
+## License boundary
+
+Frappe Books is **AGPL-3.0**; this folder is an in-repo bolt-on under the same license. `kriya-mcp`
+runs as a **separate process** over the stdio JSON pipe (never linked into Books, and no Books/`fyo`
+code is vendored into `kriya-mcp`), so the copyleft boundary stays at the exec.

--- a/kriya-mcp/agent-policy.yaml
+++ b/kriya-mcp/agent-policy.yaml
@@ -1,0 +1,46 @@
+# Governance policy for the Frappe Books bolt-on. kriya-mcp enforces this on every tools/call from
+# the external agent — the agent can only *propose*; this policy decides.
+#
+# Posture: reads + reports flow freely; routine record-keeping is allowed but audited; anything that
+# creates a financial document or POSTS TO THE LEDGER (submit) — i.e. moves money on the books — or
+# destroys/reverses a record pauses for on-device human approval. Everything else is denied by
+# default, and a per-minute cap stops a runaway agent. First matching rule wins.
+rules:
+  # Reads + reports — safe to run unattended.
+  - action: "get_*"
+    allow: true
+  - action: "list_documents"
+    allow: true
+
+  # Routine record-keeping — allowed, and recorded in the signed audit log.
+  - action: "create_party"
+    allow: true
+  - action: "create_item"
+    allow: true
+  - action: "create_account"
+    allow: true
+
+  # Financial documents + ledger posting + destructive — require a human's go-ahead, every time.
+  - action: "create_sales_invoice"
+    allow: true
+    require_approval: true
+  - action: "create_payment"
+    allow: true
+    require_approval: true
+  - action: "submit_document"   # posts double-entry AccountingLedgerEntry rows — the money moment
+    allow: true
+    require_approval: true
+  - action: "cancel_document"   # reverses ledger entries
+    allow: true
+    require_approval: true
+  - action: "delete_document"
+    allow: true
+    require_approval: true
+
+  # Everything else: denied (deny-by-default).
+  - action: "*"
+    allow: false
+
+budget:
+  # A looping agent can't hammer your books: at most 30 actions per rolling minute.
+  max_actions_per_minute: 30

--- a/kriya-mcp/kriya-exec.ts
+++ b/kriya-mcp/kriya-exec.ts
@@ -1,0 +1,233 @@
+/**
+ * Headless governed-MCP executor for Frappe Books — the flagship "real double-entry accounting"
+ * bolt-on. See README.md for how to run it.
+ *
+ * Frappe Books has NO published API package and NO REST endpoint — its capabilities live only in
+ * the running app's in-process `fyo` doctype layer. That is exactly Kriya's wedge. This script
+ * reuses that SAME layer headlessly (the bootstrap proven by Books' own test harness:
+ * `new Fyo({ DatabaseDemux: DatabaseManager, AuthDemux: DummyAuthDemux, isElectron: false })`),
+ * so an AI tool-call runs the identical `Doc.sync()/.submit()` a human action does — no rewrite,
+ * no new API, no GUI.
+ *
+ * It performs NO governance. The external `kriya-mcp` process decides policy → approval → budget →
+ * signed-audit on every call BEFORE forwarding it here (see agent-policy.yaml). By the time a line
+ * arrives, the action has cleared every gate. The Books app itself is untouched and unaware.
+ *
+ * Protocol (one JSON object per line):
+ *   in   {"action":"create_sales_invoice","params":{...}}
+ *   out  {"success":true,"data":{...}}  |  {"success":false,"error":"..."}
+ *
+ * Runs inside a Books checkout via its Electron-as-Node + ts-node + tsconfig-paths runner (run.sh),
+ * which resolves the `fyo`/`backend`/`models`/`src` path aliases and the Electron-ABI better-sqlite3.
+ */
+
+import { createInterface } from 'node:readline';
+
+// Books' own in-process layer (resolved via the checkout's tsconfig path aliases at run time).
+import { DatabaseManager } from 'backend/database/manager';
+import { Fyo } from 'fyo';
+import { DummyAuthDemux } from 'fyo/tests/helpers';
+import setupInstance from 'src/setup/setupInstance';
+import { getTestSetupWizardOptions } from 'tests/helpers';
+import { initializeInstance } from 'src/utils/initialization';
+
+// kriya-mcp reads ONE line of JSON per reply on stdout; Books/fyo/migrations also log to stdout,
+// which would corrupt the protocol. Capture the real stdout.write for replies and divert all other
+// chatter (console.log, library output) to stderr.
+const stdoutWrite = process.stdout.write.bind(process.stdout);
+process.stdout.write = process.stderr.write.bind(process.stderr) as typeof process.stdout.write;
+console.log = (...args: unknown[]) => console.error(...args);
+console.info = (...args: unknown[]) => console.error(...args);
+
+type Json = Record<string, unknown>;
+
+const ok = (data: unknown): string => JSON.stringify({ success: true, data: data ?? null });
+const fail = (message: string): string => JSON.stringify({ success: false, error: message });
+
+function reqStr(p: Json, key: string): string {
+  const v = p[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(`parameter '${key}' is required and must be a string`);
+  }
+  return v;
+}
+
+/** A small, JSON-safe summary of a Doc after a write (avoids serializing Money/pesa objects). */
+function summarize(doc: any): unknown {
+  return {
+    name: doc.name,
+    schemaName: doc.schemaName,
+    submitted: !!doc.submitted,
+    cancelled: !!doc.cancelled,
+  };
+}
+
+/**
+ * Build a headless Fyo and connect a company file. Two modes:
+ *   FRAPPE_BOOKS_DEMO=1 → a fresh in-memory company seeded with a chart of accounts (for trying it).
+ *   otherwise          → open the existing company file at FRAPPE_BOOKS_DB.
+ */
+async function buildFyo(): Promise<any> {
+  const fyo: any = new Fyo({
+    DatabaseDemux: DatabaseManager,
+    AuthDemux: DummyAuthDemux,
+    isTest: true, // skips backups + keeps telemetry off; safe for headless use
+    isElectron: false,
+  });
+
+  if (process.env.FRAPPE_BOOKS_DEMO) {
+    // Fresh in-memory company (seeds India chart of accounts: 'Sales', 'Debtors', 'Cost of Goods Sold', ...).
+    await setupInstance(':memory:', getTestSetupWizardOptions(), fyo);
+  } else {
+    const dbPath = process.env.FRAPPE_BOOKS_DB;
+    if (!dbPath) {
+      throw new Error('set FRAPPE_BOOKS_DB to your company .books.db (or FRAPPE_BOOKS_DEMO=1 for an in-memory demo)');
+    }
+    // isNew=false → connect to the existing file + register models (initializeInstance does both).
+    await (initializeInstance as any)(dbPath, false, undefined, fyo);
+  }
+  return fyo;
+}
+
+/**
+ * Map an action id to Books' existing `fyo` operations — the SAME ones the UI drives. Unknown
+ * actions are rejected so an agent only ever reaches this curated surface. Governance (which of
+ * these need approval) is enforced upstream by kriya-mcp via agent-policy.yaml.
+ */
+async function dispatch(fyo: any, action: string, p: Json): Promise<string> {
+  switch (action) {
+    // ---- Reads (policy: allow) ----
+    case 'list_documents':
+      return ok(await fyo.db.getAllRaw(reqStr(p, 'schemaName'), {
+        filters: (p.filters as object) ?? {},
+        fields: p.fields as string[] | undefined,
+      }));
+    case 'get_document': {
+      const rows = await fyo.db.getAllRaw(reqStr(p, 'schemaName'), { filters: { name: reqStr(p, 'name') } });
+      return ok((rows as unknown[])[0] ?? null);
+    }
+    case 'get_outstanding': // receivables (SalesInvoice) or payables (PurchaseInvoice)
+      return ok(await fyo.db.getTotalOutstanding(reqStr(p, 'schemaName'), reqStr(p, 'fromDate'), reqStr(p, 'toDate')));
+    case 'get_cashflow':
+      return ok(await fyo.db.getCashflow(reqStr(p, 'fromDate'), reqStr(p, 'toDate')));
+    case 'get_income_and_expenses':
+      return ok(await fyo.db.getIncomeAndExpenses(reqStr(p, 'fromDate'), reqStr(p, 'toDate')));
+
+    // ---- Routine record-keeping (policy: allow + audit) ----
+    case 'create_party': {
+      const doc = fyo.doc.getNewDoc('Party');
+      await doc.set({ name: reqStr(p, 'name'), role: (p.role as string) ?? 'Customer' });
+      await doc.sync();
+      return ok(summarize(doc));
+    }
+    case 'create_item': {
+      const doc = fyo.doc.getNewDoc('Item');
+      await doc.set({
+        name: reqStr(p, 'name'),
+        for: (p.for as string) ?? 'Sales',
+        incomeAccount: reqStr(p, 'incomeAccount'),
+        expenseAccount: reqStr(p, 'expenseAccount'),
+      });
+      if (p.rate != null) await doc.set('rate', fyo.pesa(p.rate as number));
+      await doc.sync();
+      return ok(summarize(doc));
+    }
+    case 'create_account': {
+      const doc = fyo.doc.getNewDoc('Account');
+      await doc.set({ name: reqStr(p, 'name'), rootType: reqStr(p, 'rootType') });
+      if (p.parentAccount != null) await doc.set('parentAccount', p.parentAccount);
+      if (p.accountType != null) await doc.set('accountType', p.accountType);
+      if (p.isGroup != null) await doc.set('isGroup', p.isGroup);
+      await doc.sync();
+      return ok(summarize(doc));
+    }
+
+    // ---- Financial documents — money (policy: require_approval) ----
+    case 'create_sales_invoice': {
+      const doc = fyo.doc.getNewDoc('SalesInvoice');
+      await doc.set({ party: reqStr(p, 'party'), account: reqStr(p, 'account'), date: reqStr(p, 'date') });
+      for (const it of ((p.items as Array<Record<string, unknown>>) ?? [])) {
+        await doc.append('items', {
+          item: it.item,
+          quantity: it.quantity ?? 1,
+          rate: fyo.pesa((it.rate as number) ?? 0),
+        });
+      }
+      await doc.sync(); // creates a DRAFT invoice (numberSeries default SINV-); submit posts the ledger
+      return ok(summarize(doc));
+    }
+    case 'create_payment': {
+      const doc = fyo.doc.getNewDoc('Payment');
+      await doc.set({
+        party: reqStr(p, 'party'),
+        paymentType: reqStr(p, 'paymentType'), // 'Receive' | 'Pay'
+        account: reqStr(p, 'account'),
+        paymentAccount: reqStr(p, 'paymentAccount'),
+        paymentMethod: (p.paymentMethod as string) ?? 'Cash',
+        date: reqStr(p, 'date'),
+        amount: fyo.pesa((p.amount as number) ?? 0),
+      });
+      await doc.sync();
+      return ok(summarize(doc));
+    }
+    case 'submit_document': {
+      // Posts double-entry ledger entries (Transactional.afterSubmit). The headline governed action.
+      const doc = await fyo.doc.getDoc(reqStr(p, 'schemaName'), reqStr(p, 'name'));
+      await doc.submit();
+      return ok(summarize(doc));
+    }
+    case 'cancel_document': {
+      const doc = await fyo.doc.getDoc(reqStr(p, 'schemaName'), reqStr(p, 'name'));
+      await doc.cancel();
+      return ok(summarize(doc));
+    }
+    case 'delete_document': {
+      const doc = await fyo.doc.getDoc(reqStr(p, 'schemaName'), reqStr(p, 'name'));
+      await doc.delete();
+      return ok({ name: reqStr(p, 'name'), deleted: true });
+    }
+
+    default:
+      return fail(`unknown action '${action}'`);
+  }
+}
+
+async function main(): Promise<void> {
+  const fyo = await buildFyo();
+  process.stderr.write('[books kriya-exec] ready\n');
+
+  // One request line → one reply line; EOF ends the session (covers both kriya-mcp executor modes).
+  const rl = createInterface({ input: process.stdin });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let req: { action?: string; params?: Json };
+    try {
+      req = JSON.parse(trimmed);
+    } catch {
+      stdoutWrite(fail('request was not valid JSON') + '\n');
+      continue;
+    }
+    let out: string;
+    try {
+      out = await dispatch(fyo, req.action ?? '', req.params ?? {});
+    } catch (err) {
+      out = fail(err instanceof Error ? err.message : String(err));
+    }
+    stdoutWrite(out + '\n');
+  }
+
+  // stdin closed (session over): close the DB cleanly, then exit. Electron's runtime and the open
+  // SQLite handle keep the event loop alive, so without this the process would linger after EOF.
+  try {
+    await fyo.close();
+  } catch {
+    /* best effort */
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[books kriya-exec] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/kriya-mcp/run.sh
+++ b/kriya-mcp/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run the Frappe Books kriya-exec handler headlessly, reusing Books' OWN runner (Electron-as-Node
+# + ts-node + tsconfig-paths). The external `kriya-mcp` governor points its `--exec` at this script.
+#
+# Frappe Books ships no API package, and its better-sqlite3 is built for Electron's ABI by the
+# repo's `postinstall: electron-rebuild`, so we run under the repo's Electron-as-Node (cwd = repo
+# root) to resolve the path aliases + the native module. `TS_NODE_TRANSPILE_ONLY` keeps the repo's
+# strict typecheck from gating this standalone script.
+#
+# Env (all optional — sensible defaults for running inside the repo):
+#   BOOKS_DIR            Books checkout root (default: this script's parent dir)
+#   BOOKS_KRIYA_HANDLER  path to kriya-exec.ts (default: alongside this script)
+#   FRAPPE_BOOKS_DB      your company .books.db  (omit + set FRAPPE_BOOKS_DEMO=1 to demo)
+#   FRAPPE_BOOKS_DEMO    "1" → fresh in-memory demo company (seeded chart of accounts)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BOOKS_DIR="${BOOKS_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+HANDLER="${BOOKS_KRIYA_HANDLER:-$SCRIPT_DIR/kriya-exec.ts}"
+
+cd "$BOOKS_DIR" # cwd must be the repo root so tsconfig-paths resolves Books' aliases + native deps
+export ELECTRON_RUN_AS_NODE=true
+export TS_NODE_TRANSPILE_ONLY=true
+export TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}'
+# Let Node resolve plain deps (tslib, …) from the checkout's node_modules even if the handler
+# lives elsewhere.
+export NODE_PATH="$BOOKS_DIR/node_modules${NODE_PATH:+:$NODE_PATH}"
+exec ./node_modules/.bin/electron \
+  --require ts-node/register \
+  --require tsconfig-paths/register \
+  "$HANDLER"

--- a/kriya-mcp/tools.json
+++ b/kriya-mcp/tools.json
@@ -1,0 +1,49 @@
+[
+  { "name": "list_documents", "version": 1, "description": "List records of a doctype (e.g. SalesInvoice, Party, Item, Payment, AccountingLedgerEntry). Optional filters + fields.", "permissions": [],
+    "inputSchema": { "type": "object", "properties": {
+      "schemaName": { "type": "string" },
+      "filters": { "type": "object" },
+      "fields": { "type": "array", "items": { "type": "string" } }
+    }, "required": ["schemaName"] } },
+  { "name": "get_document", "version": 1, "description": "Get one record by doctype + name.", "permissions": [],
+    "inputSchema": { "type": "object", "properties": { "schemaName": { "type": "string" }, "name": { "type": "string" } }, "required": ["schemaName", "name"] } },
+  { "name": "get_outstanding", "version": 1, "description": "Total outstanding for receivables (schemaName=SalesInvoice) or payables (PurchaseInvoice) in a date range (YYYY-MM-DD).", "permissions": [],
+    "inputSchema": { "type": "object", "properties": { "schemaName": { "type": "string" }, "fromDate": { "type": "string" }, "toDate": { "type": "string" } }, "required": ["schemaName", "fromDate", "toDate"] } },
+  { "name": "get_cashflow", "version": 1, "description": "Cashflow report for a date range (YYYY-MM-DD).", "permissions": [],
+    "inputSchema": { "type": "object", "properties": { "fromDate": { "type": "string" }, "toDate": { "type": "string" } }, "required": ["fromDate", "toDate"] } },
+  { "name": "get_income_and_expenses", "version": 1, "description": "Income and expense totals for a date range (YYYY-MM-DD).", "permissions": [],
+    "inputSchema": { "type": "object", "properties": { "fromDate": { "type": "string" }, "toDate": { "type": "string" } }, "required": ["fromDate", "toDate"] } },
+
+  { "name": "create_party", "version": 1, "description": "Create a customer/supplier. role: Customer | Supplier | Both.", "permissions": ["write:party"],
+    "inputSchema": { "type": "object", "properties": { "name": { "type": "string" }, "role": { "type": "string" } }, "required": ["name"] } },
+  { "name": "create_item", "version": 1, "description": "Create an item. rate is a currency amount in major units (e.g. 100 or 100.5). for: Sales | Purchases | Both.", "permissions": ["write:item"],
+    "inputSchema": { "type": "object", "properties": {
+      "name": { "type": "string" }, "for": { "type": "string" }, "rate": { "type": "number" },
+      "incomeAccount": { "type": "string" }, "expenseAccount": { "type": "string" }
+    }, "required": ["name", "incomeAccount", "expenseAccount"] } },
+  { "name": "create_account", "version": 1, "description": "Create a chart-of-accounts account. rootType: Asset|Liability|Equity|Income|Expense.", "permissions": ["write:account"],
+    "inputSchema": { "type": "object", "properties": {
+      "name": { "type": "string" }, "rootType": { "type": "string" }, "parentAccount": { "type": "string" },
+      "accountType": { "type": "string" }, "isGroup": { "type": "boolean" }
+    }, "required": ["name", "rootType"] } },
+
+  { "name": "create_sales_invoice", "version": 1, "description": "Create a DRAFT sales invoice (money). account = the receivable (e.g. Debtors); item account auto-resolves. rate per line is a currency amount in major units (e.g. 100 or 100.5). Submitting it later posts the ledger. Requires human approval.", "permissions": ["write:invoices", "money"],
+    "inputSchema": { "type": "object", "properties": {
+      "party": { "type": "string" }, "account": { "type": "string" }, "date": { "type": "string" },
+      "items": { "type": "array", "items": { "type": "object", "properties": {
+        "item": { "type": "string" }, "quantity": { "type": "number" }, "rate": { "type": "number" }
+      }, "required": ["item"] } }
+    }, "required": ["party", "account", "date", "items"] } },
+  { "name": "create_payment", "version": 1, "description": "Create a DRAFT payment (money). paymentType: Receive | Pay. amount is a currency amount in major units (e.g. 100 or 100.5). Requires human approval.", "permissions": ["write:payments", "money"],
+    "inputSchema": { "type": "object", "properties": {
+      "party": { "type": "string" }, "paymentType": { "type": "string" }, "account": { "type": "string" },
+      "paymentAccount": { "type": "string" }, "amount": { "type": "number" }, "date": { "type": "string" },
+      "paymentMethod": { "type": "string" }
+    }, "required": ["party", "paymentType", "account", "paymentAccount", "amount", "date"] } },
+  { "name": "submit_document", "version": 1, "description": "Submit a document (SalesInvoice/PurchaseInvoice/Payment/JournalEntry) — this POSTS double-entry ledger entries and moves money on the books. Requires human approval.", "permissions": ["submit", "money"],
+    "inputSchema": { "type": "object", "properties": { "schemaName": { "type": "string" }, "name": { "type": "string" } }, "required": ["schemaName", "name"] } },
+  { "name": "cancel_document", "version": 1, "description": "Cancel a submitted document — reverses its ledger entries. Requires human approval.", "permissions": ["cancel", "money"],
+    "inputSchema": { "type": "object", "properties": { "schemaName": { "type": "string" }, "name": { "type": "string" } }, "required": ["schemaName", "name"] } },
+  { "name": "delete_document", "version": 1, "description": "Delete a document. Requires human approval.", "permissions": ["delete"],
+    "inputSchema": { "type": "object", "properties": { "schemaName": { "type": "string" }, "name": { "type": "string" } }, "required": ["schemaName", "name"] } }
+]


### PR DESCRIPTION
## Add optional governed AI (MCP) access via Kriya (off by default)

Frappe Books is local-first with no API, so today an AI assistant could only *operate* it by
screen-scraping or raw SQLite access — both ungoverned. This adds an **optional, off-by-default**
way to let an assistant (Claude Desktop, etc.) drive Books' existing actions as a **governed
MCP server**.

### Why it's safe to merge
- **No dependency added, nothing in the app changes.** The whole integration is a self-contained
  `kriya-mcp/` folder plus a one-line `.eslintrc.js` ignore (the handler is a standalone ts-node
  script, run outside the typed build — same way `vite.config.ts`/`*.mjs` are ignored). It is inert
  unless a user explicitly wires it into their assistant.
- **Same handler, no rewrite.** `kriya-mcp/kriya-exec.ts` reuses the *same* headless `fyo` bootstrap
  your test harness uses (`new Fyo({ DatabaseDemux: DatabaseManager, isElectron: false })`) and the
  same `getNewDoc().sync()/.submit()` / `fyo.db.*` calls the UI drives — so an agent call runs
  identical code to a human action.
- **Governance lives outside the app**, in the separate open-source `kriya-mcp` process
  (https://crates.io/crates/kriya). The handler only executes already-cleared actions.

### Governance model
| Tier | Actions | Policy |
|---|---|---|
| Read / report | `list_documents`, `get_document`, `get_outstanding`, `get_cashflow`, `get_income_and_expenses` | allow |
| Routine record-keeping | `create_party`, `create_item`, `create_account` | allow + audit |
| Financial / ledger / destructive | `create_sales_invoice`, `create_payment`, **`submit_document`** (posts the ledger), `cancel_document`, `delete_document` | human approval + audit |
| Anything else | — | denied |

### Files
`kriya-mcp/`: `kriya-exec.ts` (handler), `run.sh` (runs it via the repo's Electron-as-Node + ts-node
runner), `tools.json`, `agent-policy.yaml`, `.mcp.json` (Claude Desktop template), `README.md`.
`.eslintrc.js`: ignore `kriya-mcp/`.

### Testing
Ran headless against a demo company end-to-end: create Party → Item → SalesInvoice (draft) →
`submit_document` → posts balanced `AccountingLedgerEntry` rows (Debtors 200 dr / Sales 200 cr) →
`get_outstanding` 200, plus error paths. `backup_database`/`restore_database` are intentionally not
exposed (they need the GUI dialog).

Happy to adjust the surface/policy, or move it behind a flag — and to add a short README pointer if
you'd like it discoverable.